### PR TITLE
fix(demo): generate env map thumbnail on upload and regenerate

### DIFF
--- a/src/frontend/src/mocks/dynamic-demo/shared.ts
+++ b/src/frontend/src/mocks/dynamic-demo/shared.ts
@@ -28,6 +28,7 @@ import {
   put,
   remove,
   removeRecycledItem,
+  removeThumbnail,
   storeFileBlob,
   storeThumbnail,
 } from '../db/demoDb'
@@ -62,6 +63,7 @@ export {
   put,
   remove,
   removeRecycledItem,
+  removeThumbnail,
   storeFileBlob,
   storeThumbnail,
 }
@@ -679,6 +681,22 @@ export function generateVersionThumbnailAsync(
       : generateModelThumbnail(fileBlob, 256, 256, fileName)
   gen
     .then(thumb => storeThumbnail(`version:${versionId}`, thumb))
+    .catch(() => {})
+}
+
+export function generateEnvironmentMapThumbnailAsync(
+  envMapId: number,
+  fileBlob: Blob,
+  fileName: string
+) {
+  const lower = fileName.toLowerCase()
+  const gen = lower.endsWith('.hdr')
+    ? generateHdrChannelPreview(fileBlob, 'rgb')
+    : lower.endsWith('.exr')
+      ? generateExrChannelPreview(fileBlob, 'rgb')
+      : generateImageChannelPreview(fileBlob, 'rgb')
+  gen
+    .then(preview => storeThumbnail(`envMapPreview:${envMapId}`, preview))
     .catch(() => {})
 }
 

--- a/src/frontend/src/mocks/dynamicDemoHandlers.ts
+++ b/src/frontend/src/mocks/dynamicDemoHandlers.ts
@@ -15,6 +15,7 @@ import {
   type DemoTextureSet,
   enrichModel,
   fetchStaticAsset,
+  generateEnvironmentMapThumbnailAsync,
   generateExrChannelPreview,
   generateHdrChannelPreview,
   generateImageChannelPreview,
@@ -38,6 +39,7 @@ import {
   recomputePackCounts,
   recomputeProjectCounts,
   remove,
+  removeThumbnail,
   seedAssetUrl,
   seedFileAssets,
   serveFile,
@@ -2265,6 +2267,16 @@ export const dynamicDemoHandlers = [
 
     await put('environmentMaps', environmentMap)
 
+    // Cube uploads fall back to the px face since we can't render a real sphere here.
+    const thumbnailSource = file ?? (cubeFaceFiles ? cubeFaceFiles.px : null)
+    if (thumbnailSource) {
+      generateEnvironmentMapThumbnailAsync(
+        environmentMapId,
+        thumbnailSource,
+        thumbnailSource.name
+      )
+    }
+
     trackUpload({
       batchId: url.searchParams.get('batchId') || `batch-${Date.now()}`,
       uploadType: 'EnvironmentMap',
@@ -2465,6 +2477,20 @@ export const dynamicDemoHandlers = [
       environmentMap.updatedAt = now()
       syncEnvironmentMapDerivedFields(environmentMap)
       await put('environmentMaps', environmentMap)
+
+      await removeThumbnail(`envMapPreview:${environmentMap.id}`)
+      if (environmentMap.previewFileId) {
+        const source = await loadEnvironmentMapPreviewBlob(
+          environmentMap.previewFileId
+        )
+        if (source) {
+          generateEnvironmentMapThumbnailAsync(
+            environmentMap.id,
+            source.blob,
+            source.fileName
+          )
+        }
+      }
 
       const regeneratedVariantIds = (environmentMap.variants ?? [])
         .filter(variant => !variant.isDeleted)


### PR DESCRIPTION
## Summary

- Fixes a demo-mode bug where environment map thumbnails were not generated for user uploads — only seeded env maps got thumbnails (via `prewarmSeedEnvironmentMapThumbnails`).
- Mirrors the model upload pattern: adds a fire-and-forget `generateEnvironmentMapThumbnailAsync` helper that picks the right tone-mapper by extension (HDR / EXR / image) and stores the preview at `envMapPreview:${envMapId}` — the same key the `GET /environment-maps/:id/preview` handler already checks.
- Wires it into the upload handler (`POST */environment-maps/with-file`) and the regenerate handler (`POST */environment-maps/:id/thumbnail/regenerate`). Cube uploads fall back to the `px` face since the browser mock can't reproduce the real asset processor's metallic-sphere orbit animation.

## Changes

- `src/frontend/src/mocks/dynamic-demo/shared.ts` — new `generateEnvironmentMapThumbnailAsync` helper; re-export `removeThumbnail` so handlers can clear the cache on regenerate.
- `src/frontend/src/mocks/dynamicDemoHandlers.ts` — call the helper after env map upload, and clear + regenerate on the regenerate endpoint.

## Test plan

- [ ] Run the demo build locally and upload an HDR env map — thumbnail should appear in the env maps list without a page refresh.
- [ ] Upload a cube map (six PNG faces) — px-face thumbnail should appear as a fallback.
- [ ] Click regenerate on a custom-thumbnail env map — the cached `envMapPreview:<id>` should be cleared and a fresh preview stored.
- [ ] Existing `shows a thumbnail for seeded environment maps` demo E2E test should still pass (seeded path is untouched).

## Notes for reviewer

- No new E2E coverage for the upload/regenerate paths in demo mode — the existing `demo-mode.spec.ts` test only exercises the seeded prewarm. Happy to add one if desired.
- Type-check was not run locally (no `node_modules` in the worktree); CI will verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)