### PR TITLE
feat(textures): Glossiness type + FBX preview/thumbnail fixes

### DIFF
--- a/src/Domain/Models/TextureSet.cs
+++ b/src/Domain/Models/TextureSet.cs
@@ -309,6 +309,18 @@ public class TextureSet : AggregateRoot
             }
         }
 
+        // Validate mutual exclusivity of Roughness and Glossiness (Glossiness is inverted Roughness)
+        if (texture.TextureType.IsSurfaceRelatedType())
+        {
+            var existingSurfaceType = _textures.FirstOrDefault(t => t.TextureType.IsSurfaceRelatedType());
+            if (existingSurfaceType != null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot add '{texture.TextureType}' because '{existingSurfaceType.TextureType}' already exists in this set. " +
+                    "Only one of Roughness or Glossiness can be assigned per texture set.");
+            }
+        }
+
         _textures.Add(texture);
         UpdatedAt = updatedAt;
     }

--- a/src/Domain/ValueObjects/TextureType.cs
+++ b/src/Domain/ValueObjects/TextureType.cs
@@ -44,7 +44,10 @@ public enum TextureType
     Alpha = 11,
     
     /// <summary>Displacement map - actual geometric displacement of vertices (mutually exclusive with Height, Bump)</summary>
-    Displacement = 12
+    Displacement = 12,
+
+    /// <summary>Glossiness map - inverted Roughness (mutually exclusive with Roughness). Applied as roughnessMap with channel inverted at load time.</summary>
+    Glossiness = 13
 }
 
 /// <summary>
@@ -65,17 +68,28 @@ public static class TextureTypeExtensions
         TextureType.Emissive,
         TextureType.Bump,
         TextureType.Alpha,
-        TextureType.Displacement
+        TextureType.Displacement,
+        TextureType.Glossiness
     };
 
     /// <summary>
     /// Height, Displacement, and Bump are mutually exclusive - only one can be present in a texture set.
     /// </summary>
-    public static readonly TextureType[] MutuallyExclusiveHeightTypes = 
+    public static readonly TextureType[] MutuallyExclusiveHeightTypes =
     {
         TextureType.Height,
         TextureType.Displacement,
         TextureType.Bump
+    };
+
+    /// <summary>
+    /// Roughness and Glossiness are mutually exclusive - they describe the same surface property
+    /// (microsurface) inverted. Only one can be present in a texture set.
+    /// </summary>
+    public static readonly TextureType[] MutuallyExclusiveSurfaceTypes =
+    {
+        TextureType.Roughness,
+        TextureType.Glossiness
     };
 
     /// <summary>
@@ -100,6 +114,14 @@ public static class TextureTypeExtensions
     public static bool IsHeightRelatedType(this TextureType textureType)
     {
         return MutuallyExclusiveHeightTypes.Contains(textureType);
+    }
+
+    /// <summary>
+    /// Checks if this texture type is mutually exclusive with Roughness/Glossiness.
+    /// </summary>
+    public static bool IsSurfaceRelatedType(this TextureType textureType)
+    {
+        return MutuallyExclusiveSurfaceTypes.Contains(textureType);
     }
 
     /// <summary>
@@ -129,6 +151,7 @@ public static class TextureTypeExtensions
             TextureType.Bump => "Bump map for surface detail",
             TextureType.Alpha => "Alpha map for transparency",
             TextureType.Displacement => "Displacement map for vertex displacement",
+            TextureType.Glossiness => "Glossiness map (inverted roughness)",
             _ => "Unknown texture type"
         };
     }

--- a/src/asset-processor/render-template.html
+++ b/src/asset-processor/render-template.html
@@ -519,7 +519,10 @@
         const maxDimension = Math.max(size.x, size.y, size.z)
         if (maxDimension > 0) {
           const scaleFactor = scale / maxDimension
-          model.scale.setScalar(scaleFactor)
+          // Multiply, don't replace: FBX (and some glTF) loaders bake a
+          // non-1 unit-conversion scale into the root. setScalar would drop
+          // it and shrink the model to ~1/100 of intended size.
+          model.scale.multiplyScalar(scaleFactor)
         }
 
         // Recalculate bounding box after scaling
@@ -527,11 +530,12 @@
         const scaledCenter = scaledBox.getCenter(new THREE.Vector3())
         const scaledSize = scaledBox.getSize(new THREE.Vector3())
 
-        // Center the model around its bounding box center (not origin)
-        // This ensures the model rotates correctly around its visual center
-        model.position.x = -scaledCenter.x
-        model.position.y = -scaledCenter.y
-        model.position.z = -scaledCenter.z
+        // Center the model around its bounding box center.
+        // Subtract (not assign): FBX bakes a non-zero translation into the
+        // root, and overwriting it would offset the model from the camera.
+        model.position.x -= scaledCenter.x
+        model.position.y -= scaledCenter.y
+        model.position.z -= scaledCenter.z
 
         // Create a container group for rotation around the true center
         const container = new THREE.Group()

--- a/src/frontend/src/features/model-viewer/components/Model.tsx
+++ b/src/frontend/src/features/model-viewer/components/Model.tsx
@@ -8,6 +8,7 @@ import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
 
 import { LoadingPlaceholder } from '@/components/LoadingPlaceholder'
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
+import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
 
 // Separate components for each model type to avoid conditional hooks
 function OBJModel({
@@ -30,7 +31,9 @@ function OBJModel({
     }
   })
 
-  const model = useLoader(OBJLoader, modelUrl)
+  const model = useLoader(OBJLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
 
   useEffect(() => {
     // Reset scaled flag when modelUrl changes
@@ -65,16 +68,21 @@ function OBJModel({
       const scale = 2 / maxDim
 
       // Scale the model first
-      clonedModel.scale.setScalar(scale)
+      // Multiply, don't replace: some loaders (notably FBX) bake a non-1
+      // unit-conversion scale into the root. setScalar would drop that and
+      // shrink the model to ~1/100 of intended size.
+      clonedModel.scale.multiplyScalar(scale)
 
       // Recalculate bounding box after scaling
       const scaledBox = new THREE.Box3().setFromObject(clonedModel)
       const scaledCenter = scaledBox.getCenter(new THREE.Vector3())
 
       // Position model so it's centered in X and Z, but bottom is at y=0 (floor level)
-      clonedModel.position.x = -scaledCenter.x
-      clonedModel.position.z = -scaledCenter.z
-      clonedModel.position.y = -scaledBox.min.y
+      // Subtract (not assign): FBX bakes a non-zero translation into the root,
+      // and overwriting it would offset the model from the camera target.
+      clonedModel.position.x -= scaledCenter.x
+      clonedModel.position.z -= scaledCenter.z
+      clonedModel.position.y -= scaledBox.min.y
 
       // Store the cloned model in the ref
       if (meshRef.current) {
@@ -122,7 +130,9 @@ function GLTFModel({
     }
   })
 
-  const gltf = useLoader(GLTFLoader, modelUrl)
+  const gltf = useLoader(GLTFLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
   const model = gltf?.scene
 
   useEffect(() => {
@@ -158,16 +168,21 @@ function GLTFModel({
       const scale = 2 / maxDim
 
       // Scale the model first
-      clonedModel.scale.setScalar(scale)
+      // Multiply, don't replace: some loaders (notably FBX) bake a non-1
+      // unit-conversion scale into the root. setScalar would drop that and
+      // shrink the model to ~1/100 of intended size.
+      clonedModel.scale.multiplyScalar(scale)
 
       // Recalculate bounding box after scaling
       const scaledBox = new THREE.Box3().setFromObject(clonedModel)
       const scaledCenter = scaledBox.getCenter(new THREE.Vector3())
 
       // Position model so it's centered in X and Z, but bottom is at y=0 (floor level)
-      clonedModel.position.x = -scaledCenter.x
-      clonedModel.position.z = -scaledCenter.z
-      clonedModel.position.y = -scaledBox.min.y
+      // Subtract (not assign): FBX bakes a non-zero translation into the root,
+      // and overwriting it would offset the model from the camera target.
+      clonedModel.position.x -= scaledCenter.x
+      clonedModel.position.z -= scaledCenter.z
+      clonedModel.position.y -= scaledBox.min.y
 
       // Store the cloned model in the ref
       if (meshRef.current) {
@@ -215,7 +230,9 @@ function FBXModel({
     }
   })
 
-  const model = useLoader(FBXLoader, modelUrl)
+  const model = useLoader(FBXLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
 
   useEffect(() => {
     // Reset scaled flag when modelUrl changes
@@ -249,17 +266,21 @@ function FBXModel({
       const maxDim = Math.max(size.x, size.y, size.z)
       const scale = 2 / maxDim
 
-      // Scale the model first
-      clonedModel.scale.setScalar(scale)
+      // Multiply, don't replace: some loaders (notably FBX) bake a non-1
+      // unit-conversion scale into the root. setScalar would drop that and
+      // shrink the model to ~1/100 of intended size.
+      clonedModel.scale.multiplyScalar(scale)
 
       // Recalculate bounding box after scaling
       const scaledBox = new THREE.Box3().setFromObject(clonedModel)
       const scaledCenter = scaledBox.getCenter(new THREE.Vector3())
 
       // Position model so it's centered in X and Z, but bottom is at y=0 (floor level)
-      clonedModel.position.x = -scaledCenter.x
-      clonedModel.position.z = -scaledCenter.z
-      clonedModel.position.y = -scaledBox.min.y
+      // Subtract (not assign): FBX bakes a non-zero translation into the root,
+      // and overwriting it would offset the model from the camera target.
+      clonedModel.position.x -= scaledCenter.x
+      clonedModel.position.z -= scaledCenter.z
+      clonedModel.position.y -= scaledBox.min.y
 
       // Store the cloned model in the ref
       if (meshRef.current) {

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -11,11 +11,11 @@ import {
 } from '@/features/model-viewer/hooks/useChannelExtractedTextures'
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
 import { getFileUrl } from '@/features/models/api/modelApi'
+import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
 import {
   addSharedDisplacementNormal,
   applyDispNormalDisplacement,
 } from '@/shared/three/sharedDisplacementNormal'
-import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
 import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
 
 /** Map of material names to their texture sets. Key "" means apply to all meshes. */

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -15,6 +15,7 @@ import {
   addSharedDisplacementNormal,
   applyDispNormalDisplacement,
 } from '@/shared/three/sharedDisplacementNormal'
+import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
 import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
 
 /** Map of material names to their texture sets. Key "" means apply to all meshes. */
@@ -27,15 +28,24 @@ interface TexturedModelProps {
   materialTextureSets: MaterialTextureSets
 }
 
-// Material property slot names used by MeshPhysicalMaterial
+// Material property slot names used by MeshPhysicalMaterial.
+// `fallback` is used when the primary type is absent (mutually-exclusive groups).
+// `invertFallback` means the fallback texture must be channel-inverted at load
+// time (e.g. Glossiness fed through the roughnessMap slot).
 const TEXTURE_SLOTS: Array<{
   slot: string
   type: TextureType
   fallback?: TextureType
+  invertFallback?: boolean
 }> = [
   { slot: 'map', type: TextureType.Albedo },
   { slot: 'normalMap', type: TextureType.Normal },
-  { slot: 'roughnessMap', type: TextureType.Roughness },
+  {
+    slot: 'roughnessMap',
+    type: TextureType.Roughness,
+    fallback: TextureType.Glossiness,
+    invertFallback: true,
+  },
   { slot: 'metalnessMap', type: TextureType.Metallic },
   { slot: 'specularColorMap', type: TextureType.Specular },
   { slot: 'aoMap', type: TextureType.AO },
@@ -65,16 +75,19 @@ function buildCombinedTextureConfigs(
     materialTextureSets
   )) {
     if (!textureSet?.textures) continue
-    for (const { slot, type, fallback } of TEXTURE_SLOTS) {
+    for (const { slot, type, fallback, invertFallback } of TEXTURE_SLOTS) {
       let tex = textureSet.textures.find(t => t.textureType === type)
+      let invert = false
       if (!tex && fallback) {
         tex = textureSet.textures.find(t => t.textureType === fallback)
+        if (tex && invertFallback) invert = true
       }
       if (tex) {
         configs[`${materialName}${KEY_SEP}${slot}`] = {
           url: getFileUrl(tex.fileId.toString()),
           sourceChannel: tex.sourceChannel ?? TextureChannel.RGB,
           fileName: tex.fileName,
+          invert,
         }
       }
     }
@@ -273,14 +286,18 @@ function setupModel(
   const maxDim = Math.max(size.x, size.y, size.z)
   const scale = 2 / maxDim
 
-  clonedModel.scale.setScalar(scale)
+  // Multiply, don't replace: FBX bakes a non-1 unit-conversion scale into
+  // the root and setScalar would drop it, collapsing the model.
+  clonedModel.scale.multiplyScalar(scale)
 
   const scaledBox = new THREE.Box3().setFromObject(clonedModel)
   const scaledCenter = scaledBox.getCenter(new THREE.Vector3())
 
-  clonedModel.position.x = -scaledCenter.x
-  clonedModel.position.z = -scaledCenter.z
-  clonedModel.position.y = -scaledBox.min.y
+  // Subtract (not assign): FBX bakes a non-zero translation into the root,
+  // and overwriting it would offset the model from the camera target.
+  clonedModel.position.x -= scaledCenter.x
+  clonedModel.position.z -= scaledCenter.z
+  clonedModel.position.y -= scaledBox.min.y
 
   if (meshRef.current) {
     meshRef.current.clear()
@@ -307,7 +324,9 @@ function OBJModelWithTextures({
     }
   })
 
-  const model = useLoader(OBJLoader, modelUrl)
+  const model = useLoader(OBJLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
   const { loadedTextures, texturesReady } = usePerMaterialTextures(
     materialTextureSets,
     renderer,
@@ -354,7 +373,9 @@ function GLTFModelWithTextures({
     }
   })
 
-  const gltf = useLoader(GLTFLoader, modelUrl)
+  const gltf = useLoader(GLTFLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
   const model = gltf?.scene
   const { loadedTextures, texturesReady } = usePerMaterialTextures(
     materialTextureSets,
@@ -403,7 +424,9 @@ function FBXModelWithTextures({
     }
   })
 
-  const model = useLoader(FBXLoader, modelUrl)
+  const model = useLoader(FBXLoader, modelUrl, loader => {
+    loader.manager = safeLoadingManager
+  })
   const { loadedTextures, texturesReady } = usePerMaterialTextures(
     materialTextureSets,
     renderer,

--- a/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
+++ b/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
@@ -17,23 +17,40 @@ const vertexShader = `
 `
 
 /**
- * Fragment shader - extracts a single channel and converts to grayscale
+ * Fragment shader - extracts a single channel and converts to grayscale.
+ * Optionally inverts the value (used for Glossiness → Roughness conversion).
  */
 const fragmentShader = `
   uniform sampler2D uTexture;
   uniform int uChannel; // 0=R, 1=G, 2=B, 3=A
+  uniform int uInvert; // 0=no, 1=output 1.0 - value
   varying vec2 vUv;
-  
+
   void main() {
     vec4 texColor = texture2D(uTexture, vUv);
     float channelValue;
-    
+
     if (uChannel == 0) channelValue = texColor.r;
     else if (uChannel == 1) channelValue = texColor.g;
     else if (uChannel == 2) channelValue = texColor.b;
     else channelValue = texColor.a;
-    
-    gl_FragColor = vec4(channelValue, channelValue, channelValue, 1.0);
+
+    float v = uInvert == 1 ? 1.0 - channelValue : channelValue;
+    gl_FragColor = vec4(v, v, v, 1.0);
+  }
+`
+
+/**
+ * Fragment shader - inverts RGB channels (255-based). Used when a Glossiness
+ * texture is sourced as full-RGB grayscale and no channel extraction is needed.
+ */
+const invertFragmentShader = `
+  uniform sampler2D uTexture;
+  varying vec2 vUv;
+
+  void main() {
+    vec4 texColor = texture2D(uTexture, vUv);
+    gl_FragColor = vec4(1.0 - texColor.rgb, texColor.a);
   }
 `
 
@@ -58,11 +75,13 @@ function getChannelIndex(channel: TextureChannel): number {
 /**
  * Extract a single channel from a texture using WebGL rendering.
  * Returns a new texture with the extracted channel as grayscale.
+ * If invert=true, the channel value is flipped (used for Glossiness → Roughness).
  */
 function extractChannel(
   sourceTexture: THREE.Texture,
   channel: TextureChannel,
-  renderer: THREE.WebGLRenderer
+  renderer: THREE.WebGLRenderer,
+  invert: boolean = false
 ): THREE.Texture {
   const width = sourceTexture.image?.width || 1024
   const height = sourceTexture.image?.height || 1024
@@ -86,6 +105,7 @@ function extractChannel(
     uniforms: {
       uTexture: { value: sourceTexture },
       uChannel: { value: getChannelIndex(channel) },
+      uInvert: { value: invert ? 1 : 0 },
     },
   })
 
@@ -114,11 +134,59 @@ function extractChannel(
   return extractedTexture
 }
 
+/**
+ * Invert an RGB texture using WebGL rendering. Used for Glossiness textures
+ * sourced as full-RGB grayscale, which need to be flipped to behave as roughness.
+ */
+function invertTexture(
+  sourceTexture: THREE.Texture,
+  renderer: THREE.WebGLRenderer
+): THREE.Texture {
+  const width = sourceTexture.image?.width || 1024
+  const height = sourceTexture.image?.height || 1024
+
+  const renderTarget = new THREE.WebGLRenderTarget(width, height, {
+    format: THREE.RGBAFormat,
+    type: THREE.UnsignedByteType,
+    minFilter: THREE.LinearFilter,
+    magFilter: THREE.LinearFilter,
+  })
+
+  const scene = new THREE.Scene()
+  const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+  const geometry = new THREE.PlaneGeometry(2, 2)
+  const material = new THREE.ShaderMaterial({
+    vertexShader,
+    fragmentShader: invertFragmentShader,
+    uniforms: { uTexture: { value: sourceTexture } },
+  })
+
+  const mesh = new THREE.Mesh(geometry, material)
+  scene.add(mesh)
+  renderer.setRenderTarget(renderTarget)
+  renderer.render(scene, camera)
+  renderer.setRenderTarget(null)
+
+  const inverted = renderTarget.texture.clone()
+  inverted.needsUpdate = true
+  inverted.wrapS = sourceTexture.wrapS
+  inverted.wrapT = sourceTexture.wrapT
+  inverted.flipY = sourceTexture.flipY
+
+  geometry.dispose()
+  material.dispose()
+  renderTarget.dispose()
+
+  return inverted
+}
+
 export interface TextureConfig {
   url: string
   sourceChannel: TextureChannel
   /** Original file name (used to detect formats the browser cannot decode natively, e.g. TIFF). */
   fileName?: string
+  /** Invert texture values (255-v) after load. Used for Glossiness → Roughness. */
+  invert?: boolean
 }
 
 export interface ChannelExtractedTextures {
@@ -147,7 +215,7 @@ export function useChannelExtractedTextures(
       Object.entries(textureConfigs)
         .map(
           ([key, config]) =>
-            `${key}:${config.url}:${config.sourceChannel}:${config.fileName ?? ''}`
+            `${key}:${config.url}:${config.sourceChannel}:${config.fileName ?? ''}:${config.invert ? 1 : 0}`
         )
         .join('|') + `:flipY=${flipY}`
     )
@@ -171,12 +239,18 @@ export function useChannelExtractedTextures(
       loadedTexture.flipY = flipY
 
       if (config.sourceChannel === TextureChannel.RGB) {
-        loadedTextures[slotName] = loadedTexture
+        if (config.invert) {
+          loadedTextures[slotName] = invertTexture(loadedTexture, renderer)
+          loadedTexture.dispose()
+        } else {
+          loadedTextures[slotName] = loadedTexture
+        }
       } else {
         loadedTextures[slotName] = extractChannel(
           loadedTexture,
           config.sourceChannel,
-          renderer
+          renderer,
+          config.invert ?? false
         )
         loadedTexture.dispose()
       }

--- a/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
+++ b/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
@@ -224,6 +224,12 @@ export function useChannelExtractedTextures(
   useEffect(() => {
     if (!renderer) return
 
+    // Guard against the effect re-running before async loads settle. Without
+    // this, the cleanup disposes whatever is already in loadedTextures while
+    // later-resolving promises keep writing into the same map, and the final
+    // Promise.all(...).then(setTextures) installs a state of dead GPU objects.
+    let cancelled = false
+
     const loader = new THREE.TextureLoader()
     const loadedTextures: ChannelExtractedTextures = {}
     const loadPromises: Promise<void>[] = []
@@ -233,6 +239,10 @@ export function useChannelExtractedTextures(
       config: TextureConfig,
       loadedTexture: THREE.Texture
     ) => {
+      if (cancelled) {
+        loadedTexture.dispose()
+        return
+      }
       // Configure texture wrapping and flip
       loadedTexture.wrapS = THREE.RepeatWrapping
       loadedTexture.wrapT = THREE.RepeatWrapping
@@ -299,11 +309,20 @@ export function useChannelExtractedTextures(
     })
 
     Promise.all(loadPromises).then(() => {
+      if (cancelled) {
+        // Cleanup already ran; dispose any textures that landed afterward
+        // so they don't leak. setTextures must not be called.
+        Object.values(loadedTextures).forEach(texture => {
+          if (texture) texture.dispose()
+        })
+        return
+      }
       setTextures(loadedTextures)
     })
 
     // Cleanup on unmount or config change
     return () => {
+      cancelled = true
       Object.values(loadedTextures).forEach(texture => {
         if (texture) texture.dispose()
       })

--- a/src/frontend/src/features/texture-set/components/SurfaceCard.tsx
+++ b/src/frontend/src/features/texture-set/components/SurfaceCard.tsx
@@ -1,0 +1,324 @@
+import './TextureCard.css'
+
+import { Button } from 'primereact/button'
+import { Card } from 'primereact/card'
+import { Dropdown } from 'primereact/dropdown'
+import { Toast } from 'primereact/toast'
+import { memo, useEffect, useRef, useState } from 'react'
+
+import { getFilePreviewUrl } from '@/features/models/api/modelApi'
+import { useTextureSets } from '@/features/texture-set/hooks/useTextureSets'
+import { useDragAndDrop } from '@/shared/hooks/useFileUpload'
+import { useGenericFileUpload } from '@/shared/hooks/useGenericFileUpload'
+import { type TextureDto, TextureType } from '@/types'
+import {
+  getSurfaceModeOptions,
+  getTextureTypeInfo,
+  SURFACE_RELATED_TYPES,
+} from '@/utils/textureTypeUtils'
+
+import { TexturePreview } from './TexturePreview'
+
+interface SurfaceCardProps {
+  /** All textures in the set - we'll find Roughness/Glossiness from here */
+  textures: TextureDto[]
+  setId: number
+  onTextureUpdated: () => void
+}
+
+/**
+ * Special card for Roughness/Glossiness texture types.
+ * They describe the same surface property (microsurface), inverted —
+ * only ONE can be assigned at a time. Glossiness is inverted at load time
+ * and fed into Three's roughnessMap slot.
+ */
+export const SurfaceCard = memo(function SurfaceCard({
+  textures,
+  setId,
+  onTextureUpdated,
+}: SurfaceCardProps) {
+  const existingSurfaceTexture = textures.find(t =>
+    SURFACE_RELATED_TYPES.includes(t.textureType)
+  )
+
+  const [selectedMode, setSelectedMode] = useState<TextureType>(
+    existingSurfaceTexture?.textureType || TextureType.Roughness
+  )
+  const [uploading, setUploading] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const [changingMode, setChangingMode] = useState(false)
+  const toast = useRef<Toast>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const textureSetsApi = useTextureSets()
+  const { uploadFile } = useGenericFileUpload({ fileType: 'texture' })
+
+  useEffect(() => {
+    if (existingSurfaceTexture) {
+      setSelectedMode(existingSurfaceTexture.textureType)
+    }
+  }, [existingSurfaceTexture])
+
+  const typeInfo = getTextureTypeInfo(selectedMode)
+  const modeOptions = getSurfaceModeOptions()
+
+  const handleFileUpload = async (files: File[]) => {
+    if (files.length === 0) return
+
+    const file = files[0]
+
+    const ext = file.name.toLowerCase().split('.').pop()
+    const isImage =
+      file.type.startsWith('image/') ||
+      ['exr', 'tga', 'bmp'].includes(ext || '')
+    if (!isImage) {
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Invalid File',
+        detail: 'Please upload an image file',
+        life: 3000,
+      })
+      return
+    }
+
+    try {
+      setUploading(true)
+
+      const uploadResult = await uploadFile(file)
+      const fileId = uploadResult.fileId
+
+      await textureSetsApi.addTextureToSetEndpoint(setId, {
+        fileId: fileId,
+        textureType: selectedMode,
+      })
+
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Success',
+        detail: `${typeInfo?.label} texture uploaded successfully`,
+        life: 3000,
+      })
+
+      onTextureUpdated()
+    } catch (error) {
+      console.error('Failed to upload texture:', error)
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to upload texture',
+        life: 3000,
+      })
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const { onDrop, onDragOver, onDragEnter, onDragLeave } =
+    useDragAndDrop(handleFileUpload)
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    onDragEnter(e)
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    onDragLeave(e)
+    setIsDragging(false)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    onDrop(e)
+    setIsDragging(false)
+  }
+
+  const handleModeChange = async (newMode: TextureType) => {
+    if (newMode === selectedMode) return
+
+    if (existingSurfaceTexture) {
+      try {
+        setChangingMode(true)
+        await textureSetsApi.changeTextureType(
+          setId,
+          existingSurfaceTexture.id,
+          newMode
+        )
+        toast.current?.show({
+          severity: 'success',
+          summary: 'Mode Changed',
+          detail: `Changed from ${getTextureTypeInfo(existingSurfaceTexture.textureType)?.label} to ${getTextureTypeInfo(newMode)?.label}`,
+          life: 3000,
+        })
+        onTextureUpdated()
+      } catch (error) {
+        console.error('Failed to change mode:', error)
+        toast.current?.show({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'Failed to change surface mode',
+          life: 3000,
+        })
+      } finally {
+        setChangingMode(false)
+      }
+    } else {
+      setSelectedMode(newMode)
+    }
+  }
+
+  const handleRemove = async () => {
+    if (!existingSurfaceTexture) return
+
+    try {
+      await textureSetsApi.removeTextureFromSet(
+        setId,
+        existingSurfaceTexture.id
+      )
+      toast.current?.show({
+        severity: 'success',
+        summary: 'Success',
+        detail: 'Texture removed',
+        life: 3000,
+      })
+      onTextureUpdated()
+    } catch (error) {
+      console.error('Failed to remove texture:', error)
+      toast.current?.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to remove texture',
+        life: 3000,
+      })
+    }
+  }
+
+  const handleClick = () => {
+    if (!existingSurfaceTexture && fileInputRef.current) {
+      fileInputRef.current.click()
+    }
+  }
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files
+    if (files && files.length > 0) {
+      handleFileUpload(Array.from(files))
+    }
+    e.target.value = ''
+  }
+
+  const cardClassName = `texture-card surface-card ${isDragging ? 'dragging' : ''} ${existingSurfaceTexture ? 'has-texture' : 'empty'}`
+
+  const modeOptionTemplate = (option: {
+    label: string
+    color: string
+    icon: string
+  }) => {
+    if (!option) return null
+    return (
+      <div className="height-mode-option">
+        <i className={`pi ${option.icon}`} style={{ color: option.color }} />
+        <span>{option.label}</span>
+      </div>
+    )
+  }
+
+  return (
+    <Card
+      className={cardClassName}
+      style={
+        { '--card-accent': typeInfo?.color || '#f59e0b' } as React.CSSProperties
+      }
+      onClick={handleClick}
+      onDragOver={onDragOver}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <Toast ref={toast} />
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileInputChange}
+        accept="image/*,.exr,.tga,.bmp,.tif,.tiff"
+        style={{ display: 'none' }}
+      />
+
+      <div className="texture-card-header">
+        <div
+          className="height-mode-selector"
+          onClick={e => e.stopPropagation()}
+        >
+          <Dropdown
+            value={selectedMode}
+            options={modeOptions}
+            optionLabel="label"
+            optionValue="value"
+            onChange={e => handleModeChange(e.value)}
+            disabled={changingMode}
+            className="height-mode-dropdown"
+            itemTemplate={modeOptionTemplate}
+            valueTemplate={modeOptionTemplate}
+            data-testid="surface-mode-dropdown"
+          />
+        </div>
+      </div>
+
+      <div className="texture-card-content">
+        {existingSurfaceTexture ? (
+          <div className="texture-card-with-preview">
+            <TexturePreview
+              src={getFilePreviewUrl(existingSurfaceTexture.fileId.toString())}
+              alt={typeInfo?.label || 'Roughness'}
+              fileName={existingSurfaceTexture.fileName}
+              className="texture-preview-image"
+            />
+            <div className="texture-card-overlay">
+              <div className="texture-overlay-top">
+                <Button
+                  icon="pi pi-trash"
+                  className="p-button-rounded p-button-text p-button-danger texture-icon-btn"
+                  onClick={e => {
+                    e.stopPropagation()
+                    handleRemove()
+                  }}
+                  disabled={uploading}
+                  aria-label="Remove texture"
+                />
+              </div>
+              <div className="texture-overlay-center">
+                <Button
+                  icon="pi pi-upload"
+                  className="p-button-rounded p-button-lg texture-upload-btn"
+                  onClick={e => {
+                    e.stopPropagation()
+                    fileInputRef.current?.click()
+                  }}
+                  disabled={uploading}
+                  aria-label="Replace texture"
+                />
+              </div>
+              <div className="texture-overlay-bottom">
+                <span className="texture-overlay-filename">
+                  {existingSurfaceTexture.fileName}
+                </span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="texture-card-empty" onClick={handleClick}>
+            <i
+              className="pi pi-cloud-upload"
+              style={{ fontSize: '3rem', color: '#94a3b8' }}
+            ></i>
+            <p className="drop-text">Drop image here or click to browse</p>
+          </div>
+        )}
+      </div>
+
+      {isDragging && (
+        <div className="texture-drop-overlay">
+          <i className="pi pi-upload" />
+          <span>Drop to upload</span>
+        </div>
+      )}
+    </Card>
+  )
+})

--- a/src/frontend/src/features/texture-set/components/TextureTypesTab.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureTypesTab.tsx
@@ -1,9 +1,10 @@
 import { CardWidthSlider } from '@/shared/components/CardWidthSlider'
 import { useCardWidthStore } from '@/stores/cardWidthStore'
 import { type TextureSetDto, type TextureType } from '@/types'
-import { getNonHeightTypes } from '@/utils/textureTypeUtils'
+import { getRegularTypes } from '@/utils/textureTypeUtils'
 
 import { HeightCard } from './HeightCard'
+import { SurfaceCard } from './SurfaceCard'
 import { TextureCard } from './TextureCard'
 
 interface TextureTypesTabProps {
@@ -21,7 +22,7 @@ export function TextureTypesTab({
   const cardWidthKey =
     side === 'right' ? 'textureSetViewerRight' : 'textureSetViewerLeft'
   const cardWidth = settings[cardWidthKey]
-  const nonHeightTypes = getNonHeightTypes()
+  const regularTypes = getRegularTypes()
 
   return (
     <>
@@ -45,7 +46,7 @@ export function TextureTypesTab({
           gridTemplateColumns: `repeat(auto-fill, minmax(${cardWidth}px, 1fr))`,
         }}
       >
-        {nonHeightTypes.map((textureType: TextureType) => {
+        {regularTypes.map((textureType: TextureType) => {
           const texture =
             textureSet.textures.find(t => t.textureType === textureType) || null
 
@@ -59,6 +60,12 @@ export function TextureTypesTab({
             />
           )
         })}
+
+        <SurfaceCard
+          textures={textureSet.textures}
+          setId={textureSet.id}
+          onTextureUpdated={onTextureUpdated}
+        />
 
         <HeightCard
           textures={textureSet.textures}

--- a/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
@@ -53,6 +53,9 @@ interface TextureUrlInfo {
    *  Only set when textureQuality=0 (original) and texture uses a split channel.
    *  When using proxies, channel extraction is done server-side. */
   sourceChannel?: number
+  /** Invert pixel values (255 - v) after decode. Used for Glossiness, which is
+   *  stored as glossiness but rendered through Three's roughnessMap slot. */
+  invert?: boolean
 }
 
 /** Build ALL texture URLs from the texture set (never filters by disabled state).
@@ -112,6 +115,12 @@ function buildTextureUrls(
   )
   if (roughness) urls.roughnessMap = makeInfo(roughness)
 
+  // Glossiness is the inverse of Roughness — same slot, channel inverted at load
+  const glossiness = textureSet.textures.find(
+    t => t.textureType === TextureType.Glossiness
+  )
+  if (glossiness) urls.roughnessMap = { ...makeInfo(glossiness), invert: true }
+
   const metallic = textureSet.textures.find(
     t => t.textureType === TextureType.Metallic
   )
@@ -158,7 +167,7 @@ function buildTextureUrls(
 const MATERIAL_PROP_TO_TYPE_KEY: Record<string, string[]> = {
   map: ['Albedo'],
   normalMap: ['Normal'],
-  roughnessMap: ['Roughness'],
+  roughnessMap: ['Roughness', 'Glossiness'],
   metalnessMap: ['Metallic'],
   specularColorMap: ['Specular'],
   aoMap: ['AO'],
@@ -173,12 +182,15 @@ const COLOR_TEXTURE_PROPS = new Set(['map', 'emissiveMap', 'specularColorMap'])
 
 /**
  * Extract a single channel from an ImageBitmap, producing a grayscale canvas texture.
+ * Optionally inverts the channel value (used for Glossiness → Roughness conversion).
  * @param bitmap Source ImageBitmap (will be closed after extraction)
  * @param channel 1=R, 2=G, 3=B, 4=A
+ * @param invert If true, output 255 - channelValue instead of channelValue
  */
 function extractChannelFromBitmap(
   bitmap: ImageBitmap,
-  channel: number
+  channel: number,
+  invert: boolean = false
 ): HTMLCanvasElement {
   const canvas = document.createElement('canvas')
   canvas.width = bitmap.width
@@ -190,11 +202,38 @@ function extractChannelFromBitmap(
   const offset = channel - 1 // 1→0, 2→1, 3→2, 4→3
 
   for (let i = 0; i < data.length; i += 4) {
-    const v = data[i + offset]
+    const raw = data[i + offset]
+    const v = invert ? 255 - raw : raw
     data[i] = v // R
     data[i + 1] = v // G
     data[i + 2] = v // B
     data[i + 3] = 255
+  }
+
+  ctx.putImageData(imageData, 0, 0)
+  bitmap.close()
+  return canvas
+}
+
+/**
+ * Invert RGB pixel values (255 - v) of an ImageBitmap. Alpha is preserved.
+ * Used for Glossiness textures sourced as full-RGB grayscale, where we need
+ * to flip the channel before feeding it into Three's roughnessMap slot.
+ * @param bitmap Source ImageBitmap (will be closed after inversion)
+ */
+function invertBitmap(bitmap: ImageBitmap): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = bitmap.width
+  canvas.height = bitmap.height
+  const ctx = canvas.getContext('2d')!
+  ctx.drawImage(bitmap, 0, 0)
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const data = imageData.data
+
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255 - data[i]
+    data[i + 1] = 255 - data[i + 1]
+    data[i + 2] = 255 - data[i + 2]
   }
 
   ctx.putImageData(imageData, 0, 0)
@@ -213,7 +252,8 @@ async function loadTextureOffThread(
   isTiff: boolean,
   signal: AbortSignal,
   sourceChannel?: number,
-  cachedBlob?: Blob
+  cachedBlob?: Blob,
+  invert: boolean = false
 ): Promise<THREE.Texture> {
   if (isExr) {
     // EXR must use the specialised loader — no ImageBitmap path
@@ -238,9 +278,17 @@ async function loadTextureOffThread(
     ? await decodeTiffBlobToBitmap(blob, { flipY: true })
     : await createImageBitmap(blob, { imageOrientation: 'flipY' })
 
-  // If a specific channel needs extraction, do it via canvas
+  // If a specific channel needs extraction, do it via canvas (inversion fused in)
   if (sourceChannel && sourceChannel >= 1 && sourceChannel <= 4) {
-    const canvas = extractChannelFromBitmap(bitmap, sourceChannel)
+    const canvas = extractChannelFromBitmap(bitmap, sourceChannel, invert)
+    const texture = new THREE.CanvasTexture(canvas)
+    texture.needsUpdate = true
+    return texture
+  }
+
+  // Full-RGB path with inversion (e.g. Glossiness as a normal grayscale image)
+  if (invert) {
+    const canvas = invertBitmap(bitmap)
     const texture = new THREE.CanvasTexture(canvas)
     texture.needsUpdate = true
     return texture
@@ -386,7 +434,8 @@ function TexturedMesh({
               info.isTiffFormat,
               abortController.signal,
               info.sourceChannel,
-              blobCache.get(info.url)
+              blobCache.get(info.url),
+              info.invert
             )
             if (!abortController.signal.aborted) {
               // Set color space based on texture property

--- a/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturedGeometry.tsx
@@ -216,6 +216,39 @@ function extractChannelFromBitmap(
 }
 
 /**
+ * Invert the RGB channels of an EXR-loaded texture in place. EXR stores
+ * linear-light values, so the Glossiness → Roughness inversion is `1 - v`.
+ * Three's EXRLoader returns either Float32 or HalfFloat (Uint16) pixel data;
+ * both layouts are handled. Alpha is preserved.
+ */
+function invertExrTextureInPlace(texture: THREE.Texture): void {
+  const img = texture.image as
+    | { data?: Float32Array | Uint16Array; width: number; height: number }
+    | undefined
+  const data = img?.data
+  if (!data) return
+
+  if (data instanceof Float32Array) {
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 1 - data[i]
+      data[i + 1] = 1 - data[i + 1]
+      data[i + 2] = 1 - data[i + 2]
+    }
+  } else if (data instanceof Uint16Array) {
+    // HalfFloat path — decode, invert, re-encode each value.
+    for (let i = 0; i < data.length; i += 4) {
+      for (let c = 0; c < 3; c++) {
+        const v = THREE.DataUtils.fromHalfFloat(data[i + c])
+        data[i + c] = THREE.DataUtils.toHalfFloat(1 - v)
+      }
+    }
+  } else {
+    return
+  }
+  texture.needsUpdate = true
+}
+
+/**
  * Invert RGB pixel values (255 - v) of an ImageBitmap. Alpha is preserved.
  * Used for Glossiness textures sourced as full-RGB grayscale, where we need
  * to flip the channel before feeding it into Three's roughnessMap slot.
@@ -258,7 +291,9 @@ async function loadTextureOffThread(
   if (isExr) {
     // EXR must use the specialised loader — no ImageBitmap path
     const exrLoader = new EXRLoader()
-    return exrLoader.loadAsync(url)
+    const texture = await exrLoader.loadAsync(url)
+    if (invert) invertExrTextureInPlace(texture)
+    return texture
   }
 
   // Fetch blob (or use cached one for dedup), then decode off-thread

--- a/src/frontend/src/features/texture-set/dialogs/MergeTextureSetDialog.tsx
+++ b/src/frontend/src/features/texture-set/dialogs/MergeTextureSetDialog.tsx
@@ -12,6 +12,7 @@ import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
 import {
   getTextureTypeLabel,
   isHeightRelatedType,
+  isSurfaceRelatedType,
 } from '../../../utils/textureTypeUtils'
 
 // RGB dropdown options
@@ -173,6 +174,30 @@ export function MergeTextureSetDialog({
     return null
   }, [targetTextureSet, getAllSelectedTypes])
 
+  // Check Surface exclusivity (Roughness vs Glossiness)
+  const surfaceConflict = useMemo(() => {
+    const selectedTypes = getAllSelectedTypes()
+    const targetSurfaceType = targetTextureSet?.textures?.find(t =>
+      isSurfaceRelatedType(t.textureType)
+    )?.textureType
+
+    const selectedSurfaceTypes = selectedTypes.filter(t =>
+      isSurfaceRelatedType(t)
+    )
+    if (selectedSurfaceTypes.length > 1) {
+      return 'Cannot select multiple Roughness/Glossiness types'
+    }
+
+    if (targetSurfaceType && selectedSurfaceTypes.length > 0) {
+      const selectedSurface = selectedSurfaceTypes[0]
+      if (selectedSurface !== targetSurfaceType) {
+        return `Target already has ${getTextureTypeLabel(targetSurfaceType)}. Cannot add ${getTextureTypeLabel(selectedSurface)}.`
+      }
+    }
+
+    return null
+  }, [targetTextureSet, getAllSelectedTypes])
+
   const updateFileMapping = (
     fileId: number,
     updates: Partial<FileChannelMapping>
@@ -183,11 +208,12 @@ export function MergeTextureSetDialog({
   }
 
   const handleMerge = async () => {
-    if (heightConflict) {
+    const conflict = heightConflict || surfaceConflict
+    if (conflict) {
       toast.current?.show({
         severity: 'error',
         summary: 'Validation Error',
-        detail: heightConflict,
+        detail: conflict,
         life: 3000,
       })
       return
@@ -271,7 +297,7 @@ export function MergeTextureSetDialog({
         label="Merge Textures"
         icon="pi pi-check"
         onClick={handleMerge}
-        disabled={merging || !!heightConflict}
+        disabled={merging || !!heightConflict || !!surfaceConflict}
         loading={merging}
       />
     </div>
@@ -397,6 +423,14 @@ export function MergeTextureSetDialog({
                 <Message
                   severity="error"
                   text={heightConflict}
+                  className="height-conflict-error"
+                />
+              )}
+
+              {surfaceConflict && (
+                <Message
+                  severity="error"
+                  text={surfaceConflict}
                   className="height-conflict-error"
                 />
               )}

--- a/src/frontend/src/features/texture-set/types/index.ts
+++ b/src/frontend/src/features/texture-set/types/index.ts
@@ -13,6 +13,7 @@ export enum TextureType {
   Bump = 10,
   Alpha = 11,
   Displacement = 12,
+  Glossiness = 13,
 }
 
 export enum TextureChannel {

--- a/src/frontend/src/shared/three/safeLoadingManager.ts
+++ b/src/frontend/src/shared/three/safeLoadingManager.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three'
+
+// 1x1 transparent PNG. Returned in place of unresolvable texture URLs so
+// Three's loaders can finish parsing without firing real network requests.
+const TRANSPARENT_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='
+
+// Our backend serves files by numeric ID at /api/files/<id>. Anything that
+// doesn't match this shape and looks like a texture filename is something
+// the model file itself referenced (e.g. FBX-internal "chest_Specular.tga")
+// and will 400 against the strictly-typed route, taking the WebGL context
+// down with it. Replace those with a transparent pixel.
+const TEXTURE_EXT_RE =
+  /\.(?:tga|png|jpe?g|tif?f|exr|webp|bmp|hdr|dds|gif)(?:\?.*)?$/i
+const OUR_FILE_ENDPOINT_RE = /\/api\/files\/\d+(?:\?.*)?$/
+
+function rewriteTextureUrl(url: string): string {
+  if (OUR_FILE_ENDPOINT_RE.test(url)) return url
+  if (TEXTURE_EXT_RE.test(url)) return TRANSPARENT_PIXEL
+  return url
+}
+
+/**
+ * Shared LoadingManager that short-circuits embedded texture references
+ * (filename-only paths a model format like FBX or OBJ/MTL stores internally)
+ * to a 1x1 transparent PNG. Attach to a Three.js loader via
+ * `loader.manager = safeLoadingManager` so its in-format texture parsing
+ * does not hit /api/files/<filename> and crash the server route.
+ *
+ * Modelibr texture sets are loaded out-of-band by useChannelExtractedTextures
+ * and TexturedGeometry — they don't go through this manager.
+ */
+export const safeLoadingManager = new THREE.LoadingManager()
+safeLoadingManager.setURLModifier(rewriteTextureUrl)
+
+/** Test-only export. */
+export const __test = { rewriteTextureUrl }

--- a/src/frontend/src/shared/three/safeLoadingManager.ts
+++ b/src/frontend/src/shared/three/safeLoadingManager.ts
@@ -14,7 +14,8 @@ const TRANSPARENT_PIXEL =
 // that will 400 against the strictly-typed file route and crash the WebGL
 // context. Inverted allowlist: pass through only the shapes we know are
 // safe; rewrite the rest to a transparent pixel.
-const OUR_FILE_ENDPOINT_RE = /^https?:\/\/[^/]+\/api\/files\/\d+(?:\?.*)?$|^\/api\/files\/\d+(?:\?.*)?$/
+const OUR_FILE_ENDPOINT_RE =
+  /^https?:\/\/[^/]+\/api\/files\/\d+(?:\?.*)?$|^\/api\/files\/\d+(?:\?.*)?$/
 
 function rewriteTextureUrl(url: string): string {
   if (OUR_FILE_ENDPOINT_RE.test(url)) return url

--- a/src/frontend/src/shared/three/safeLoadingManager.ts
+++ b/src/frontend/src/shared/three/safeLoadingManager.ts
@@ -5,17 +5,18 @@ import * as THREE from 'three'
 const TRANSPARENT_PIXEL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='
 
-// Our backend serves files by numeric ID at /api/files/<id>. This manager
-// is only attached to the top-level model loaders (FBX/OBJ/GLTF), so the
-// only legitimate URLs that flow through it are the model file itself and
-// any URLs the loader synthesises after we hand it a data: substitute.
-// Everything else is a model-internal texture reference (e.g. FBX-baked
-// "chest_Specular.tga" or "C:\Assets\chest_Specular" with no extension)
-// that will 400 against the strictly-typed file route and crash the WebGL
-// context. Inverted allowlist: pass through only the shapes we know are
-// safe; rewrite the rest to a transparent pixel.
-const OUR_FILE_ENDPOINT_RE =
-  /^https?:\/\/[^/]+\/api\/files\/\d+(?:\?.*)?$|^\/api\/files\/\d+(?:\?.*)?$/
+// Our backend serves files by numeric ID under /files/<id>. The URL prefix
+// varies by deployment: dev/e2e talks to the WebAPI directly (host:8080/
+// files/...), production hits nginx that rewrites /api/files/... → backend.
+// Match the path shape, not the prefix. This manager is only attached to
+// the top-level model loaders (FBX/OBJ/GLTF), so legitimate URLs flowing
+// through it are the model file itself plus data:/blob: refs the loader
+// synthesises after we hand it a substitute. Everything else is a model-
+// internal texture reference (e.g. FBX-baked "chest_Specular.tga" or
+// "C:\Assets\chest_Specular" with no extension) that will 400 against the
+// strictly-typed file route and crash the WebGL context. Inverted allow-
+// list: pass through what we know is safe; rewrite the rest.
+const OUR_FILE_ENDPOINT_RE = /\/files\/\d+(?:\?[^/]*)?$/
 
 function rewriteTextureUrl(url: string): string {
   if (OUR_FILE_ENDPOINT_RE.test(url)) return url

--- a/src/frontend/src/shared/three/safeLoadingManager.ts
+++ b/src/frontend/src/shared/three/safeLoadingManager.ts
@@ -5,19 +5,21 @@ import * as THREE from 'three'
 const TRANSPARENT_PIXEL =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='
 
-// Our backend serves files by numeric ID at /api/files/<id>. Anything that
-// doesn't match this shape and looks like a texture filename is something
-// the model file itself referenced (e.g. FBX-internal "chest_Specular.tga")
-// and will 400 against the strictly-typed route, taking the WebGL context
-// down with it. Replace those with a transparent pixel.
-const TEXTURE_EXT_RE =
-  /\.(?:tga|png|jpe?g|tif?f|exr|webp|bmp|hdr|dds|gif)(?:\?.*)?$/i
-const OUR_FILE_ENDPOINT_RE = /\/api\/files\/\d+(?:\?.*)?$/
+// Our backend serves files by numeric ID at /api/files/<id>. This manager
+// is only attached to the top-level model loaders (FBX/OBJ/GLTF), so the
+// only legitimate URLs that flow through it are the model file itself and
+// any URLs the loader synthesises after we hand it a data: substitute.
+// Everything else is a model-internal texture reference (e.g. FBX-baked
+// "chest_Specular.tga" or "C:\Assets\chest_Specular" with no extension)
+// that will 400 against the strictly-typed file route and crash the WebGL
+// context. Inverted allowlist: pass through only the shapes we know are
+// safe; rewrite the rest to a transparent pixel.
+const OUR_FILE_ENDPOINT_RE = /^https?:\/\/[^/]+\/api\/files\/\d+(?:\?.*)?$|^\/api\/files\/\d+(?:\?.*)?$/
 
 function rewriteTextureUrl(url: string): string {
   if (OUR_FILE_ENDPOINT_RE.test(url)) return url
-  if (TEXTURE_EXT_RE.test(url)) return TRANSPARENT_PIXEL
-  return url
+  if (url.startsWith('data:') || url.startsWith('blob:')) return url
+  return TRANSPARENT_PIXEL
 }
 
 /**

--- a/src/frontend/src/utils/index.ts
+++ b/src/frontend/src/utils/index.ts
@@ -26,7 +26,8 @@ export type { TextureTypeInfo } from './textureTypeUtils'
 export {
   getAllTextureTypes,
   getHeightModeOptions,
-  getNonHeightTypes,
+  getRegularTypes,
+  getSurfaceModeOptions,
   getTextureTypeColor,
   getTextureTypeIcon,
   getTextureTypeInfo,
@@ -34,6 +35,8 @@ export {
   getTextureTypeOptions,
   HEIGHT_RELATED_TYPES,
   isHeightRelatedType,
+  isSurfaceRelatedType,
+  SURFACE_RELATED_TYPES,
   TEXTURE_TYPE_INFO,
 } from './textureTypeUtils'
 export type { OperatingSystem, WebDavPathInfo } from './webdavUtils'

--- a/src/frontend/src/utils/textureTypeUtils.ts
+++ b/src/frontend/src/utils/textureTypeUtils.ts
@@ -44,9 +44,17 @@ export const TEXTURE_TYPE_INFO: Partial<Record<TextureType, TextureTypeInfo>> =
     },
     [TextureType.Roughness]: {
       label: 'Roughness',
-      description: 'Roughness map - surface micro-detail affecting reflections',
+      description:
+        'Roughness map - surface micro-detail affecting reflections (exclusive with Glossiness)',
       color: '#f59e0b', // Orange/yellow
       icon: 'pi-circle',
+    },
+    [TextureType.Glossiness]: {
+      label: 'Glossiness',
+      description:
+        'Glossiness map - inverted roughness, applied as roughnessMap with channel inverted (exclusive with Roughness)',
+      color: '#fbbf24', // Lighter yellow/amber
+      icon: 'pi-circle-fill',
     },
     [TextureType.Metallic]: {
       label: 'Metallic',
@@ -96,6 +104,12 @@ export const HEIGHT_RELATED_TYPES = [
   TextureType.Displacement,
 ]
 
+// Surface-related types are mutually exclusive (Glossiness is inverted Roughness)
+export const SURFACE_RELATED_TYPES = [
+  TextureType.Roughness,
+  TextureType.Glossiness,
+]
+
 export function getTextureTypeInfo(textureType: TextureType): TextureTypeInfo {
   return (
     TEXTURE_TYPE_INFO[textureType] || {
@@ -142,10 +156,22 @@ export function isHeightRelatedType(textureType: TextureType): boolean {
 }
 
 /**
- * Get all texture types except Height/Displacement/Bump (for regular cards)
+ * Check if a texture type is one of the mutually exclusive surface-related types
+ * (Roughness or Glossiness)
  */
-export function getNonHeightTypes(): TextureType[] {
-  return getAllTextureTypes().filter(type => !isHeightRelatedType(type))
+export function isSurfaceRelatedType(textureType: TextureType): boolean {
+  return SURFACE_RELATED_TYPES.includes(textureType)
+}
+
+/**
+ * Get all texture types that are rendered as standalone cards (i.e. not grouped
+ * behind a mode dropdown — Height/Bump/Displacement and Roughness/Glossiness
+ * are excluded because they live in HeightCard and SurfaceCard respectively).
+ */
+export function getRegularTypes(): TextureType[] {
+  return getAllTextureTypes().filter(
+    type => !isHeightRelatedType(type) && !isSurfaceRelatedType(type)
+  )
 }
 
 /**
@@ -153,6 +179,18 @@ export function getNonHeightTypes(): TextureType[] {
  */
 export function getHeightModeOptions() {
   return HEIGHT_RELATED_TYPES.map(type => ({
+    label: getTextureTypeLabel(type),
+    value: type,
+    color: getTextureTypeColor(type),
+    icon: getTextureTypeIcon(type),
+  }))
+}
+
+/**
+ * Get Surface mode dropdown options (Roughness / Glossiness)
+ */
+export function getSurfaceModeOptions() {
+  return SURFACE_RELATED_TYPES.map(type => ({
     label: getTextureTypeLabel(type),
     value: type,
     color: getTextureTypeColor(type),

--- a/tests/Domain.Tests/ValueObjects/TextureTypeTests.cs
+++ b/tests/Domain.Tests/ValueObjects/TextureTypeTests.cs
@@ -18,6 +18,7 @@ public class TextureTypeTests
     [InlineData(TextureType.Bump)]
     [InlineData(TextureType.Alpha)]
     [InlineData(TextureType.Displacement)]
+    [InlineData(TextureType.Glossiness)]
     public void ValidateForStorage_WithSupportedTypes_ReturnsSuccess(TextureType textureType)
     {
         // Act
@@ -49,8 +50,8 @@ public class TextureTypeTests
         // Act
         var supportedTypes = TextureTypeExtensions.GetSupportedTypes();
 
-        // Assert - Diffuse removed, SplitChannel + Specular present, now 12 types
-        Assert.Equal(12, supportedTypes.Count);
+        // Assert - Diffuse removed, SplitChannel + Specular present, Glossiness added, now 13 types
+        Assert.Equal(13, supportedTypes.Count);
         Assert.Contains(TextureType.SplitChannel, supportedTypes);
         Assert.Contains(TextureType.Albedo, supportedTypes);
         Assert.Contains(TextureType.Normal, supportedTypes);
@@ -63,6 +64,7 @@ public class TextureTypeTests
         Assert.Contains(TextureType.Bump, supportedTypes);
         Assert.Contains(TextureType.Alpha, supportedTypes);
         Assert.Contains(TextureType.Displacement, supportedTypes);
+        Assert.Contains(TextureType.Glossiness, supportedTypes);
     }
 
     [Theory]
@@ -77,6 +79,7 @@ public class TextureTypeTests
     [InlineData(TextureType.Bump, "Bump map for surface detail")]
     [InlineData(TextureType.Alpha, "Alpha map for transparency")]
     [InlineData(TextureType.Displacement, "Displacement map for vertex displacement")]
+    [InlineData(TextureType.Glossiness, "Glossiness map (inverted roughness)")]
     public void GetDescription_ReturnsCorrectDescription(TextureType textureType, string expectedDescription)
     {
         // Act


### PR DESCRIPTION
## Summary

Two pieces of work that landed together:

**1. Glossiness texture support** (primary)
- Mirrors the existing Roughness/Height/Bump/Displacement patterns.
- Glossiness is inverted Roughness; storage is its own type but at render time it's piped into Three's `roughnessMap` slot with the channel inverted.
- Roughness ↔ Glossiness are mutually exclusive in a TextureSet (same as Height/Bump/Displacement).

**2. FBX preview & thumbnail reliability fixes** (encountered while validating the Glossiness flow on a real model)
- `safeLoadingManager` short-circuits embedded texture filename refs (e.g. `chest_Specular.tga` baked into the FBX). Without this, Three's loader fires `/api/files/<filename>` for every internal ref, the int-only file route returns 400, and the cascade crashes the WebGL context.
- `setScalar` → `multiplyScalar` on model root: FBXLoader bakes a non-1 unit-conversion scale into the root, and `setScalar` dropped it, collapsing models to ~1/100 of intended size.
- `position.x = ...` → `position.x -= ...` on the centering math: FBX also bakes a non-zero translation into the root, and assignment was overwriting it, leaving the model offset from the camera target.
- Same scale/position fixes applied to the asset-processor thumbnail renderer (`render-template.html`), which had the identical pattern.

## Changes

### Backend
- [TextureType.cs](src/Domain/ValueObjects/TextureType.cs) — `Glossiness = 13`, `MutuallyExclusiveSurfaceTypes`, `IsSurfaceRelatedType()`.
- [TextureSet.cs](src/Domain/Models/TextureSet.cs) — surface-mutex check in `AddTexture` (mirrors the height-mutex block).

### Frontend — types & utils
- [types/index.ts](src/frontend/src/features/texture-set/types/index.ts) — `TextureType.Glossiness`.
- [textureTypeUtils.ts](src/frontend/src/utils/textureTypeUtils.ts) — `SURFACE_RELATED_TYPES`, `isSurfaceRelatedType`, `getSurfaceModeOptions`, `getRegularTypes` (renamed from `getNonHeightTypes` since it now excludes both groups).
- [utils/index.ts](src/frontend/src/utils/index.ts) — barrel updated.

### Frontend — preview rendering
- [TexturedGeometry.tsx](src/frontend/src/features/texture-set/components/TexturedGeometry.tsx) — Glossiness routes to `roughnessMap` with `invert: true`. `loadTextureOffThread` accepts an `invert` flag; channel-extract path fuses inversion in, RGB path uses a new `invertBitmap` helper.
- [useChannelExtractedTextures.ts](src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts) — existing channel-extract shader takes a `uInvert` uniform; new `invertTexture` shader covers the RGB-passthrough case.
- [TexturedModel.tsx](src/frontend/src/features/model-viewer/components/TexturedModel.tsx) — Glossiness as `roughnessMap` fallback with `invertFallback: true`.

### Frontend — UI
- [SurfaceCard.tsx](src/frontend/src/features/texture-set/components/SurfaceCard.tsx) — new card, mirrors `HeightCard` with Roughness/Glossiness dropdown.
- [TextureTypesTab.tsx](src/frontend/src/features/texture-set/components/TextureTypesTab.tsx) — renders `SurfaceCard` alongside `HeightCard`.
- [MergeTextureSetDialog.tsx](src/frontend/src/features/texture-set/dialogs/MergeTextureSetDialog.tsx) — parallel `surfaceConflict` check, with message + button-disable wiring.

### FBX fixes
- [safeLoadingManager.ts](src/frontend/src/shared/three/safeLoadingManager.ts) — new helper, single shared `LoadingManager` whose URL modifier replaces filename-only texture refs with a transparent data URL.
- [TexturedModel.tsx](src/frontend/src/features/model-viewer/components/TexturedModel.tsx), [Model.tsx](src/frontend/src/features/model-viewer/components/Model.tsx) — each `useLoader(LoaderProto, modelUrl)` gets `loader.manager = safeLoadingManager` via the extensions callback.
- [Model.tsx](src/frontend/src/features/model-viewer/components/Model.tsx) and [TexturedModel.tsx](src/frontend/src/features/model-viewer/components/TexturedModel.tsx) `setupModel` — `multiplyScalar` + subtractive position.
- [render-template.html](src/asset-processor/render-template.html) `normalizeModel` — same `multiplyScalar` + subtractive position. **Asset-processor container needs rebuild for the thumbnail fix to take effect.**

## Test plan

- [x] Upload a Glossiness texture into a TextureSet; verify preview shows correct micro-surface (mid-grey gloss → mid-grey roughness equivalent).
- [x] Toggle the SurfaceCard dropdown Roughness ↔ Glossiness on an existing texture; type change persists and re-renders.
- [ ] Attempt to add a second Roughness/Glossiness to a set → backend returns the mutex error.
- [ ] Merge dialog: try to merge a set with Glossiness into one that already has Roughness → conflict message appears, Merge button disabled.
- [x] StylizedChest FBX preview: renders centered, correct size, no WebGL context loss, no 400-flood in webapi logs.
- [x] Regenerate thumbnail for the same FBX (after asset-processor rebuild) → chest is visible, centered.