### PR TITLE
fix(demo): generate env map thumbnails matching real app sphere render

### DIFF
--- a/src/frontend/src/mocks/dynamic-demo/shared.ts
+++ b/src/frontend/src/mocks/dynamic-demo/shared.ts
@@ -33,6 +33,7 @@ import {
   storeThumbnail,
 } from '../db/demoDb'
 import {
+  generateEnvironmentMapThumbnail,
   generateExrChannelPreview,
   generateHdrChannelPreview,
   generateImageChannelPreview,
@@ -159,7 +160,7 @@ export const seedFileAssets: Record<number, string> = {
   402: 'texture_albedo.png',
   501: 'test-tone.wav',
   601: 'hdri/potsdamer_platz_1k.hdr',
-  602: 'global texture/normal.exr',
+  602: 'hdri/potsdamer_platz_1k.hdr',
 }
 
 export function paginate<T>(items: T[], page: number, pageSize: number) {
@@ -687,16 +688,33 @@ export function generateVersionThumbnailAsync(
 export function generateEnvironmentMapThumbnailAsync(
   envMapId: number,
   fileBlob: Blob,
+  fileName: string,
+  variantId?: number
+) {
+  generateEnvironmentMapThumbnail(fileBlob, fileName)
+    .then(preview => {
+      const writes: Promise<void>[] = [
+        storeThumbnail(`envMapPreview:${envMapId}`, preview),
+      ]
+      if (variantId) {
+        writes.push(
+          storeThumbnail(`envMapVariantPreview:${variantId}`, preview)
+        )
+      }
+      return Promise.all(writes)
+    })
+    .catch(() => {})
+}
+
+export function generateEnvironmentMapVariantThumbnailAsync(
+  variantId: number,
+  fileBlob: Blob,
   fileName: string
 ) {
-  const lower = fileName.toLowerCase()
-  const gen = lower.endsWith('.hdr')
-    ? generateHdrChannelPreview(fileBlob, 'rgb')
-    : lower.endsWith('.exr')
-      ? generateExrChannelPreview(fileBlob, 'rgb')
-      : generateImageChannelPreview(fileBlob, 'rgb')
-  gen
-    .then(preview => storeThumbnail(`envMapPreview:${envMapId}`, preview))
+  generateEnvironmentMapThumbnail(fileBlob, fileName)
+    .then(preview =>
+      storeThumbnail(`envMapVariantPreview:${variantId}`, preview)
+    )
     .catch(() => {})
 }
 
@@ -1177,13 +1195,35 @@ export async function prewarmSeedThumbnails(): Promise<void> {
  */
 export async function prewarmSeedEnvironmentMapThumbnails(): Promise<void> {
   const seedItems = [
-    { envMapId: 1, fileId: 601, fileName: 'potsdamer_platz_1k.hdr' },
+    {
+      envMapId: 1,
+      variantId: 1,
+      fileId: 601,
+      fileName: 'potsdamer_platz_1k.hdr',
+      isPreviewVariant: true,
+    },
+    {
+      envMapId: 1,
+      variantId: 2,
+      fileId: 601,
+      fileName: 'potsdamer_platz_1k.hdr',
+      isPreviewVariant: false,
+    },
   ]
 
-  for (const { envMapId, fileId, fileName } of seedItems) {
-    const cacheKey = `envMapPreview:${envMapId}`
-    const existing = await getThumbnail(cacheKey)
-    if (existing) continue
+  for (const {
+    envMapId,
+    variantId,
+    fileId,
+    fileName,
+    isPreviewVariant,
+  } of seedItems) {
+    const variantKey = `envMapVariantPreview:${variantId}`
+    const mapKey = `envMapPreview:${envMapId}`
+
+    const existingVariant = await getThumbnail(variantKey)
+    const existingMap = isPreviewVariant ? await getThumbnail(mapKey) : null
+    if (existingVariant && (!isPreviewVariant || existingMap)) continue
 
     const seedPath = seedFileAssets[fileId]
     if (!seedPath) continue
@@ -1195,17 +1235,11 @@ export async function prewarmSeedEnvironmentMapThumbnails(): Promise<void> {
       if (!response.ok) continue
 
       const blob = await response.blob()
-      let preview: Blob
-
-      if (fileName.endsWith('.hdr')) {
-        preview = await generateHdrChannelPreview(blob, 'rgb')
-      } else if (fileName.endsWith('.exr')) {
-        preview = await generateExrChannelPreview(blob, 'rgb')
-      } else {
-        preview = await generateImageChannelPreview(blob, 'rgb')
+      const preview = await generateEnvironmentMapThumbnail(blob, fileName)
+      await storeThumbnail(variantKey, preview)
+      if (isPreviewVariant) {
+        await storeThumbnail(mapKey, preview)
       }
-
-      await storeThumbnail(cacheKey, preview)
     } catch {
       // Silently ignore — preview requests will still generate on demand.
     }

--- a/src/frontend/src/mocks/dynamicDemoHandlers.ts
+++ b/src/frontend/src/mocks/dynamicDemoHandlers.ts
@@ -16,6 +16,7 @@ import {
   enrichModel,
   fetchStaticAsset,
   generateEnvironmentMapThumbnailAsync,
+  generateEnvironmentMapVariantThumbnailAsync,
   generateExrChannelPreview,
   generateHdrChannelPreview,
   generateImageChannelPreview,
@@ -2070,11 +2071,20 @@ export const dynamicDemoHandlers = [
   http.get(
     '*/environment-maps/:id/variants/:variantId/preview',
     async ({ params }) => {
+      const variantId = Number(params.variantId)
+
+      const cached = await getThumbnail(`envMapVariantPreview:${variantId}`)
+      if (cached) {
+        return new HttpResponse(cached, {
+          headers: { 'Content-Type': cached.type || 'image/png' },
+        })
+      }
+
       const environmentMap = await getById('environmentMaps', Number(params.id))
       if (!environmentMap) return new HttpResponse(null, { status: 404 })
 
       const variant = (environmentMap.variants ?? []).find(
-        item => item.id === Number(params.variantId) && !item.isDeleted
+        item => item.id === variantId && !item.isDeleted
       )
       if (!variant) return new HttpResponse(null, { status: 404 })
 
@@ -2273,7 +2283,8 @@ export const dynamicDemoHandlers = [
       generateEnvironmentMapThumbnailAsync(
         environmentMapId,
         thumbnailSource,
-        thumbnailSource.name
+        thumbnailSource.name,
+        variantId
       )
     }
 
@@ -2436,6 +2447,16 @@ export const dynamicDemoHandlers = [
       syncEnvironmentMapDerivedFields(environmentMap)
       await put('environmentMaps', environmentMap)
 
+      const variantThumbnailSource =
+        file ?? (cubeFaceFiles ? cubeFaceFiles.px : null)
+      if (variantThumbnailSource) {
+        generateEnvironmentMapVariantThumbnailAsync(
+          variantId,
+          variantThumbnailSource,
+          variantThumbnailSource.name
+        )
+      }
+
       return HttpResponse.json({
         variantId,
         fileId,
@@ -2479,22 +2500,42 @@ export const dynamicDemoHandlers = [
       await put('environmentMaps', environmentMap)
 
       await removeThumbnail(`envMapPreview:${environmentMap.id}`)
-      if (environmentMap.previewFileId) {
-        const source = await loadEnvironmentMapPreviewBlob(
-          environmentMap.previewFileId
-        )
-        if (source) {
+
+      const activeVariants = (environmentMap.variants ?? []).filter(
+        variant => !variant.isDeleted
+      )
+
+      for (const variant of activeVariants) {
+        await removeThumbnail(`envMapVariantPreview:${variant.id}`)
+
+        const variantFileId =
+          variant.previewFileId ??
+          variant.panoramicFile?.fileId ??
+          variant.cubeFaces?.px.fileId ??
+          variant.fileId ??
+          null
+        if (!variantFileId) continue
+
+        const source = await loadEnvironmentMapPreviewBlob(variantFileId)
+        if (!source) continue
+
+        if (variant.id === environmentMap.previewVariantId) {
           generateEnvironmentMapThumbnailAsync(
             environmentMap.id,
+            source.blob,
+            source.fileName,
+            variant.id
+          )
+        } else {
+          generateEnvironmentMapVariantThumbnailAsync(
+            variant.id,
             source.blob,
             source.fileName
           )
         }
       }
 
-      const regeneratedVariantIds = (environmentMap.variants ?? [])
-        .filter(variant => !variant.isDeleted)
-        .map(variant => variant.id)
+      const regeneratedVariantIds = activeVariants.map(variant => variant.id)
 
       return HttpResponse.json({
         message:

--- a/src/frontend/src/mocks/services/browserAssetProcessor.ts
+++ b/src/frontend/src/mocks/services/browserAssetProcessor.ts
@@ -8,18 +8,22 @@
  * 2. Audio Waveforms  — OfflineAudioContext peak extraction → Canvas 2D PNG
  */
 import {
+  ACESFilmicToneMapping,
   AmbientLight,
   Box3,
   CanvasTexture,
   Color,
   DirectionalLight,
+  EquirectangularReflectionMapping,
   type Group,
   Mesh,
   MeshStandardMaterial,
   type Object3D,
   PerspectiveCamera,
+  PMREMGenerator,
   Scene,
   SphereGeometry,
+  type Texture,
   Vector3,
   WebGLRenderer,
 } from 'three'
@@ -709,6 +713,109 @@ export async function generateTextureSetThumbnail(
     return blob
   } catch {
     return generatePlaceholderThumbnail(width, height, '#7b5ea7')
+  }
+}
+
+// ─── Environment Map Thumbnails ─────────────────────────────────────────
+
+async function loadEquirectangularEnvTexture(
+  blob: Blob,
+  fileName: string
+): Promise<Texture> {
+  const lower = fileName.toLowerCase()
+  const url = URL.createObjectURL(blob)
+  try {
+    if (lower.endsWith('.hdr')) {
+      const { RGBELoader } = await import('three-stdlib')
+      const loader = new RGBELoader()
+      return await new Promise<Texture>((resolve, reject) => {
+        loader.load(url, resolve as (tex: unknown) => void, undefined, reject)
+      })
+    }
+    if (lower.endsWith('.exr')) {
+      const { EXRLoader } = await import('three/addons/loaders/EXRLoader.js')
+      const loader = new EXRLoader()
+      return await new Promise<Texture>((resolve, reject) => {
+        loader.load(url, resolve as (tex: unknown) => void, undefined, reject)
+      })
+    }
+    const bitmap = await createImageBitmap(blob)
+    return new CanvasTexture(bitmap as unknown as HTMLCanvasElement)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+/**
+ * Render an environment map thumbnail as an animated WebP: a polished
+ * metallic sphere using the env map for IBL, orbited 360° around the
+ * camera. Mirrors the real asset-processor's environmentMapProcessor.js
+ * output — tone-mapped through ACES so HDRs no longer blow out to white.
+ */
+export async function generateEnvironmentMapThumbnail(
+  fileBlob: Blob,
+  fileName: string,
+  width = 256,
+  height = 256
+): Promise<Blob> {
+  try {
+    const envTexture = await loadEquirectangularEnvTexture(fileBlob, fileName)
+    envTexture.mapping = EquirectangularReflectionMapping
+
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+
+    const renderer = new WebGLRenderer({
+      canvas,
+      alpha: true,
+      antialias: true,
+      preserveDrawingBuffer: true,
+    })
+    renderer.setSize(width, height)
+    renderer.setClearColor(0x2a2a2e, 1)
+    renderer.toneMapping = ACESFilmicToneMapping
+    renderer.toneMappingExposure = 1.0
+
+    const pmrem = new PMREMGenerator(renderer)
+    const prefiltered = pmrem.fromEquirectangular(envTexture).texture
+
+    const scene = new Scene()
+    scene.background = envTexture
+    scene.environment = prefiltered
+
+    const camera = new PerspectiveCamera(45, width / height, 0.01, 1000)
+
+    const geometry = new SphereGeometry(1, 64, 64)
+    const material = new MeshStandardMaterial({
+      color: 0xffffff,
+      metalness: 1.0,
+      roughness: 0.08,
+      envMapIntensity: 1.2,
+    })
+    scene.add(new Mesh(geometry, material))
+
+    const fov = camera.fov * (Math.PI / 180)
+    const distance = (2.0 / (2 * Math.tan(fov / 2))) * 1.8
+
+    const thumbnailBlob = await renderOrbitAnimation(
+      renderer,
+      scene,
+      camera,
+      distance,
+      width,
+      height
+    )
+
+    renderer.dispose()
+    pmrem.dispose()
+    geometry.dispose()
+    material.dispose()
+    envTexture.dispose()
+    prefiltered.dispose()
+    return thumbnailBlob
+  } catch {
+    return generatePlaceholderThumbnail(width, height, '#4a90d9')
   }
 }
 


### PR DESCRIPTION
## Summary
- Demo mode environment maps now generate the same orbiting metallic-sphere thumbnail the real asset processor produces, instead of being missing or rendered as a washed-out flat HDR tonemap.
- Mirrors the existing model thumbnail mock pattern: fire-and-forget generation on upload + regenerate, plus prewarm for seed data.
- Caches per-variant (`envMapVariantPreview:${variantId}`) so the `/environment-maps/:id/variants/:variantId/preview` endpoint stays consistent with the map-level preview.

## What changed
- [`browserAssetProcessor.ts`](https://github.com/Papyszoo/Modelibr/blob/claude/wonderful-aryabhata-7f857f/src/frontend/src/mocks/services/browserAssetProcessor.ts) — new `generateEnvironmentMapThumbnail` using `PMREMGenerator` + ACES tone mapping + metallic sphere (`metalness=1.0`, `roughness=0.08`, `envMapIntensity=1.2`) matching the real `environmentMapProcessor.js`. Uses the existing `renderOrbitAnimation` helper to produce an animated WebP.
- [`dynamic-demo/shared.ts`](https://github.com/Papyszoo/Modelibr/blob/claude/wonderful-aryabhata-7f857f/src/frontend/src/mocks/dynamic-demo/shared.ts) — added `generateEnvironmentMapVariantThumbnailAsync`; updated `generateEnvironmentMapThumbnailAsync` to optionally dual-write the variant cache; updated `prewarmSeedEnvironmentMapThumbnails` to iterate seed variants. Fixed `seedFileAssets[602]` which incorrectly pointed at a normal map.
- [`dynamicDemoHandlers.ts`](https://github.com/Papyszoo/Modelibr/blob/claude/wonderful-aryabhata-7f857f/src/frontend/src/mocks/dynamicDemoHandlers.ts) — variant-preview endpoint now checks per-variant cache; upload + variant-add handlers populate the variant cache; regenerate handler clears and re-renders every variant.

## Test plan
- [ ] Reset demo IndexedDB (Application → IndexedDB → delete `modelibr-demo`).
- [ ] Reload the demo. The seeded `City Night Lights` env map shows an orbiting metallic-sphere thumbnail (no washed-out flat HDR).
- [ ] Open the env map detail; both `1K` and `2K` variant previews show the orbit animation.
- [ ] Upload an HDR/EXR; thumbnail appears within a few seconds without a refresh.
- [ ] Regenerate the thumbnail; orbit animation re-renders for every variant.
- [ ] `tests/e2e/run-demo-e2e.js` (env-map feature, scenario "A generated environment map thumbnail appears, can be overridden, and can be regenerated").

🤖 Generated with [Claude Code](https://claude.com/claude-code)