### PR TITLE
fix(preview): make textured-model previews watertight under displacement + add Specular type

### DIFF
--- a/src/Domain/ValueObjects/TextureType.cs
+++ b/src/Domain/ValueObjects/TextureType.cs
@@ -30,8 +30,10 @@ public enum TextureType
     Metallic = 6,
     
     // Diffuse = 7 (REMOVED - use Albedo instead)
-    // Specular = 8 (REMOVED - not PBR standard)
-    
+
+    /// <summary>Specular map - defines specular reflection color/intensity (legacy / non-PBR workflows)</summary>
+    Specular = 8,
+
     /// <summary>Emissive map - areas where the mesh emits light</summary>
     Emissive = 9,
     
@@ -59,6 +61,7 @@ public static class TextureTypeExtensions
         TextureType.AO,
         TextureType.Roughness,
         TextureType.Metallic,
+        TextureType.Specular,
         TextureType.Emissive,
         TextureType.Bump,
         TextureType.Alpha,
@@ -121,6 +124,7 @@ public static class TextureTypeExtensions
             TextureType.AO => "Ambient Occlusion map",
             TextureType.Roughness => "Surface roughness map",
             TextureType.Metallic => "Metallic surface map",
+            TextureType.Specular => "Specular reflection map",
             TextureType.Emissive => "Emissive map for glowing areas",
             TextureType.Bump => "Bump map for surface detail",
             TextureType.Alpha => "Alpha map for transparency",

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -1081,14 +1081,9 @@ export class PuppeteerRenderer {
                       child.material.emissiveIntensity = 1.0
                     }
                     if (property === 'displacementMap') {
-                      // Scale conservatively + bias by -scale/2 so the
-                      // heightmap's mid-grey means "no displacement";
-                      // without the bias every vertex inflates outward and
-                      // only the grout *recesses*. Triplanar projection is
-                      // intentionally NOT applied here — it samples by
-                      // world-axis projection and produces chevron
-                      // patterns on curved surfaces; the geometry's
-                      // native UVs project the heightmap correctly.
+                      // Bias by -scale/2 so heightmap mid-grey means "no
+                      // displacement" — without it every vertex inflates
+                      // outward and only the grout *recesses*.
                       child.material.displacementScale = 0.02
                       child.material.displacementBias = -0.01
                     }

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -801,7 +801,7 @@ export class PuppeteerRenderer {
             const renderer = window.modelRenderer.renderer
             const textureLoader = new THREE.TextureLoader()
 
-            // Map texture type enum values to material properties
+            // Map texture type enum values to MeshPhysicalMaterial properties
             const textureTypeMap = {
               1: 'map', // Albedo
               2: 'normalMap',
@@ -810,7 +810,7 @@ export class PuppeteerRenderer {
               5: 'roughnessMap',
               6: 'metalnessMap',
               7: 'map', // Diffuse (legacy)
-              8: 'specularMap',
+              8: 'specularColorMap', // Specular (MeshPhysicalMaterial)
               9: 'emissiveMap', // Emissive
               10: 'bumpMap', // Bump
               11: 'alphaMap', // Alpha
@@ -822,7 +822,7 @@ export class PuppeteerRenderer {
               Roughness: 'roughnessMap',
               Metallic: 'metalnessMap',
               Diffuse: 'map',
-              Specular: 'specularMap',
+              Specular: 'specularColorMap',
               BaseColor: 'map',
               AmbientOcclusion: 'aoMap',
               Emissive: 'emissiveMap',
@@ -974,7 +974,11 @@ export class PuppeteerRenderer {
             }
 
             // Texture types that carry color data (need sRGB color space)
-            const colorTextureProps = new Set(['map', 'emissiveMap'])
+            const colorTextureProps = new Set([
+              'map',
+              'emissiveMap',
+              'specularColorMap',
+            ])
 
             const loadedTextures = {}
             for (const [type, data] of Object.entries(textures)) {
@@ -1046,8 +1050,12 @@ export class PuppeteerRenderer {
                   ? child.material[0]?.name || ''
                   : child.material?.name || ''
 
-                // Create new material with white base color for textures
-                child.material = new THREE.MeshStandardMaterial({
+                // Create new material with white base color for textures.
+                // specularIntensity defaults to 1 on MeshPhysicalMaterial,
+                // which adds a dielectric sheen even without a Specular map
+                // and visibly washes the albedo. Disable it unless a real
+                // specularColorMap is present.
+                child.material = new THREE.MeshPhysicalMaterial({
                   name: originalName,
                   color: loadedTextures.map
                     ? 0xffffff
@@ -1055,6 +1063,7 @@ export class PuppeteerRenderer {
                   metalness: loadedTextures.metalnessMap ? 1 : 0,
                   roughness: loadedTextures.roughnessMap ? 1 : 0.8,
                   envMapIntensity: 1.0,
+                  specularIntensity: loadedTextures.specularColorMap ? 1 : 0,
                 })
 
                 // Apply each loaded texture with proper material settings
@@ -1072,7 +1081,16 @@ export class PuppeteerRenderer {
                       child.material.emissiveIntensity = 1.0
                     }
                     if (property === 'displacementMap') {
-                      child.material.displacementScale = 0.1
+                      // Scale conservatively + bias by -scale/2 so the
+                      // heightmap's mid-grey means "no displacement";
+                      // without the bias every vertex inflates outward and
+                      // only the grout *recesses*. Triplanar projection is
+                      // intentionally NOT applied here — it samples by
+                      // world-axis projection and produces chevron
+                      // patterns on curved surfaces; the geometry's
+                      // native UVs project the heightmap correctly.
+                      child.material.displacementScale = 0.02
+                      child.material.displacementBias = -0.01
                     }
                     if (property === 'normalMap') {
                       child.material.normalScale = new THREE.Vector2(1, 1)

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -169,6 +169,7 @@ function applyMaterialTextures(
     metalness: 0.3,
     roughness: 0.4,
     envMapIntensity: 1.0,
+    specularIntensity: 0,
   })
 
   clonedModel.traverse(child => {

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/features/model-viewer/hooks/useChannelExtractedTextures'
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
 import { getFileUrl } from '@/features/models/api/modelApi'
+import { weldByPosition } from '@/shared/three/weldGeometry'
 import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
 
 /** Map of material names to their texture sets. Key "" means apply to all meshes. */
@@ -23,7 +24,7 @@ interface TexturedModelProps {
   materialTextureSets: MaterialTextureSets
 }
 
-// Material property slot names used by MeshStandardMaterial
+// Material property slot names used by MeshPhysicalMaterial
 const TEXTURE_SLOTS: Array<{
   slot: string
   type: TextureType
@@ -33,6 +34,7 @@ const TEXTURE_SLOTS: Array<{
   { slot: 'normalMap', type: TextureType.Normal },
   { slot: 'roughnessMap', type: TextureType.Roughness },
   { slot: 'metalnessMap', type: TextureType.Metallic },
+  { slot: 'specularColorMap', type: TextureType.Specular },
   { slot: 'aoMap', type: TextureType.AO },
   { slot: 'emissiveMap', type: TextureType.Emissive },
   { slot: 'bumpMap', type: TextureType.Bump },
@@ -85,27 +87,35 @@ function getMeshMaterialNames(mesh: THREE.Mesh): string[] {
 }
 
 /**
- * Build a MeshStandardMaterial from loaded textures for a given material key prefix.
+ * Build a MeshPhysicalMaterial from loaded textures for a given material key prefix.
  */
 function buildMaterialFromTextures(
   loadedTextures: Record<string, THREE.Texture | null>,
   materialPrefix: string
-): THREE.MeshStandardMaterial {
+): THREE.MeshPhysicalMaterial {
   const get = (slot: string) =>
     loadedTextures[`${materialPrefix}${KEY_SEP}${slot}`] ?? null
   const hasMap = get('map') !== null
 
-  const material = new THREE.MeshStandardMaterial({
+  const material = new THREE.MeshPhysicalMaterial({
     color: hasMap ? 0xffffff : new THREE.Color(0.7, 0.7, 0.9),
     metalness: hasMap ? 1 : 0.3,
     roughness: hasMap ? 1 : 0.4,
     envMapIntensity: 1.0,
+    // MeshPhysicalMaterial enables a dielectric specular channel by default
+    // (intensity=1, color=white). Without an explicit Specular texture we
+    // want MeshStandardMaterial-equivalent behavior, otherwise the channel
+    // adds a sheen that washes the albedo toward white.
+    specularIntensity: get('specularColorMap') ? 1 : 0,
   })
 
   if (get('map')) material.map = get('map')
   if (get('normalMap')) material.normalMap = get('normalMap')
   if (get('roughnessMap')) material.roughnessMap = get('roughnessMap')
   if (get('metalnessMap')) material.metalnessMap = get('metalnessMap')
+  if (get('specularColorMap')) {
+    material.specularColorMap = get('specularColorMap')
+  }
   if (get('aoMap')) material.aoMap = get('aoMap')
   if (get('emissiveMap')) {
     material.emissiveMap = get('emissiveMap')
@@ -116,7 +126,14 @@ function buildMaterialFromTextures(
     material.alphaMap = get('alphaMap')
     material.transparent = true
   }
-  if (get('displacementMap')) material.displacementMap = get('displacementMap')
+  if (get('displacementMap')) {
+    material.displacementMap = get('displacementMap')
+    // Scale conservatively + bias by -scale/2 so the heightmap's mid-grey
+    // means "no displacement"; without the bias every vertex inflates
+    // outward (only grout *recesses* — tile tops stay near the surface).
+    material.displacementScale = 0.02
+    material.displacementBias = -0.01
+  }
 
   return material
 }
@@ -136,7 +153,7 @@ function applyMaterialTextures(
   const hasWildcard = materialNames.includes('')
 
   // Pre-build materials for each material name that has textures
-  const builtMaterials: Record<string, THREE.MeshStandardMaterial> = {}
+  const builtMaterials: Record<string, THREE.MeshPhysicalMaterial> = {}
   if (texturesReady) {
     for (const matName of materialNames) {
       builtMaterials[matName] = buildMaterialFromTextures(
@@ -147,7 +164,7 @@ function applyMaterialTextures(
   }
 
   // Shared fallback material for unmatched meshes (avoids per-mesh allocation)
-  const fallbackMaterial = new THREE.MeshStandardMaterial({
+  const fallbackMaterial = new THREE.MeshPhysicalMaterial({
     color: new THREE.Color(0.7, 0.7, 0.9),
     metalness: 0.3,
     roughness: 0.4,
@@ -156,16 +173,19 @@ function applyMaterialTextures(
 
   clonedModel.traverse(child => {
     if (!child.isMesh) return
-    child.castShadow = true
-    child.receiveShadow = true
+    const mesh = child as THREE.Mesh
+    mesh.castShadow = true
+    mesh.receiveShadow = true
 
-    const meshMatNames = getMeshMaterialNames(child as THREE.Mesh)
+    const meshMatNames = getMeshMaterialNames(mesh)
 
     // Find matching material: check mesh material names against our map
     let matched = false
+    let appliedMaterial: THREE.MeshPhysicalMaterial | null = null
     for (const meshMatName of meshMatNames) {
       if (meshMatName in builtMaterials) {
-        ;(child as THREE.Mesh).material = builtMaterials[meshMatName]
+        appliedMaterial = builtMaterials[meshMatName]
+        mesh.material = appliedMaterial
         matched = true
         break
       }
@@ -173,12 +193,35 @@ function applyMaterialTextures(
 
     // Fallback: use wildcard "" material (applies to all unmatched meshes)
     if (!matched && hasWildcard && texturesReady) {
-      ;(child as THREE.Mesh).material = builtMaterials['']
+      appliedMaterial = builtMaterials['']
+      mesh.material = appliedMaterial
     }
 
     // Strip embedded materials from unmatched meshes to match worker behavior
     if (!matched && !hasWildcard) {
-      ;(child as THREE.Mesh).material = fallbackMaterial
+      mesh.material = fallbackMaterial
+    }
+
+    // Weld duplicated edge vertices when this mesh is about to be displaced.
+    // User-uploaded models with hard edges (e.g., game assets, low-poly
+    // boxes) carry the same per-face vertex duplication as three's stock
+    // primitives, and would tear open along every seam under displacement.
+    // Cache the welded geometry on userData so we only do the work once per
+    // (geometry, displacement-applied) pair.
+    if (appliedMaterial?.displacementMap) {
+      const cached = mesh.geometry.userData.weldedForDisplacement as
+        | THREE.BufferGeometry
+        | undefined
+      if (cached) {
+        mesh.geometry = cached
+      } else {
+        const welded = weldByPosition(mesh.geometry)
+        if (welded !== mesh.geometry) {
+          // Stash on the *original* geometry so re-traversals reuse it.
+          mesh.geometry.userData.weldedForDisplacement = welded
+          mesh.geometry = welded
+        }
+      }
     }
   })
 }

--- a/src/frontend/src/features/texture-set/components/FilesTab.tsx
+++ b/src/frontend/src/features/texture-set/components/FilesTab.tsx
@@ -29,7 +29,7 @@ interface FilesTabProps {
 interface FileMapping {
   fileId: number
   fileName: string
-  rgbOption: 'none' | 'albedo' | 'normal' | 'emissive' | 'split'
+  rgbOption: 'none' | 'albedo' | 'normal' | 'specular' | 'emissive' | 'split'
   rChannel: TextureType | null
   gChannel: TextureType | null
   bChannel: TextureType | null
@@ -41,6 +41,7 @@ const rgbOptions = [
   { label: 'None', value: 'none' },
   { label: 'Albedo', value: 'albedo' },
   { label: 'Normal', value: 'normal' },
+  { label: 'Specular', value: 'specular' },
   { label: 'Emissive', value: 'emissive' },
   { label: 'Split Channels', value: 'split' },
 ]
@@ -108,6 +109,9 @@ function inferRgbOption(textures: TextureDto[]): FileMapping['rgbOption'] {
 
   const normal = textures.find(t => t.textureType === TextureType.Normal)
   if (normal) return 'normal'
+
+  const specular = textures.find(t => t.textureType === TextureType.Specular)
+  if (specular) return 'specular'
 
   const emissive = textures.find(t => t.textureType === TextureType.Emissive)
   if (emissive) return 'emissive'
@@ -189,6 +193,7 @@ export function FilesTab({ textureSet, onMappingChanged }: FilesTabProps) {
         const typeMap: Record<string, TextureType> = {
           albedo: TextureType.Albedo,
           normal: TextureType.Normal,
+          specular: TextureType.Specular,
           emissive: TextureType.Emissive,
         }
         const textureType = typeMap[opt.value]
@@ -343,6 +348,7 @@ export function FilesTab({ textureSet, onMappingChanged }: FilesTabProps) {
       let targetType: TextureType | null = null
       if (newOption === 'albedo') targetType = TextureType.Albedo
       else if (newOption === 'normal') targetType = TextureType.Normal
+      else if (newOption === 'specular') targetType = TextureType.Specular
       else if (newOption === 'emissive') targetType = TextureType.Emissive
 
       if (targetType) {

--- a/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { EXRLoader } from 'three/examples/jsm/loaders/EXRLoader.js'
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
 
 import { getFileUrl } from '@/features/models/api/modelApi'
+import { weldByPosition } from '@/shared/three/weldGeometry'
 import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
 import { isExrFile, isTiffFile } from '@/utils/fileUtils'
 import { decodeTiffBlobToBitmap } from '@/utils/tiffTextureLoader'
@@ -115,6 +117,11 @@ function buildTextureUrls(
   )
   if (metallic) urls.metalnessMap = makeInfo(metallic)
 
+  const specular = textureSet.textures.find(
+    t => t.textureType === TextureType.Specular
+  )
+  if (specular) urls.specularColorMap = makeInfo(specular)
+
   const ao = textureSet.textures.find(t => t.textureType === TextureType.AO)
   if (ao) urls.aoMap = makeInfo(ao)
 
@@ -153,6 +160,7 @@ const MATERIAL_PROP_TO_TYPE_KEY: Record<string, string[]> = {
   normalMap: ['Normal'],
   roughnessMap: ['Roughness'],
   metalnessMap: ['Metallic'],
+  specularColorMap: ['Specular'],
   aoMap: ['AO'],
   emissiveMap: ['Emissive'],
   bumpMap: ['Bump'],
@@ -161,30 +169,85 @@ const MATERIAL_PROP_TO_TYPE_KEY: Record<string, string[]> = {
 }
 
 /**
+ * Copy `uv` to `uv2` if `uv2` doesn't already exist. AO maps require a
+ * second UV set; without this the post-weld UVs (which keep only the
+ * first occurrence per merged position) propagate into uv2 too, causing
+ * misaligned AO at rim/seam vertices.
+ */
+function ensureUv2(geometry: THREE.BufferGeometry): THREE.BufferGeometry {
+  const uv = geometry.getAttribute('uv')
+  if (uv && !geometry.getAttribute('uv2')) {
+    geometry.setAttribute('uv2', uv.clone())
+  }
+  return geometry
+}
+
+/**
+ * Compound cylinder: welded open-ended side + two independent
+ * CircleGeometry caps merged into one buffer. A simple welded
+ * CylinderGeometry would collapse cap-and-side rim vertices into a single
+ * averaged-normal vertex (~45° outward-up), which flares the rim badly
+ * under displacement. Keeping the rim vertices distinct between side and
+ * cap preserves the hard 90° edge — they share position, so adjacent
+ * triangles meet visually, but each piece keeps its own normal/UV.
+ */
+function createCylinderGeometry(): THREE.BufferGeometry {
+  const side = weldByPosition(
+    ensureUv2(new THREE.CylinderGeometry(1, 1, 2, 128, 128, true))
+  )
+
+  const topCap = ensureUv2(new THREE.CircleGeometry(1, 128))
+  topCap.rotateX(-Math.PI / 2)
+  topCap.translate(0, 1, 0)
+
+  const bottomCap = ensureUv2(new THREE.CircleGeometry(1, 128))
+  bottomCap.rotateX(Math.PI / 2)
+  bottomCap.translate(0, -1, 0)
+
+  const merged = mergeGeometries([side, topCap, bottomCap])
+  if (!merged) {
+    return weldByPosition(
+      ensureUv2(new THREE.CylinderGeometry(1, 1, 2, 128, 128, false))
+    )
+  }
+  return merged
+}
+
+/**
  * Create a BufferGeometry for the given primitive type.
- * Uses fixed standard unit sizes — the <Stage> component positions
- * the object consistently for all geometry types.
+ *
+ * Welding by position collapses seam/edge vertex duplicates so adjacent
+ * triangles share a single normal and stay watertight under displacement.
+ * `uv → uv2` is copied *before* welding so AO sampling at rim/seam
+ * vertices uses the same (welded) UV the color textures do. The cylinder
+ * is a compound geometry — see `createCylinderGeometry`.
  */
 function createGeometry(geometryType: GeometryType): THREE.BufferGeometry {
   switch (geometryType) {
     case 'plane':
       // High subdivision (512) so displacement mapping captures fine texture detail
-      return new THREE.PlaneGeometry(2.4, 2.4, 512, 512)
+      return ensureUv2(new THREE.PlaneGeometry(2.4, 2.4, 512, 512))
     case 'box':
-      return new THREE.BoxGeometry(2, 2, 2, 128, 128, 128)
+      return weldByPosition(
+        ensureUv2(new THREE.BoxGeometry(2, 2, 2, 128, 128, 128))
+      )
     case 'sphere':
-      return new THREE.SphereGeometry(1.2, 128, 128)
+      return weldByPosition(
+        ensureUv2(new THREE.SphereGeometry(1.2, 128, 128))
+      )
     case 'cylinder':
-      return new THREE.CylinderGeometry(1, 1, 2, 128, 128, false)
+      return createCylinderGeometry()
     case 'torus':
-      return new THREE.TorusGeometry(1, 0.4, 64, 128)
+      return weldByPosition(
+        ensureUv2(new THREE.TorusGeometry(1, 0.4, 64, 128))
+      )
     default:
-      return new THREE.PlaneGeometry(2.4, 2.4, 512, 512)
+      return ensureUv2(new THREE.PlaneGeometry(2.4, 2.4, 512, 512))
   }
 }
 
 /** Texture properties that carry color data (need sRGB encoding) */
-const COLOR_TEXTURE_PROPS = new Set(['map', 'emissiveMap'])
+const COLOR_TEXTURE_PROPS = new Set(['map', 'emissiveMap', 'specularColorMap'])
 
 /**
  * Extract a single channel from an ImageBitmap, producing a grayscale canvas texture.
@@ -308,18 +371,6 @@ function TexturedMesh({
   const geometry = useMemo(() => createGeometry(geometryType), [geometryType])
 
   const hasNormalMap = !!loadedTextures.normalMap
-  const hasAoMap = !!loadedTextures.aoMap
-
-  // AO maps require a second UV set — copy uv to uv2
-  useEffect(() => {
-    const geo = geometry
-    if (hasAoMap && geo && !geo.getAttribute('uv2')) {
-      const uvAttr = geo.getAttribute('uv')
-      if (uvAttr) {
-        geo.setAttribute('uv2', uvAttr.clone())
-      }
-    }
-  }, [hasAoMap, geometry])
 
   // Compute tangents for correct normal-map rendering
   useEffect(() => {
@@ -502,13 +553,19 @@ function TexturedMesh({
 
   return (
     <mesh ref={meshRef} castShadow receiveShadow geometry={geometry}>
-      <meshStandardMaterial
+      <meshPhysicalMaterial
         key={materialKey}
         map={(!isDisabled('map') && t.map) || null}
         normalMap={(!isDisabled('normalMap') && t.normalMap) || null}
         normalScale={normalScale}
         roughnessMap={(!isDisabled('roughnessMap') && t.roughnessMap) || null}
         metalnessMap={(!isDisabled('metalnessMap') && t.metalnessMap) || null}
+        specularColorMap={
+          (!isDisabled('specularColorMap') && t.specularColorMap) || null
+        }
+        specularIntensity={
+          t.specularColorMap && !isDisabled('specularColorMap') ? 1 : 0
+        }
         aoMap={(!isDisabled('aoMap') && t.aoMap) || null}
         aoMapIntensity={getStrength('aoMap')}
         emissiveMap={(!isDisabled('emissiveMap') && t.emissiveMap) || null}
@@ -518,7 +575,12 @@ function TexturedMesh({
         alphaMap={(!isDisabled('alphaMap') && t.alphaMap) || null}
         displacementMap={hasDisplacementMap ? t.displacementMap : null}
         displacementScale={
-          hasDisplacementMap ? getStrength('displacementMap') * 0.1 : 0
+          hasDisplacementMap ? getStrength('displacementMap') * 0.02 : 0
+        }
+        displacementBias={
+          hasDisplacementMap
+            ? -(getStrength('displacementMap') * 0.02) / 2
+            : 0
         }
         roughness={t.roughnessMap && !isDisabled('roughnessMap') ? 1 : 0.8}
         metalness={t.metalnessMap && !isDisabled('metalnessMap') ? 1 : 0}

--- a/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
@@ -232,15 +232,11 @@ function createGeometry(geometryType: GeometryType): THREE.BufferGeometry {
         ensureUv2(new THREE.BoxGeometry(2, 2, 2, 128, 128, 128))
       )
     case 'sphere':
-      return weldByPosition(
-        ensureUv2(new THREE.SphereGeometry(1.2, 128, 128))
-      )
+      return weldByPosition(ensureUv2(new THREE.SphereGeometry(1.2, 128, 128)))
     case 'cylinder':
       return createCylinderGeometry()
     case 'torus':
-      return weldByPosition(
-        ensureUv2(new THREE.TorusGeometry(1, 0.4, 64, 128))
-      )
+      return weldByPosition(ensureUv2(new THREE.TorusGeometry(1, 0.4, 64, 128)))
     default:
       return ensureUv2(new THREE.PlaneGeometry(2.4, 2.4, 512, 512))
   }
@@ -578,9 +574,7 @@ function TexturedMesh({
           hasDisplacementMap ? getStrength('displacementMap') * 0.02 : 0
         }
         displacementBias={
-          hasDisplacementMap
-            ? -(getStrength('displacementMap') * 0.02) / 2
-            : 0
+          hasDisplacementMap ? -(getStrength('displacementMap') * 0.02) / 2 : 0
         }
         roughness={t.roughnessMap && !isDisabled('roughnessMap') ? 1 : 0.8}
         metalness={t.metalnessMap && !isDisabled('metalnessMap') ? 1 : 0}

--- a/src/frontend/src/features/texture-set/types/index.ts
+++ b/src/frontend/src/features/texture-set/types/index.ts
@@ -8,6 +8,7 @@ export enum TextureType {
   AO = 4,
   Roughness = 5,
   Metallic = 6,
+  Specular = 8,
   Emissive = 9,
   Bump = 10,
   Alpha = 11,

--- a/src/frontend/src/shared/three/__tests__/weldGeometry.test.ts
+++ b/src/frontend/src/shared/three/__tests__/weldGeometry.test.ts
@@ -95,7 +95,9 @@ describe('weldByPosition', () => {
     const geom = new THREE.BufferGeometry()
     geom.setAttribute('position', positionAttr)
     geom.setAttribute('uv', uvAttr)
-    geom.setIndex(new THREE.BufferAttribute(new Uint16Array([0, 1, 2, 3, 4, 5]), 1))
+    geom.setIndex(
+      new THREE.BufferAttribute(new Uint16Array([0, 1, 2, 3, 4, 5]), 1)
+    )
 
     const welded = weldByPosition(geom)
 

--- a/src/frontend/src/shared/three/__tests__/weldGeometry.test.ts
+++ b/src/frontend/src/shared/three/__tests__/weldGeometry.test.ts
@@ -1,0 +1,115 @@
+import * as THREE from 'three'
+
+import { weldByPosition } from '../weldGeometry'
+
+function makeQuad(): THREE.BufferGeometry {
+  // Two triangles sharing an edge — vertices 1+2 and 3+4 are positional
+  // duplicates (e.g., the hard-edge case from BoxGeometry-style authoring).
+  // Positions:
+  //   0: (0, 0, 0)   used by tri A
+  //   1: (1, 0, 0)   used by tri A AND duplicated as vertex 3
+  //   2: (0, 1, 0)   used by tri A AND duplicated as vertex 4
+  //   3: (1, 0, 0)   used by tri B  (== pos of 1)
+  //   4: (0, 1, 0)   used by tri B  (== pos of 2)
+  //   5: (1, 1, 0)   used by tri B
+  const positions = new Float32Array([
+    0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+  ])
+  // UVs differ between the duplicates so stock mergeVertices wouldn't
+  // collapse them; weldByPosition should.
+  const uvs = new Float32Array([0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1])
+  // Normals: tri A is back-face (-Z), tri B is front-face (+Z) so the
+  // weld must average them to (0,0,0)... but computeVertexNormals will
+  // recompute anyway from the merged topology.
+  const normals = new Float32Array([
+    0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+  ])
+  const indices = new Uint16Array([0, 1, 2, 3, 4, 5])
+
+  const geom = new THREE.BufferGeometry()
+  geom.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+  geom.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
+  geom.setAttribute('normal', new THREE.BufferAttribute(normals, 3))
+  geom.setIndex(new THREE.BufferAttribute(indices, 1))
+  return geom
+}
+
+describe('weldByPosition', () => {
+  it('collapses positional duplicates and rewrites the index buffer', () => {
+    const welded = weldByPosition(makeQuad())
+
+    expect(welded.getAttribute('position').count).toBe(4) // 6 → 4 unique
+    expect(welded.index).not.toBeNull()
+    expect(welded.index!.count).toBe(6) // index length unchanged
+  })
+
+  it('keeps the first occurrence UV for each merged vertex', () => {
+    const welded = weldByPosition(makeQuad())
+    const uv = welded.getAttribute('uv')
+
+    // Vertex 1 (pos (1,0,0)) was seen first with UV (1,0); the duplicate at
+    // old index 3 had UV (1,1) but loses since it's the second occurrence.
+    // Find the welded index for that position via the rewritten index.
+    const idx = welded.index!
+    const mergedSlotForOldIndex1 = idx.getX(1)
+    expect(uv.getX(mergedSlotForOldIndex1)).toBe(1)
+    expect(uv.getY(mergedSlotForOldIndex1)).toBe(0)
+  })
+
+  it('returns the source unchanged when there are no duplicates', () => {
+    const plain = new THREE.PlaneGeometry(1, 1, 1, 1)
+    const result = weldByPosition(plain)
+    expect(result).toBe(plain) // identity — no allocation
+  })
+
+  it('handles non-indexed input by treating each vertex as its own index', () => {
+    const positions = new Float32Array([
+      0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    ])
+    const geom = new THREE.BufferGeometry()
+    geom.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+    // No index, no other attributes.
+
+    const welded = weldByPosition(geom)
+
+    expect(welded.getAttribute('position').count).toBe(4)
+    expect(welded.index).not.toBeNull()
+    expect(welded.index!.count).toBe(6) // synthesised index covers all 6 verts
+  })
+
+  it('reads InterleavedBufferAttribute through the accessor API', () => {
+    // Build a single interleaved buffer carrying both position (x,y,z) and
+    // uv (u,v) per vertex — common shape for GLTF imports. The raw .array
+    // path used to mis-index here; the welded result must read consistent
+    // values via getX/getY/getZ.
+    //
+    // Layout per vertex (stride 5): [px, py, pz, u, v]
+    const interleaved = new Float32Array([
+      0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1,
+      1, 1, 0, 1, 1,
+    ])
+    const buf = new THREE.InterleavedBuffer(interleaved, 5)
+    const positionAttr = new THREE.InterleavedBufferAttribute(buf, 3, 0)
+    const uvAttr = new THREE.InterleavedBufferAttribute(buf, 2, 3)
+
+    const geom = new THREE.BufferGeometry()
+    geom.setAttribute('position', positionAttr)
+    geom.setAttribute('uv', uvAttr)
+    geom.setIndex(new THREE.BufferAttribute(new Uint16Array([0, 1, 2, 3, 4, 5]), 1))
+
+    const welded = weldByPosition(geom)
+
+    // 6 verts → 4 unique positions (same topology as the quad test).
+    expect(welded.getAttribute('position').count).toBe(4)
+    // Position at old index 1 was (1, 0, 0).
+    const mergedSlotForOldIndex1 = welded.index!.getX(1)
+    const pos = welded.getAttribute('position')
+    expect(pos.getX(mergedSlotForOldIndex1)).toBe(1)
+    expect(pos.getY(mergedSlotForOldIndex1)).toBe(0)
+    expect(pos.getZ(mergedSlotForOldIndex1)).toBe(0)
+    // UV at the same merged slot is the first occurrence's UV (1, 0).
+    const uv = welded.getAttribute('uv')
+    expect(uv.getX(mergedSlotForOldIndex1)).toBe(1)
+    expect(uv.getY(mergedSlotForOldIndex1)).toBe(0)
+  })
+})

--- a/src/frontend/src/shared/three/weldGeometry.ts
+++ b/src/frontend/src/shared/three/weldGeometry.ts
@@ -1,0 +1,106 @@
+import * as THREE from 'three'
+
+/**
+ * Merge duplicated vertices by position alone, then recompute vertex normals.
+ *
+ * Why this exists: three.js primitives (BoxGeometry, SphereGeometry,
+ * CylinderGeometry, TorusGeometry) and many user-uploaded meshes (anything
+ * authored with hard edges) carry *duplicated* vertices at every shared
+ * seam — each copy holds the same position but a face-aligned normal and a
+ * face-local UV. Under per-vertex displacement, those duplicates push along
+ * their own face normal — `(1,0,0)` on the +X face, `(0,1,0)` on the +Y
+ * face, and so on — so the shared edge tears apart even if the height
+ * sample is identical (e.g., when fed by triplanar projection).
+ *
+ * The stock `BufferGeometryUtils.mergeVertices` hashes by every attribute,
+ * so the differing normals/UVs prevent it from collapsing those copies.
+ * This welder hashes by position only, then `computeVertexNormals` averages
+ * the face normals at each merged vertex so adjacent faces displace along
+ * a single shared direction. The UV at each merged vertex keeps the first
+ * occurrence's value; for tileable PBR textures with RepeatWrapping that
+ * leaves only a one-vertex-wide texture wraparound at face boundaries —
+ * an acceptable cost compared to the visible gap.
+ *
+ * Returns a new geometry; the input is untouched. If no duplicates exist
+ * (e.g., PlaneGeometry), returns the input unchanged.
+ */
+export function weldByPosition(
+  source: THREE.BufferGeometry,
+  tolerance = 1e-4
+): THREE.BufferGeometry {
+  const position = source.getAttribute('position') as
+    | THREE.BufferAttribute
+    | undefined
+  if (!position) return source
+
+  const oldCount = position.count
+  const inputIndex = source.index
+  const indexCount = inputIndex ? inputIndex.count : oldCount
+
+  const mult = 1 / tolerance
+  const posKeyToNewIdx = new Map<string, number>()
+  const oldToNew = new Uint32Array(oldCount)
+  let newCount = 0
+
+  for (let i = 0; i < oldCount; i++) {
+    const x = Math.round(position.getX(i) * mult)
+    const y = Math.round(position.getY(i) * mult)
+    const z = Math.round(position.getZ(i) * mult)
+    const key = `${x},${y},${z}`
+    let newIdx = posKeyToNewIdx.get(key)
+    if (newIdx === undefined) {
+      newIdx = newCount++
+      posKeyToNewIdx.set(key, newIdx)
+    }
+    oldToNew[i] = newIdx
+  }
+
+  if (newCount === oldCount) {
+    return source
+  }
+
+  const dest = new THREE.BufferGeometry()
+  for (const name in source.attributes) {
+    const attr = source.attributes[name] as THREE.BufferAttribute
+    const itemSize = attr.itemSize
+    const ArrCtor = attr.array.constructor as {
+      new (length: number): ArrayLike<number> & { [n: number]: number }
+    }
+    const newArr = new ArrCtor(newCount * itemSize) as unknown as
+      | Float32Array
+      | Uint16Array
+      | Uint32Array
+    const seen = new Uint8Array(newCount)
+    for (let i = 0; i < oldCount; i++) {
+      const newIdx = oldToNew[i]
+      if (!seen[newIdx]) {
+        seen[newIdx] = 1
+        for (let k = 0; k < itemSize; k++) {
+          newArr[newIdx * itemSize + k] = attr.array[i * itemSize + k]
+        }
+      }
+    }
+    dest.setAttribute(
+      name,
+      new THREE.BufferAttribute(newArr, itemSize, attr.normalized)
+    )
+  }
+
+  const newIndexArray =
+    newCount < 0xffff
+      ? new Uint16Array(indexCount)
+      : new Uint32Array(indexCount)
+  for (let i = 0; i < indexCount; i++) {
+    const oldIdx = inputIndex ? inputIndex.getX(i) : i
+    newIndexArray[i] = oldToNew[oldIdx]
+  }
+  dest.setIndex(new THREE.BufferAttribute(newIndexArray, 1))
+
+  // Tangents (if any) reference per-vertex normals that no longer exist as
+  // authored. Drop them; the renderer will recompute when a normal map is
+  // attached.
+  dest.deleteAttribute('tangent')
+  dest.computeVertexNormals()
+
+  return dest
+}

--- a/src/frontend/src/shared/three/weldGeometry.ts
+++ b/src/frontend/src/shared/three/weldGeometry.ts
@@ -61,23 +61,30 @@ export function weldByPosition(
 
   const dest = new THREE.BufferGeometry()
   for (const name in source.attributes) {
-    const attr = source.attributes[name] as THREE.BufferAttribute
+    const attr = source.attributes[name] as
+      | THREE.BufferAttribute
+      | THREE.InterleavedBufferAttribute
     const itemSize = attr.itemSize
-    const ArrCtor = attr.array.constructor as {
-      new (length: number): ArrayLike<number> & { [n: number]: number }
-    }
-    const newArr = new ArrCtor(newCount * itemSize) as unknown as
-      | Float32Array
-      | Uint16Array
-      | Uint32Array
+    // GLTF imports commonly use InterleavedBufferAttribute (strided buffers);
+    // reading attr.array directly would index into the shared interleaved
+    // buffer with the wrong stride. Use getX/getY/getZ/getW which both
+    // attribute types implement and de-interleave the output.
+    const srcArray =
+      attr instanceof THREE.InterleavedBufferAttribute
+        ? attr.data.array
+        : attr.array
+    const ArrCtor = srcArray.constructor as new (length: number) => typeof srcArray
+    const newArr = new ArrCtor(newCount * itemSize)
     const seen = new Uint8Array(newCount)
     for (let i = 0; i < oldCount; i++) {
       const newIdx = oldToNew[i]
       if (!seen[newIdx]) {
         seen[newIdx] = 1
-        for (let k = 0; k < itemSize; k++) {
-          newArr[newIdx * itemSize + k] = attr.array[i * itemSize + k]
-        }
+        const base = newIdx * itemSize
+        if (itemSize >= 1) newArr[base] = attr.getX(i)
+        if (itemSize >= 2) newArr[base + 1] = attr.getY(i)
+        if (itemSize >= 3) newArr[base + 2] = attr.getZ(i)
+        if (itemSize >= 4) newArr[base + 3] = attr.getW(i)
       }
     }
     dest.setAttribute(

--- a/src/frontend/src/shared/three/weldGeometry.ts
+++ b/src/frontend/src/shared/three/weldGeometry.ts
@@ -73,7 +73,9 @@ export function weldByPosition(
       attr instanceof THREE.InterleavedBufferAttribute
         ? attr.data.array
         : attr.array
-    const ArrCtor = srcArray.constructor as new (length: number) => typeof srcArray
+    const ArrCtor = srcArray.constructor as new (
+      length: number
+    ) => typeof srcArray
     const newArr = new ArrCtor(newCount * itemSize)
     const seen = new Uint8Array(newCount)
     for (let i = 0; i < oldCount; i++) {

--- a/src/frontend/src/utils/textureTypeUtils.ts
+++ b/src/frontend/src/utils/textureTypeUtils.ts
@@ -8,7 +8,7 @@ export interface TextureTypeInfo {
 }
 
 // Texture type definitions with visual indicators
-// Note: Diffuse and Specular have been removed (not PBR standard)
+// Note: Diffuse has been removed (use Albedo instead)
 export const TEXTURE_TYPE_INFO: Partial<Record<TextureType, TextureTypeInfo>> =
   {
     [TextureType.SplitChannel]: {
@@ -53,6 +53,13 @@ export const TEXTURE_TYPE_INFO: Partial<Record<TextureType, TextureTypeInfo>> =
       description: 'Metallic map - defines metallic vs non-metallic areas',
       color: '#6b7280', // Silver/gray
       icon: 'pi-star-fill',
+    },
+    [TextureType.Specular]: {
+      label: 'Specular',
+      description:
+        'Specular map - defines specular reflection color/intensity (legacy/non-PBR workflows)',
+      color: '#e5e7eb', // Light silver
+      icon: 'pi-sparkles',
     },
     [TextureType.Emissive]: {
       label: 'Emissive',

--- a/tests/Domain.Tests/ValueObjects/TextureTypeTests.cs
+++ b/tests/Domain.Tests/ValueObjects/TextureTypeTests.cs
@@ -13,6 +13,7 @@ public class TextureTypeTests
     [InlineData(TextureType.AO)]
     [InlineData(TextureType.Roughness)]
     [InlineData(TextureType.Metallic)]
+    [InlineData(TextureType.Specular)]
     [InlineData(TextureType.Emissive)]
     [InlineData(TextureType.Bump)]
     [InlineData(TextureType.Alpha)]
@@ -48,8 +49,8 @@ public class TextureTypeTests
         // Act
         var supportedTypes = TextureTypeExtensions.GetSupportedTypes();
 
-        // Assert - Diffuse and Specular have been removed, SplitChannel added, now 11 types
-        Assert.Equal(11, supportedTypes.Count);
+        // Assert - Diffuse removed, SplitChannel + Specular present, now 12 types
+        Assert.Equal(12, supportedTypes.Count);
         Assert.Contains(TextureType.SplitChannel, supportedTypes);
         Assert.Contains(TextureType.Albedo, supportedTypes);
         Assert.Contains(TextureType.Normal, supportedTypes);
@@ -57,6 +58,7 @@ public class TextureTypeTests
         Assert.Contains(TextureType.AO, supportedTypes);
         Assert.Contains(TextureType.Roughness, supportedTypes);
         Assert.Contains(TextureType.Metallic, supportedTypes);
+        Assert.Contains(TextureType.Specular, supportedTypes);
         Assert.Contains(TextureType.Emissive, supportedTypes);
         Assert.Contains(TextureType.Bump, supportedTypes);
         Assert.Contains(TextureType.Alpha, supportedTypes);
@@ -70,6 +72,7 @@ public class TextureTypeTests
     [InlineData(TextureType.AO, "Ambient Occlusion map")]
     [InlineData(TextureType.Roughness, "Surface roughness map")]
     [InlineData(TextureType.Metallic, "Metallic surface map")]
+    [InlineData(TextureType.Specular, "Specular reflection map")]
     [InlineData(TextureType.Emissive, "Emissive map for glowing areas")]
     [InlineData(TextureType.Bump, "Bump map for surface detail")]
     [InlineData(TextureType.Alpha, "Alpha map for transparency")]
@@ -115,6 +118,7 @@ public class TextureTypeTests
     [InlineData(TextureType.AO)]
     [InlineData(TextureType.Roughness)]
     [InlineData(TextureType.Metallic)]
+    [InlineData(TextureType.Specular)]
     [InlineData(TextureType.Emissive)]
     [InlineData(TextureType.Alpha)]
     public void IsHeightRelatedType_WithNonHeightTypes_ReturnsFalse(TextureType textureType)


### PR DESCRIPTION
## Summary

- **Add Specular** as a supported texture type (enum value 8) end-to-end: domain, frontend mirror enum, RGB option in the FilesTab, tests.
- **Make texture previews watertight under displacement.** Three.js primitives and many user-uploaded meshes carry duplicated edge vertices, and per-vertex displacement was pushing those duplicates along divergent face normals — cubes split at every edge, sphere/cylinder seams cracked, hard-edged user models came apart. Fixed by welding by position before displacement is sampled.
- **Make the displacement amplitude/lighting honest.** Reduce the displacement baseline 5×, add a `displacementBias = -scale/2` so heightmap mid-grey means "no displacement", and disable the `MeshPhysicalMaterial` dielectric specular when no Specular map is bound (it was washing the albedo white).

## Why

User reported a tileable PBR set rendering as a chunky, washed-out, chevron-streaked column on the cylinder primitive — and as a "completely disconnected" model in the viewer. Three independent bugs were compounding:

1. **Tearing** — face-aligned per-vertex normals × per-vertex displacement = duplicates pushed in different directions at every shared edge. Three.js's stock `mergeVertices` hashes by all attributes (normal + uv), so the duplicate vertices that share position but differ in normal/UV never collapse. The new `weldByPosition` hashes by position alone, then recomputes vertex normals.
2. **Triplanar misadventure** — I had tried sampling the heightmap triplanar to fix this, but triplanar samples by world axes; on a cylinder side, the X- and Z-axis projections meet at every vertex and produce the chevron pattern. Triplanar is removed entirely; welding alone fixes the tearing.
3. **Washed-out albedo + inflated geometry** — the earlier migration from `MeshStandardMaterial` to `MeshPhysicalMaterial` (to support `specularColorMap`) defaulted `specularIntensity` to 1, adding a sheen on top of every albedo. Displacement scale of `× 0.1` on a unit-radius cylinder pushed 10% of the radius outward; the missing bias meant every vertex inflated rather than just grout recessing.

## Changes

### `src/Domain/ValueObjects/TextureType.cs` + tests
- Reintroduce `Specular = 8` to the enum and the `SupportedTypes` array.
- Add a description + tests covering validation and `IsHeightRelatedType`.

### `src/frontend/src/features/texture-set/`
- Mirror `Specular = 8` in the frontend enum.
- Add `TEXTURE_TYPE_INFO[Specular]` entry (label, color, icon).
- Wire Specular as an RGB option in `FilesTab` alongside Albedo/Normal/Emissive (dropdown + change handler + auto-inference).

### `src/frontend/src/shared/three/weldGeometry.ts` (new)
- `weldByPosition(geometry, tolerance?)`: hashes vertices by quantized position, keeps the first occurrence's attributes per merged vertex, drops the now-stale `tangent` attribute, calls `computeVertexNormals` so adjacent faces share a single displacement direction. Returns the input unchanged when there are no duplicates (plane / torus pass-through).

### `src/frontend/src/features/texture-set/components/TexturedGeometry.tsx`
- New `ensureUv2(geom)` helper — copies `uv → uv2` *before* welding so AO sampling at welded seams uses the same UVs the color textures do.
- New `createCylinderGeometry()` — welds an open-ended `CylinderGeometry` and merges two independent `CircleGeometry` caps via `BufferGeometryUtils.mergeGeometries`. Side rim keeps radial normals; cap rim keeps ±Y normals — no averaged 45° rim flare under displacement.
- All other primitives: `ensureUv2 → weldByPosition` uniformly.
- `<meshPhysicalMaterial>` JSX: `displacementScale` from `× 0.1` to `× 0.02`, new `displacementBias = -(strength × 0.02) / 2`, explicit `specularIntensity={0}` unless a Specular map is loaded.

### `src/frontend/src/features/model-viewer/components/TexturedModel.tsx`
- Weld user-mesh geometry when the applied material has a `displacementMap`, caching the welded copy on the original geometry's `userData.weldedForDisplacement` so traversals reuse it.
- Material: `specularIntensity` = 1 only if a `specularColorMap` is bound, `displacementScale = 0.02`, `displacementBias = -0.01`.

### `src/asset-processor/puppeteerRenderer.js`
- Match the frontend's displacement scale / bias / specular changes so server-side thumbnails track the live preview.

## Test plan

- [ ] Open Preview tab on a tileable PBR set with Albedo + Displacement (e.g. `interior_tiles_diff_4k`). Each primitive (plane, cube, sphere, cylinder, torus) should render with the texture tiling cleanly, no torn edges, no chevron seams. The cylinder's hard 90° rim should be preserved.
- [ ] Open the model viewer with a user model containing hard edges + a tileable PBR set with displacement. Mesh should stay watertight along seams.
- [ ] Apply a Specular texture via the FilesTab "Specular" RGB option and confirm `specularColorMap` is wired through (sheen visible vs. albedo-only flat look).
- [ ] Regenerate a texture-set thumbnail and confirm the server-side render matches the live preview (no washout, sane displacement amplitude).
- [ ] `dotnet test tests/Domain.Tests` — 36 TextureType tests pass.
- [ ] `npx jest src/features src/utils` from `src/frontend` — all 169 tests pass.