### PR TITLE
Backup & restore with restore-on-boot flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,9 @@ Generated_Code/
 # because we have git ;-)
 _UpgradeReport_Files/
 Backup*/
+# `Backup*/` (Visual Studio default) would otherwise swallow the entire
+# backup-restore-e2e test suite directory.
+!tests/backup-restore-e2e/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,14 @@ services:
             - ASPNETCORE_ENVIRONMENT=${ASPNETCORE_ENVIRONMENT}
             - WORKER_API_KEY=${WORKER_API_KEY:-}
             - UPLOAD_STORAGE_PATH=/var/lib/modelibr/uploads
+            - BACKUP_STORAGE_PATH=/var/lib/modelibr/backups
+            - RESTORE_STORAGE_PATH=/var/lib/modelibr/restore
+            - THUMBNAIL_STORAGE_PATH=/var/lib/modelibr/thumbnails
+            - POSTGRES_HOST=postgres
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=Modelibr
+            - POSTGRES_USER=${POSTGRES_USER}
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - ConnectionStrings__Default=Host=postgres;Port=5432;Database=Modelibr;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
             - DisableHttpsRedirection=true
             - HTTPS_PORT=${HTTPS_PORT:-8443}
@@ -48,6 +56,9 @@ services:
             - ${HOME}/.microsoft/usersecrets:/home/app/.microsoft/usersecrets:ro
             - ${HOME}/.aspnet/https:/home/app/.aspnet/https:ro
             - ./data/uploads:/var/lib/modelibr/uploads
+            - ./data/backups:/var/lib/modelibr/backups
+            - ./data/restore:/var/lib/modelibr/restore
+            - ./data/thumbnails:/var/lib/modelibr/thumbnails
             - blender-data:/var/lib/modelibr/blender
         depends_on:
             postgres:

--- a/src/Application/Abstractions/Services/IBackupService.cs
+++ b/src/Application/Abstractions/Services/IBackupService.cs
@@ -1,0 +1,52 @@
+namespace Application.Abstractions.Services;
+
+public record BackupScope(bool IncludeThumbnails);
+
+public record BackupSummary(
+    string FileName,
+    long SizeBytes,
+    DateTime CreatedAtUtc,
+    string Status,
+    string HostPath,
+    string ContainerPath,
+    bool IncludesThumbnails,
+    string? Error);
+
+public record BackupStorageInfo(
+    string HostPath,
+    string ContainerPath,
+    long TotalUsedBytes);
+
+public record BackupSizeEstimate(
+    long DatabaseBytes,
+    long UploadsBytes,
+    long ThumbnailsBytes);
+
+public interface IBackupService
+{
+    /// <summary>
+    /// Starts a backup job in the background. Returns immediately with the placeholder summary.
+    /// Only one backup may run at a time; subsequent calls while running return a Conflict-style result.
+    /// </summary>
+    Task<BackupSummary> StartBackupAsync(BackupScope scope, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists archives in the backups directory plus any in-progress job.
+    /// </summary>
+    IReadOnlyList<BackupSummary> ListBackups();
+
+    BackupStorageInfo GetStorageInfo();
+
+    Task<BackupSizeEstimate> EstimateSizeAsync(CancellationToken cancellationToken);
+
+    /// <summary>Absolute path to a finished backup archive, or null if missing.</summary>
+    string? ResolveBackupPath(string fileName);
+
+    void DeleteBackup(string fileName);
+
+    /// <summary>
+    /// Stages a finished backup archive for restore-on-boot by hard-linking (or copying)
+    /// it into the restore directory. Throws if the file is missing.
+    /// </summary>
+    void StageRestore(string fileName);
+}

--- a/src/Application/Abstractions/Services/IBackupService.cs
+++ b/src/Application/Abstractions/Services/IBackupService.cs
@@ -26,7 +26,7 @@ public interface IBackupService
 {
     /// <summary>
     /// Starts a backup job in the background. Returns immediately with the placeholder summary.
-    /// Only one backup may run at a time; subsequent calls while running return a Conflict-style result.
+    /// Only one backup may run at a time; subsequent calls while running throw InvalidOperationException.
     /// </summary>
     Task<BackupSummary> StartBackupAsync(BackupScope scope, CancellationToken cancellationToken);
 
@@ -45,8 +45,46 @@ public interface IBackupService
     void DeleteBackup(string fileName);
 
     /// <summary>
-    /// Stages a finished backup archive for restore-on-boot by hard-linking (or copying)
-    /// it into the restore directory. Throws if the file is missing.
+    /// Stages a finished backup archive for restore-on-boot by copying it into the
+    /// restore directory. Throws if the file is missing.
     /// </summary>
     void StageRestore(string fileName);
+}
+
+/// <summary>
+/// Canonical backup manifest written into every archive as <c>manifest.json</c>.
+///
+/// IMPORTANT: this type is the single source of truth for the on-disk format.
+/// Both <c>BackupService</c> (writer) and <c>RestoreOnBootProcessor</c> (reader)
+/// consume this type — do not duplicate it.
+///
+/// When making any breaking change to the layout, bump
+/// <see cref="BackupManifestConstants.CurrentManifestVersion"/>. The restore
+/// processor refuses any archive whose <c>ManifestVersion</c> does not match
+/// the value baked into the running app.
+/// </summary>
+public sealed record BackupManifest(
+    int ManifestVersion,
+    DateTime CreatedAtUtc,
+    int PostgresMajorVersion,
+    BackupManifestScope Scope,
+    BackupManifestStats Stats);
+
+public sealed record BackupManifestScope(bool Database, bool Uploads, bool Thumbnails);
+
+public sealed record BackupManifestStats(
+    int UploadsCount,
+    long UploadsBytes,
+    int ThumbnailsCount,
+    long ThumbnailsBytes,
+    long DatabaseDumpBytes,
+    // SHA-256 of the database.dump entry's bytes as written into the archive.
+    // Restore-on-boot verifies this against the extracted bytes before invoking
+    // pg_restore, so a truncated or corrupted dump cannot silently produce a
+    // partially-restored database.
+    string DatabaseDumpSha256);
+
+public static class BackupManifestConstants
+{
+    public const int CurrentManifestVersion = 1;
 }

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -60,6 +60,9 @@ namespace Infrastructure
             // Add audio selection service for trimmed audio snippets
             services.AddSingleton<IAudioSelectionService, AudioSelectionService>();
 
+            // Backup / restore service
+            services.AddSingleton<IBackupService, BackupService>();
+
             // Add Blender installation management service
             services.AddSingleton<IBlenderInstallationService, BlenderInstallationService>();
             services.AddSingleton<IBlendFileGenerator, BlendFileGenerator>();

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Formats.Tar;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Application.Abstractions.Services;
 using Microsoft.Extensions.Configuration;
@@ -9,17 +10,16 @@ namespace Infrastructure.Services;
 
 public sealed class BackupService : IBackupService
 {
-    private const string ManifestEntryName = "manifest.json";
-    private const string DatabaseDumpEntryName = "database.dump";
-    private const string UploadsPrefix = "uploads/";
-    private const string ThumbnailsPrefix = "thumbnails/";
-
-    public const int CurrentManifestVersion = 1;
+    public const string ManifestEntryName = "manifest.json";
+    public const string DatabaseDumpEntryName = "database.dump";
+    public const string UploadsPrefix = "uploads/";
+    public const string ThumbnailsPrefix = "thumbnails/";
 
     private readonly ILogger<BackupService> _logger;
     private readonly BackupPaths _paths;
     private readonly PostgresConnectionInfo _postgres;
     private readonly SemaphoreSlim _runLock = new(1, 1);
+    private readonly SemaphoreSlim _stageLock = new(1, 1);
 
     private readonly object _stateLock = new();
     private BackupSummary? _inProgress;
@@ -61,7 +61,7 @@ public sealed class BackupService : IBackupService
             SizeBytes: 0,
             CreatedAtUtc: createdAt,
             Status: "in_progress",
-            HostPath: PathRelativeToHost(finalPath, _paths.BackupRoot),
+            HostPath: _paths.HostRelativeBackupPath(fileName),
             ContainerPath: finalPath,
             IncludesThumbnails: scope.IncludeThumbnails,
             Error: null);
@@ -76,10 +76,7 @@ public sealed class BackupService : IBackupService
             try
             {
                 await RunBackupAsync(scope, tmpPath, finalPath, createdAt);
-                lock (_stateLock)
-                {
-                    _inProgress = null;
-                }
+                lock (_stateLock) { _inProgress = null; }
                 _logger.LogInformation("Backup completed: {FileName}", fileName);
             }
             catch (Exception ex)
@@ -124,7 +121,7 @@ public sealed class BackupService : IBackupService
                     SizeBytes: info.Length,
                     CreatedAtUtc: info.LastWriteTimeUtc,
                     Status: "ready",
-                    HostPath: PathRelativeToHost(file, _paths.BackupRoot),
+                    HostPath: _paths.HostRelativeBackupPath(info.Name),
                     ContainerPath: file,
                     IncludesThumbnails: includesThumbnails,
                     Error: null));
@@ -140,9 +137,7 @@ public sealed class BackupService : IBackupService
             }
         }
 
-        return list
-            .OrderByDescending(b => b.CreatedAtUtc)
-            .ToList();
+        return list.OrderByDescending(b => b.CreatedAtUtc).ToList();
     }
 
     public BackupStorageInfo GetStorageInfo()
@@ -157,7 +152,7 @@ public sealed class BackupService : IBackupService
             }
         }
         return new BackupStorageInfo(
-            HostPath: "./data/backups",
+            HostPath: _paths.HostBackupRoot,
             ContainerPath: _paths.BackupRoot,
             TotalUsedBytes: total);
     }
@@ -198,15 +193,31 @@ public sealed class BackupService : IBackupService
         if (!File.Exists(source))
             throw new FileNotFoundException("Backup not found.", fileName);
 
-        // Clear any older staged restore so only the newest takes effect on boot.
-        foreach (var existing in Directory.EnumerateFiles(_paths.RestoreRoot, "*.tar"))
+        // Single-lock the clear-then-copy sequence so concurrent calls cannot
+        // interleave and leave the wrong backup staged.
+        _stageLock.Wait();
+        try
         {
-            try { File.Delete(existing); }
-            catch (IOException ex) { _logger.LogWarning(ex, "Failed to clear staged restore {Path}", existing); }
-        }
+            // Clear any older staged restore so only the newest takes effect on boot.
+            foreach (var existing in Directory.EnumerateFiles(_paths.RestoreRoot, "*.tar"))
+            {
+                try { File.Delete(existing); }
+                catch (IOException ex) { _logger.LogWarning(ex, "Failed to clear staged restore {Path}", existing); }
+            }
 
-        var target = Path.Combine(_paths.RestoreRoot, fileName);
-        File.Copy(source, target, overwrite: true);
+            var target = Path.Combine(_paths.RestoreRoot, fileName);
+            // Copy into a .tmp sibling first, fsync, then atomic rename — guarantees
+            // the boot processor never sees a half-copied archive.
+            var tmpTarget = target + ".staging";
+            File.Copy(source, tmpTarget, overwrite: true);
+            FsyncFile(tmpTarget);
+            if (File.Exists(target)) File.Delete(target);
+            File.Move(tmpTarget, target);
+        }
+        finally
+        {
+            _stageLock.Release();
+        }
     }
 
     // ── private ─────────────────────────────────────────────────────────
@@ -221,13 +232,20 @@ public sealed class BackupService : IBackupService
 
         try
         {
+            // Pre-flight: query the running Postgres for its actual major version
+            // so the manifest reports the truth, not a baked-in literal.
+            var pgMajor = await GetPostgresMajorVersionAsync();
+
             await RunPgDumpAsync(dumpPath);
             var dumpInfo = new FileInfo(dumpPath);
+            var dumpSha = await ComputeSha256Async(dumpPath);
 
             await using (var outStream = File.Create(tmpPath))
             await using (var tar = new TarWriter(outStream, TarEntryFormat.Pax, leaveOpen: false))
             {
-                // database.dump first so streaming consumers can decide quickly.
+                // database.dump first so a streaming reader can extract the DB
+                // even before scanning every upload entry. Manifest is written
+                // last so its stats reflect the actual contents.
                 await WriteFileEntryAsync(tar, dumpPath, DatabaseDumpEntryName);
 
                 if (Directory.Exists(_paths.UploadRoot))
@@ -244,22 +262,28 @@ public sealed class BackupService : IBackupService
                 }
 
                 var manifest = new BackupManifest(
-                    ManifestVersion: CurrentManifestVersion,
+                    ManifestVersion: BackupManifestConstants.CurrentManifestVersion,
                     CreatedAtUtc: createdAt,
-                    PostgresMajorVersion: 16,
-                    Scope: new ManifestScope(
+                    PostgresMajorVersion: pgMajor,
+                    Scope: new BackupManifestScope(
                         Database: true,
                         Uploads: true,
                         Thumbnails: scope.IncludeThumbnails),
-                    Stats: new ManifestStats(
+                    Stats: new BackupManifestStats(
                         UploadsCount: uploadsCount,
                         UploadsBytes: uploadsBytes,
                         ThumbnailsCount: thumbsCount,
                         ThumbnailsBytes: thumbsBytes,
-                        DatabaseDumpBytes: dumpInfo.Length));
+                        DatabaseDumpBytes: dumpInfo.Length,
+                        DatabaseDumpSha256: dumpSha));
 
                 await WriteJsonEntryAsync(tar, ManifestEntryName, manifest);
             }
+
+            // Force the OS to write the file's bytes to disk before we make it
+            // visible. Without this, a power loss between completion and the
+            // OS flushing buffers could leave a zero-byte or torn archive.
+            FsyncFile(tmpPath);
 
             // Atomic publish.
             if (File.Exists(finalPath)) File.Delete(finalPath);
@@ -305,6 +329,38 @@ public sealed class BackupService : IBackupService
         }
     }
 
+    private async Task<int> GetPostgresMajorVersionAsync()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "psql",
+            ArgumentList =
+            {
+                "-h", _postgres.Host,
+                "-p", _postgres.Port.ToString(),
+                "-U", _postgres.User,
+                "-d", _postgres.Database,
+                "-t", "-A",
+                "-c", "SHOW server_version_num",
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["PGPASSWORD"] = _postgres.Password;
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch psql for version probe.");
+        var output = (await p.StandardOutput.ReadToEndAsync()).Trim();
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0 || !int.TryParse(output, out var verNum))
+        {
+            throw new InvalidOperationException($"Failed to read postgres version (exit {p.ExitCode}): '{output}'");
+        }
+        // server_version_num format: 160003 → major 16; 170000 → 17. Major = verNum / 10000.
+        return verNum / 10000;
+    }
+
     private static async Task WriteFileEntryAsync(TarWriter tar, string filePath, string entryName)
     {
         var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName);
@@ -336,10 +392,13 @@ public sealed class BackupService : IBackupService
             var entryName = entryPrefix + relative;
             var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName);
             await using var fs = File.OpenRead(path);
+            // fs.Length is valid here regardless of stream position — it returns the
+            // file's size, not bytes-read-since-open.
+            var size = fs.Length;
             entry.DataStream = fs;
             await tar.WriteEntryAsync(entry);
             count++;
-            bytes += fs.Length;
+            bytes += size;
         }
 
         return (count, bytes);
@@ -369,6 +428,29 @@ public sealed class BackupService : IBackupService
             }
         }
         return null;
+    }
+
+    private static async Task<string> ComputeSha256Async(string filePath)
+    {
+        await using var fs = File.OpenRead(filePath);
+        using var sha = SHA256.Create();
+        var hash = await sha.ComputeHashAsync(fs);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static void FsyncFile(string path)
+    {
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+            fs.Flush(flushToDisk: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort. On filesystems that don't support fsync (rare in our
+            // bind-mounted Linux setup) the rest of the pipeline still produces
+            // a valid archive — the manifest read on restore catches truncation.
+        }
     }
 
     private async Task<long> GetDatabaseSizeBytesAsync(CancellationToken cancellationToken)
@@ -427,13 +509,6 @@ public sealed class BackupService : IBackupService
             && name.StartsWith("modelibr-", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string PathRelativeToHost(string containerPath, string containerRoot)
-    {
-        // Map the container path to its bind-mount equivalent for display purposes.
-        var rel = Path.GetRelativePath(containerRoot, containerPath).Replace('\\', '/');
-        return $"./data/backups/{rel}";
-    }
-
     // ── nested config types ─────────────────────────────────────────────
 
     internal sealed class BackupPaths
@@ -445,6 +520,16 @@ public sealed class BackupService : IBackupService
         public required string RestoreFailed { get; init; }
         public required string UploadRoot { get; init; }
         public required string ThumbnailRoot { get; init; }
+        // Best-effort hint shown in the UI so operators know where to find the
+        // archive on the host. Defaults to the value used by docker-compose;
+        // override with BACKUP_HOST_DISPLAY_PATH if your bind mount differs.
+        public required string HostBackupRoot { get; init; }
+
+        public string HostRelativeBackupPath(string fileName)
+        {
+            var trimmed = HostBackupRoot.TrimEnd('/', '\\');
+            return $"{trimmed}/{fileName}";
+        }
 
         public static BackupPaths FromConfiguration(IConfiguration cfg)
         {
@@ -452,6 +537,7 @@ public sealed class BackupService : IBackupService
             var restoreRoot = cfg["RESTORE_STORAGE_PATH"] ?? "/var/lib/modelibr/restore";
             var uploadRoot = cfg["UPLOAD_STORAGE_PATH"] ?? "/var/lib/modelibr/uploads";
             var thumbRoot = cfg["THUMBNAIL_STORAGE_PATH"] ?? "/var/lib/modelibr/thumbnails";
+            var hostBackupRoot = cfg["BACKUP_HOST_DISPLAY_PATH"] ?? "./data/backups";
             return new BackupPaths
             {
                 BackupRoot = backupRoot,
@@ -461,6 +547,7 @@ public sealed class BackupService : IBackupService
                 RestoreFailed = Path.Combine(restoreRoot, "failed"),
                 UploadRoot = uploadRoot,
                 ThumbnailRoot = thumbRoot,
+                HostBackupRoot = hostBackupRoot,
             };
         }
     }
@@ -485,22 +572,4 @@ public sealed class BackupService : IBackupService
             };
         }
     }
-
-    // ── manifest types ──────────────────────────────────────────────────
-
-    public sealed record BackupManifest(
-        int ManifestVersion,
-        DateTime CreatedAtUtc,
-        int PostgresMajorVersion,
-        ManifestScope Scope,
-        ManifestStats Stats);
-
-    public sealed record ManifestScope(bool Database, bool Uploads, bool Thumbnails);
-
-    public sealed record ManifestStats(
-        int UploadsCount,
-        long UploadsBytes,
-        int ThumbnailsCount,
-        long ThumbnailsBytes,
-        long DatabaseDumpBytes);
 }

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -1,0 +1,506 @@
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.Text.Json;
+using Application.Abstractions.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Services;
+
+public sealed class BackupService : IBackupService
+{
+    private const string ManifestEntryName = "manifest.json";
+    private const string DatabaseDumpEntryName = "database.dump";
+    private const string UploadsPrefix = "uploads/";
+    private const string ThumbnailsPrefix = "thumbnails/";
+
+    public const int CurrentManifestVersion = 1;
+
+    private readonly ILogger<BackupService> _logger;
+    private readonly BackupPaths _paths;
+    private readonly PostgresConnectionInfo _postgres;
+    private readonly SemaphoreSlim _runLock = new(1, 1);
+
+    private readonly object _stateLock = new();
+    private BackupSummary? _inProgress;
+
+    public BackupService(IConfiguration configuration, ILogger<BackupService> logger)
+    {
+        _logger = logger;
+        _paths = BackupPaths.FromConfiguration(configuration);
+        _postgres = PostgresConnectionInfo.FromConfiguration(configuration);
+
+        Directory.CreateDirectory(_paths.BackupRoot);
+        Directory.CreateDirectory(_paths.BackupTmp);
+        Directory.CreateDirectory(_paths.RestoreRoot);
+        Directory.CreateDirectory(_paths.RestoreProcessed);
+        Directory.CreateDirectory(_paths.RestoreFailed);
+
+        // Sweep leftover tmp files from a previously-crashed backup run.
+        foreach (var stale in Directory.EnumerateFiles(_paths.BackupTmp))
+        {
+            try { File.Delete(stale); }
+            catch (IOException ex) { _logger.LogWarning(ex, "Failed to delete stale tmp backup {Path}", stale); }
+        }
+    }
+
+    public Task<BackupSummary> StartBackupAsync(BackupScope scope, CancellationToken cancellationToken)
+    {
+        if (!_runLock.Wait(0, cancellationToken))
+        {
+            throw new InvalidOperationException("A backup is already in progress.");
+        }
+
+        var createdAt = DateTime.UtcNow;
+        var fileName = $"modelibr-{createdAt:yyyy-MM-dd-HHmmss}.tar";
+        var finalPath = Path.Combine(_paths.BackupRoot, fileName);
+        var tmpPath = Path.Combine(_paths.BackupTmp, fileName);
+
+        var summary = new BackupSummary(
+            FileName: fileName,
+            SizeBytes: 0,
+            CreatedAtUtc: createdAt,
+            Status: "in_progress",
+            HostPath: PathRelativeToHost(finalPath, _paths.BackupRoot),
+            ContainerPath: finalPath,
+            IncludesThumbnails: scope.IncludeThumbnails,
+            Error: null);
+
+        lock (_stateLock)
+        {
+            _inProgress = summary;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RunBackupAsync(scope, tmpPath, finalPath, createdAt);
+                lock (_stateLock)
+                {
+                    _inProgress = null;
+                }
+                _logger.LogInformation("Backup completed: {FileName}", fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Backup failed: {FileName}", fileName);
+                try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { /* swallow */ }
+                lock (_stateLock)
+                {
+                    _inProgress = summary with { Status = "failed", Error = ex.Message };
+                }
+            }
+            finally
+            {
+                _runLock.Release();
+            }
+        }, CancellationToken.None);
+
+        return Task.FromResult(summary);
+    }
+
+    public IReadOnlyList<BackupSummary> ListBackups()
+    {
+        var list = new List<BackupSummary>();
+
+        if (Directory.Exists(_paths.BackupRoot))
+        {
+            foreach (var file in Directory.EnumerateFiles(_paths.BackupRoot, "*.tar"))
+            {
+                var info = new FileInfo(file);
+                bool includesThumbnails;
+                try
+                {
+                    includesThumbnails = TryReadManifest(file)?.Scope?.Thumbnails ?? false;
+                }
+                catch
+                {
+                    includesThumbnails = false;
+                }
+
+                list.Add(new BackupSummary(
+                    FileName: info.Name,
+                    SizeBytes: info.Length,
+                    CreatedAtUtc: info.LastWriteTimeUtc,
+                    Status: "ready",
+                    HostPath: PathRelativeToHost(file, _paths.BackupRoot),
+                    ContainerPath: file,
+                    IncludesThumbnails: includesThumbnails,
+                    Error: null));
+            }
+        }
+
+        lock (_stateLock)
+        {
+            if (_inProgress is not null)
+            {
+                list.RemoveAll(b => b.FileName == _inProgress.FileName);
+                list.Add(_inProgress);
+            }
+        }
+
+        return list
+            .OrderByDescending(b => b.CreatedAtUtc)
+            .ToList();
+    }
+
+    public BackupStorageInfo GetStorageInfo()
+    {
+        long total = 0;
+        if (Directory.Exists(_paths.BackupRoot))
+        {
+            foreach (var file in Directory.EnumerateFiles(_paths.BackupRoot, "*.tar"))
+            {
+                try { total += new FileInfo(file).Length; }
+                catch { /* ignore */ }
+            }
+        }
+        return new BackupStorageInfo(
+            HostPath: "./data/backups",
+            ContainerPath: _paths.BackupRoot,
+            TotalUsedBytes: total);
+    }
+
+    public async Task<BackupSizeEstimate> EstimateSizeAsync(CancellationToken cancellationToken)
+    {
+        var dbBytes = await GetDatabaseSizeBytesAsync(cancellationToken);
+        var uploadBytes = DirectorySize(_paths.UploadRoot);
+        var thumbBytes = DirectorySize(_paths.ThumbnailRoot);
+        return new BackupSizeEstimate(dbBytes, uploadBytes, thumbBytes);
+    }
+
+    public string? ResolveBackupPath(string fileName)
+    {
+        if (!IsValidBackupName(fileName)) return null;
+        var path = Path.Combine(_paths.BackupRoot, fileName);
+        return File.Exists(path) ? path : null;
+    }
+
+    public void DeleteBackup(string fileName)
+    {
+        if (!IsValidBackupName(fileName))
+            throw new ArgumentException("Invalid backup filename.", nameof(fileName));
+
+        var path = Path.Combine(_paths.BackupRoot, fileName);
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Backup not found.", fileName);
+
+        File.Delete(path);
+    }
+
+    public void StageRestore(string fileName)
+    {
+        if (!IsValidBackupName(fileName))
+            throw new ArgumentException("Invalid backup filename.", nameof(fileName));
+
+        var source = Path.Combine(_paths.BackupRoot, fileName);
+        if (!File.Exists(source))
+            throw new FileNotFoundException("Backup not found.", fileName);
+
+        // Clear any older staged restore so only the newest takes effect on boot.
+        foreach (var existing in Directory.EnumerateFiles(_paths.RestoreRoot, "*.tar"))
+        {
+            try { File.Delete(existing); }
+            catch (IOException ex) { _logger.LogWarning(ex, "Failed to clear staged restore {Path}", existing); }
+        }
+
+        var target = Path.Combine(_paths.RestoreRoot, fileName);
+        File.Copy(source, target, overwrite: true);
+    }
+
+    // ── private ─────────────────────────────────────────────────────────
+
+    private async Task RunBackupAsync(BackupScope scope, string tmpPath, string finalPath, DateTime createdAt)
+    {
+        var dumpPath = tmpPath + ".dump";
+        long uploadsBytes = 0;
+        int uploadsCount = 0;
+        long thumbsBytes = 0;
+        int thumbsCount = 0;
+
+        try
+        {
+            await RunPgDumpAsync(dumpPath);
+            var dumpInfo = new FileInfo(dumpPath);
+
+            await using (var outStream = File.Create(tmpPath))
+            await using (var tar = new TarWriter(outStream, TarEntryFormat.Pax, leaveOpen: false))
+            {
+                // database.dump first so streaming consumers can decide quickly.
+                await WriteFileEntryAsync(tar, dumpPath, DatabaseDumpEntryName);
+
+                if (Directory.Exists(_paths.UploadRoot))
+                {
+                    // Skip uploads/tmp/ — that's HashBasedFileStorage's staging directory for in-flight uploads.
+                    (uploadsCount, uploadsBytes) = await WriteDirectoryEntriesAsync(
+                        tar, _paths.UploadRoot, UploadsPrefix, skipDirName: "tmp");
+                }
+
+                if (scope.IncludeThumbnails && Directory.Exists(_paths.ThumbnailRoot))
+                {
+                    (thumbsCount, thumbsBytes) = await WriteDirectoryEntriesAsync(
+                        tar, _paths.ThumbnailRoot, ThumbnailsPrefix, skipDirName: null);
+                }
+
+                var manifest = new BackupManifest(
+                    ManifestVersion: CurrentManifestVersion,
+                    CreatedAtUtc: createdAt,
+                    PostgresMajorVersion: 16,
+                    Scope: new ManifestScope(
+                        Database: true,
+                        Uploads: true,
+                        Thumbnails: scope.IncludeThumbnails),
+                    Stats: new ManifestStats(
+                        UploadsCount: uploadsCount,
+                        UploadsBytes: uploadsBytes,
+                        ThumbnailsCount: thumbsCount,
+                        ThumbnailsBytes: thumbsBytes,
+                        DatabaseDumpBytes: dumpInfo.Length));
+
+                await WriteJsonEntryAsync(tar, ManifestEntryName, manifest);
+            }
+
+            // Atomic publish.
+            if (File.Exists(finalPath)) File.Delete(finalPath);
+            File.Move(tmpPath, finalPath);
+        }
+        finally
+        {
+            if (File.Exists(dumpPath))
+            {
+                try { File.Delete(dumpPath); }
+                catch (IOException ex) { _logger.LogWarning(ex, "Failed to delete temp dump {Path}", dumpPath); }
+            }
+        }
+    }
+
+    private async Task RunPgDumpAsync(string outputPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "pg_dump",
+            ArgumentList =
+            {
+                "-Fc",                               // custom format (compressed)
+                "-h", _postgres.Host,
+                "-p", _postgres.Port.ToString(),
+                "-U", _postgres.User,
+                "-d", _postgres.Database,
+                "-f", outputPath,
+            },
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["PGPASSWORD"] = _postgres.Password;
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch pg_dump.");
+        var stderr = await p.StandardError.ReadToEndAsync();
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"pg_dump exited with code {p.ExitCode}: {stderr}");
+        }
+    }
+
+    private static async Task WriteFileEntryAsync(TarWriter tar, string filePath, string entryName)
+    {
+        var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName);
+        await using (var fs = File.OpenRead(filePath))
+        {
+            entry.DataStream = fs;
+            await tar.WriteEntryAsync(entry);
+        }
+    }
+
+    private static async Task<(int count, long bytes)> WriteDirectoryEntriesAsync(
+        TarWriter tar,
+        string rootDir,
+        string entryPrefix,
+        string? skipDirName)
+    {
+        var count = 0;
+        long bytes = 0;
+        var rootFull = Path.GetFullPath(rootDir);
+
+        foreach (var path in Directory.EnumerateFiles(rootDir, "*", SearchOption.AllDirectories))
+        {
+            if (skipDirName != null)
+            {
+                var rel = Path.GetRelativePath(rootFull, path).Replace('\\', '/');
+                if (rel.StartsWith(skipDirName + "/", StringComparison.Ordinal)) continue;
+            }
+            var relative = Path.GetRelativePath(rootFull, path).Replace('\\', '/');
+            var entryName = entryPrefix + relative;
+            var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName);
+            await using var fs = File.OpenRead(path);
+            entry.DataStream = fs;
+            await tar.WriteEntryAsync(entry);
+            count++;
+            bytes += fs.Length;
+        }
+
+        return (count, bytes);
+    }
+
+    private static async Task WriteJsonEntryAsync<T>(TarWriter tar, string entryName, T payload)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(payload, new JsonSerializerOptions { WriteIndented = true });
+        var entry = new PaxTarEntry(TarEntryType.RegularFile, entryName);
+        entry.DataStream = new MemoryStream(json);
+        await tar.WriteEntryAsync(entry);
+    }
+
+    private static BackupManifest? TryReadManifest(string tarPath)
+    {
+        using var fs = File.OpenRead(tarPath);
+        using var reader = new TarReader(fs);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry(copyData: true)) != null)
+        {
+            if (entry.Name == ManifestEntryName && entry.DataStream != null)
+            {
+                using var ms = new MemoryStream();
+                entry.DataStream.CopyTo(ms);
+                ms.Position = 0;
+                return JsonSerializer.Deserialize<BackupManifest>(ms);
+            }
+        }
+        return null;
+    }
+
+    private async Task<long> GetDatabaseSizeBytesAsync(CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "psql",
+            ArgumentList =
+            {
+                "-h", _postgres.Host,
+                "-p", _postgres.Port.ToString(),
+                "-U", _postgres.User,
+                "-d", _postgres.Database,
+                "-t", "-A",
+                "-c", $"SELECT pg_database_size('{_postgres.Database}')",
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["PGPASSWORD"] = _postgres.Password;
+
+        try
+        {
+            using var p = Process.Start(psi);
+            if (p == null) return 0;
+            var output = await p.StandardOutput.ReadToEndAsync(cancellationToken);
+            await p.WaitForExitAsync(cancellationToken);
+            return long.TryParse(output.Trim(), out var size) ? size : 0;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static long DirectorySize(string dir)
+    {
+        if (!Directory.Exists(dir)) return 0;
+        try
+        {
+            return Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories)
+                .Sum(f => { try { return new FileInfo(f).Length; } catch { return 0L; } });
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static bool IsValidBackupName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        if (name.Contains('/') || name.Contains('\\') || name.Contains("..", StringComparison.Ordinal)) return false;
+        return name.EndsWith(".tar", StringComparison.OrdinalIgnoreCase)
+            && name.StartsWith("modelibr-", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string PathRelativeToHost(string containerPath, string containerRoot)
+    {
+        // Map the container path to its bind-mount equivalent for display purposes.
+        var rel = Path.GetRelativePath(containerRoot, containerPath).Replace('\\', '/');
+        return $"./data/backups/{rel}";
+    }
+
+    // ── nested config types ─────────────────────────────────────────────
+
+    internal sealed class BackupPaths
+    {
+        public required string BackupRoot { get; init; }
+        public required string BackupTmp { get; init; }
+        public required string RestoreRoot { get; init; }
+        public required string RestoreProcessed { get; init; }
+        public required string RestoreFailed { get; init; }
+        public required string UploadRoot { get; init; }
+        public required string ThumbnailRoot { get; init; }
+
+        public static BackupPaths FromConfiguration(IConfiguration cfg)
+        {
+            var backupRoot = cfg["BACKUP_STORAGE_PATH"] ?? "/var/lib/modelibr/backups";
+            var restoreRoot = cfg["RESTORE_STORAGE_PATH"] ?? "/var/lib/modelibr/restore";
+            var uploadRoot = cfg["UPLOAD_STORAGE_PATH"] ?? "/var/lib/modelibr/uploads";
+            var thumbRoot = cfg["THUMBNAIL_STORAGE_PATH"] ?? "/var/lib/modelibr/thumbnails";
+            return new BackupPaths
+            {
+                BackupRoot = backupRoot,
+                BackupTmp = Path.Combine(backupRoot, ".tmp"),
+                RestoreRoot = restoreRoot,
+                RestoreProcessed = Path.Combine(restoreRoot, "processed"),
+                RestoreFailed = Path.Combine(restoreRoot, "failed"),
+                UploadRoot = uploadRoot,
+                ThumbnailRoot = thumbRoot,
+            };
+        }
+    }
+
+    internal sealed class PostgresConnectionInfo
+    {
+        public required string Host { get; init; }
+        public required int Port { get; init; }
+        public required string Database { get; init; }
+        public required string User { get; init; }
+        public required string Password { get; init; }
+
+        public static PostgresConnectionInfo FromConfiguration(IConfiguration cfg)
+        {
+            return new PostgresConnectionInfo
+            {
+                Host = cfg["POSTGRES_HOST"] ?? "postgres",
+                Port = int.TryParse(cfg["POSTGRES_PORT"], out var p) ? p : 5432,
+                Database = cfg["POSTGRES_DB"] ?? "Modelibr",
+                User = cfg["POSTGRES_USER"] ?? "modelibr",
+                Password = cfg["POSTGRES_PASSWORD"] ?? string.Empty,
+            };
+        }
+    }
+
+    // ── manifest types ──────────────────────────────────────────────────
+
+    public sealed record BackupManifest(
+        int ManifestVersion,
+        DateTime CreatedAtUtc,
+        int PostgresMajorVersion,
+        ManifestScope Scope,
+        ManifestStats Stats);
+
+    public sealed record ManifestScope(bool Database, bool Uploads, bool Thumbnails);
+
+    public sealed record ManifestStats(
+        int UploadsCount,
+        long UploadsBytes,
+        int ThumbnailsCount,
+        long ThumbnailsBytes,
+        long DatabaseDumpBytes);
+}

--- a/src/WebApi/Dockerfile
+++ b/src/WebApi/Dockerfile
@@ -36,9 +36,16 @@ RUN dotnet publish "./WebApi.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:
 
 # Final stage
 FROM base AS final
-# Install curl for healthchecks and libgomp1 for Magick.NET (ImageMagick OpenMP)
+# Install curl for healthchecks, libgomp1 for Magick.NET (ImageMagick OpenMP),
+# and postgresql-client-16 (matching postgres:16-alpine in compose) for backup/restore via pg_dump/pg_restore.
 USER root
-RUN apt-get update && apt-get install -y curl libgomp1 xz-utils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl libgomp1 xz-utils gnupg lsb-release \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y postgresql-client-16 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install x86_64 compatibility libraries when the container itself is not amd64.
 # The runtime installer downloads the Linux x64 Blender binary into shared storage.
@@ -59,6 +66,9 @@ RUN groupadd -g $APP_GID app || true && \
     useradd -u $APP_UID -g app -m -d /home/app app || true && \
     mkdir -p /var/lib/modelibr/uploads && \
     mkdir -p /var/lib/modelibr/blender && \
+    mkdir -p /var/lib/modelibr/backups && \
+    mkdir -p /var/lib/modelibr/restore && \
+    mkdir -p /var/lib/modelibr/thumbnails && \
     chmod -R 755 /var/lib/modelibr && \
     chown -R app:app /var/lib/modelibr
 # Copy published output

--- a/src/WebApi/Endpoints/BackupEndpoints.cs
+++ b/src/WebApi/Endpoints/BackupEndpoints.cs
@@ -90,7 +90,9 @@ public static class BackupEndpoints
             try
             {
                 backupService.StageRestore(fileName);
-                return Results.Ok(new
+                // 202 Accepted — the actual restore happens on the next webapi boot
+                // via RestoreOnBootProcessor, not synchronously here.
+                return Results.Accepted(value: new
                 {
                     staged = true,
                     message = "Backup staged for restore. Restart the webapi container to apply.",

--- a/src/WebApi/Endpoints/BackupEndpoints.cs
+++ b/src/WebApi/Endpoints/BackupEndpoints.cs
@@ -1,0 +1,113 @@
+using Application.Abstractions.Services;
+
+namespace WebApi.Endpoints;
+
+public static class BackupEndpoints
+{
+    public static void MapBackupEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/backups", (IBackupService backupService) =>
+        {
+            return Results.Ok(new { backups = backupService.ListBackups() });
+        })
+        .WithName("List Backups")
+        .WithTags("Backups");
+
+        app.MapGet("/backups/storage", (IBackupService backupService) =>
+        {
+            return Results.Ok(backupService.GetStorageInfo());
+        })
+        .WithName("Get Backup Storage Info")
+        .WithTags("Backups");
+
+        app.MapGet("/backups/estimate", async (IBackupService backupService, CancellationToken ct) =>
+        {
+            var estimate = await backupService.EstimateSizeAsync(ct);
+            return Results.Ok(estimate);
+        })
+        .WithName("Estimate Backup Size")
+        .WithTags("Backups");
+
+        app.MapPost("/backups", async (
+            CreateBackupRequest? request,
+            IBackupService backupService,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var scope = new BackupScope(IncludeThumbnails: request?.IncludeThumbnails ?? false);
+                var summary = await backupService.StartBackupAsync(scope, ct);
+                return Results.Accepted($"/backups/{summary.FileName}", summary);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = "BackupInProgress", message = ex.Message });
+            }
+        })
+        .WithName("Create Backup")
+        .WithTags("Backups");
+
+        app.MapGet("/backups/{fileName}", (
+            string fileName,
+            IBackupService backupService) =>
+        {
+            var path = backupService.ResolveBackupPath(fileName);
+            if (path == null)
+            {
+                return Results.NotFound(new { error = "BackupNotFound", message = $"Backup {fileName} not found." });
+            }
+
+            return Results.File(path, "application/x-tar", fileDownloadName: fileName);
+        })
+        .WithName("Download Backup")
+        .WithTags("Backups");
+
+        app.MapDelete("/backups/{fileName}", (
+            string fileName,
+            IBackupService backupService) =>
+        {
+            try
+            {
+                backupService.DeleteBackup(fileName);
+                return Results.NoContent();
+            }
+            catch (FileNotFoundException)
+            {
+                return Results.NotFound(new { error = "BackupNotFound", message = $"Backup {fileName} not found." });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = "InvalidName", message = ex.Message });
+            }
+        })
+        .WithName("Delete Backup")
+        .WithTags("Backups");
+
+        app.MapPost("/backups/{fileName}/restore", (
+            string fileName,
+            IBackupService backupService) =>
+        {
+            try
+            {
+                backupService.StageRestore(fileName);
+                return Results.Ok(new
+                {
+                    staged = true,
+                    message = "Backup staged for restore. Restart the webapi container to apply.",
+                });
+            }
+            catch (FileNotFoundException)
+            {
+                return Results.NotFound(new { error = "BackupNotFound", message = $"Backup {fileName} not found." });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = "InvalidName", message = ex.Message });
+            }
+        })
+        .WithName("Stage Backup For Restore")
+        .WithTags("Backups");
+    }
+}
+
+public record CreateBackupRequest(bool IncludeThumbnails);

--- a/src/WebApi/Infrastructure/RestoreOnBootProcessor.cs
+++ b/src/WebApi/Infrastructure/RestoreOnBootProcessor.cs
@@ -1,23 +1,29 @@
 using System.Diagnostics;
 using System.Formats.Tar;
+using System.Security.Cryptography;
 using System.Text.Json;
+using Application.Abstractions.Services;
 
 namespace WebApi.Infrastructure;
 
 /// <summary>
 /// Runs before the host is built. If a .tar archive is present in the restore
-/// directory, validates its manifest, then restores Postgres (pg_restore --clean)
-/// and replaces the uploads/thumbnails trees. On success the archive is moved to
-/// restore/processed/. On validation failure it is moved to restore/failed/ and
-/// boot proceeds normally — never destroy live data because of a bad archive.
+/// directory, performs a strict pre-flight validation (manifest version, app
+/// schema compat, archive integrity, expected entries) BEFORE moving any live
+/// data. If validation passes, stages existing uploads/thumbnails into
+/// <c>.pre-restore-&lt;ts&gt;/</c>, extracts the archive, runs
+/// <c>pg_restore --clean --if-exists --exit-on-error</c>, and only then moves
+/// the archive to <c>restore/processed/</c>.
+///
+/// Invalid archives go to <c>restore/failed/</c> with an <c>.error.txt</c>
+/// sibling — live data is never touched in that path.
+///
+/// <c>.pre-restore-*</c> directories are NEVER auto-swept: a failed restore
+/// leaves the operator's only recovery copy on disk, and silently deleting
+/// it on the next boot would cause permanent data loss.
 /// </summary>
 public static class RestoreOnBootProcessor
 {
-    private const string ManifestEntryName = "manifest.json";
-    private const string DatabaseDumpEntryName = "database.dump";
-    private const string UploadsPrefix = "uploads/";
-    private const string ThumbnailsPrefix = "thumbnails/";
-
     public static async Task RunAsync(IConfiguration configuration, ILogger logger)
     {
         var restoreRoot = configuration["RESTORE_STORAGE_PATH"] ?? "/var/lib/modelibr/restore";
@@ -30,35 +36,89 @@ public static class RestoreOnBootProcessor
         Directory.CreateDirectory(processedDir);
         Directory.CreateDirectory(failedDir);
 
-        // Clean up stale .pre-restore-* directories from any previous incomplete run.
-        SweepStalePreRestoreDirs(uploadRoot, logger);
-        SweepStalePreRestoreDirs(thumbnailRoot, logger);
+        // Surface stale .pre-restore-* directories (left by a previous failed
+        // restore). We do NOT delete them automatically — they are the only
+        // recovery copy of the operator's live data and must be removed manually.
+        WarnAboutStalePreRestoreDirs(uploadRoot, logger);
+        WarnAboutStalePreRestoreDirs(thumbnailRoot, logger);
 
         var archive = Directory.EnumerateFiles(restoreRoot, "*.tar")
             .OrderBy(f => f, StringComparer.Ordinal)
             .FirstOrDefault();
         if (archive == null) return;
 
+        // Refuse to run a second restore on top of an unrecovered pre-restore dir.
+        // If those still exist, an operator hasn't finished cleaning up the previous
+        // failure — running another restore now would shadow the recovery copy.
+        if (HasStalePreRestoreDirs(uploadRoot) || HasStalePreRestoreDirs(thumbnailRoot))
+        {
+            await MoveToFailedAsync(archive, failedDir,
+                "Refusing to restore: .pre-restore-* directories from a previous run still exist. " +
+                "Either delete them manually after confirming live data is intact, or move them back " +
+                "into place to recover.",
+                logger);
+            return;
+        }
+
         logger.LogInformation("Found staged restore archive {Archive}", archive);
 
-        Manifest? manifest;
+        // ── Phase 1: validate the archive BEFORE touching live data ────────
+
+        BackupManifest? manifest;
+        string? archiveValidationError = null;
         try
         {
-            manifest = ReadManifest(archive)
-                ?? throw new InvalidOperationException("Archive does not contain manifest.json.");
+            manifest = ReadManifest(archive);
+            if (manifest == null)
+            {
+                archiveValidationError = "Archive does not contain manifest.json.";
+            }
+            else if (manifest.ManifestVersion != BackupManifestConstants.CurrentManifestVersion)
+            {
+                archiveValidationError =
+                    $"Backup ManifestVersion {manifest.ManifestVersion} is incompatible with this " +
+                    $"app's expected version {BackupManifestConstants.CurrentManifestVersion}.";
+            }
+            else if (!manifest.Scope.Database)
+            {
+                archiveValidationError = "Manifest claims no database — refusing to restore.";
+            }
+            else
+            {
+                // Confirm the archive structurally has what the manifest promised
+                // before we let any pg_restore or file-tree mutation happen.
+                var entryNames = EnumerateEntryNames(archive).ToHashSet(StringComparer.Ordinal);
+                if (!entryNames.Contains(BackupServiceConstants.DatabaseDumpEntryName))
+                {
+                    archiveValidationError = "Archive is missing the database.dump entry.";
+                }
+                else
+                {
+                    var uploadEntries = entryNames.Count(n =>
+                        n.StartsWith(BackupServiceConstants.UploadsPrefix, StringComparison.Ordinal));
+                    if (uploadEntries != manifest.Stats.UploadsCount)
+                    {
+                        archiveValidationError =
+                            $"Archive integrity check failed: manifest says {manifest.Stats.UploadsCount} upload " +
+                            $"entries but tar contains {uploadEntries}. Refusing to restore — backup is truncated.";
+                    }
+                }
+            }
         }
         catch (Exception ex)
         {
-            await MoveToFailedAsync(archive, failedDir, $"Manifest read failed: {ex.Message}", logger);
+            archiveValidationError = $"Manifest read failed: {ex.Message}";
+            manifest = null;
+        }
+
+        if (archiveValidationError != null || manifest == null)
+        {
+            await MoveToFailedAsync(archive, failedDir,
+                archiveValidationError ?? "Unknown validation failure", logger);
             return;
         }
 
-        if (manifest.PostgresMajorVersion != 16)
-        {
-            await MoveToFailedAsync(archive, failedDir,
-                $"Backup Postgres major version {manifest.PostgresMajorVersion} does not match current 16.", logger);
-            return;
-        }
+        // ── Phase 2: connect to Postgres and verify versions ──────────────
 
         var host = configuration["POSTGRES_HOST"] ?? "postgres";
         var port = int.TryParse(configuration["POSTGRES_PORT"], out var p) ? p : 5432;
@@ -67,36 +127,79 @@ public static class RestoreOnBootProcessor
         var password = configuration["POSTGRES_PASSWORD"] ?? string.Empty;
 
         await WaitForPostgresAsync(host, port, user, password, db, logger);
+        var liveMajor = await GetPostgresMajorVersionAsync(host, port, user, password, db);
+        if (liveMajor != manifest.PostgresMajorVersion)
+        {
+            await MoveToFailedAsync(archive, failedDir,
+                $"Postgres major version mismatch: archive was made under PG {manifest.PostgresMajorVersion} " +
+                $"but the running server reports PG {liveMajor}. Restore aborted — live data untouched.",
+                logger);
+            return;
+        }
 
-        // Stage the existing uploads/thumbnails trees to .pre-restore-<ts>/ — preserved
-        // until the entire restore succeeds so we can recover manually on failure.
+        // ── Phase 3: extract dump to a temp file and verify its SHA-256 ───
+        // The dump bytes are read out of the tar BEFORE any live tree is moved.
+        // If the archive is truncated mid-dump, we abort while live data is intact.
+
         var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
-        var uploadsPreRestore = StageExistingTree(uploadRoot, $".pre-restore-{stamp}", logger);
-        var thumbnailsPreRestore = manifest.Scope.Thumbnails
-            ? StageExistingTree(thumbnailRoot, $".pre-restore-{stamp}", logger)
-            : null;
-
         var dumpPath = Path.Combine(restoreRoot, $".dump-{stamp}");
         try
         {
-            ExtractArchive(archive, dumpPath, uploadRoot, thumbnailRoot, manifest, logger);
+            ExtractDatabaseDumpOnly(archive, dumpPath, logger);
 
+            var actualSha = await ComputeSha256Async(dumpPath);
+            if (!string.Equals(actualSha, manifest.Stats.DatabaseDumpSha256, StringComparison.OrdinalIgnoreCase))
+            {
+                await MoveToFailedAsync(archive, failedDir,
+                    $"database.dump SHA-256 mismatch — expected {manifest.Stats.DatabaseDumpSha256}, got {actualSha}. " +
+                    "Archive is corrupted. Live data untouched.",
+                    logger);
+                return;
+            }
+
+            // ── Phase 4: stage existing trees and extract uploads/thumbnails ──
+            // Past this point we ARE touching live data. Any failure leaves
+            // pre-restore copies behind for manual recovery.
+
+            var uploadsPreRestore = StageExistingTreeStrict(uploadRoot, $".pre-restore-{stamp}", logger);
+            var thumbnailsPreRestore = manifest.Scope.Thumbnails
+                ? StageExistingTreeStrict(thumbnailRoot, $".pre-restore-{stamp}", logger)
+                : null;
+
+            var (extractedUploads, extractedThumbnails) =
+                ExtractDataEntries(archive, uploadRoot, thumbnailRoot, manifest);
+
+            if (extractedUploads != manifest.Stats.UploadsCount)
+            {
+                throw new InvalidOperationException(
+                    $"Extracted {extractedUploads} upload files but manifest expected {manifest.Stats.UploadsCount}. " +
+                    $"Pre-restore copy preserved at {uploadsPreRestore}.");
+            }
+            if (manifest.Scope.Thumbnails && extractedThumbnails != manifest.Stats.ThumbnailsCount)
+            {
+                throw new InvalidOperationException(
+                    $"Extracted {extractedThumbnails} thumbnail files but manifest expected " +
+                    $"{manifest.Stats.ThumbnailsCount}. Pre-restore copy preserved at {thumbnailsPreRestore}.");
+            }
+
+            // ── Phase 5: pg_restore with --exit-on-error so exit 1 is fatal ──
             await RunPgRestoreAsync(dumpPath, host, port, user, password, db, logger);
 
-            // Success — drop the pre-restore copies.
+            // Success — drop the pre-restore copies and move the archive aside.
             DeleteDirectoryQuiet(uploadsPreRestore, logger);
             if (thumbnailsPreRestore != null) DeleteDirectoryQuiet(thumbnailsPreRestore, logger);
 
-            // Move the archive into processed/.
             var processedPath = Path.Combine(processedDir, $"{stamp}-{Path.GetFileName(archive)}");
             File.Move(archive, processedPath);
             logger.LogInformation("Restore completed successfully. Archive moved to {Path}", processedPath);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Restore failed. Pre-restore data preserved at {UploadsBackup}", uploadsPreRestore);
-            await MoveToFailedAsync(archive, failedDir, $"Restore execution failed: {ex.Message}", logger);
-            // Note: pre-restore-* directories are left in place so the operator can recover manually.
+            logger.LogError(ex, "Restore execution failed.");
+            // Guarantee the archive leaves the staging directory even if MoveToFailed
+            // itself errors — otherwise the next boot retries the same broken archive
+            // and locks the container in a crash loop.
+            await EnsureArchiveOutOfStagingAsync(archive, failedDir, $"Restore execution failed: {ex.Message}", logger);
             throw;
         }
         finally
@@ -111,65 +214,94 @@ public static class RestoreOnBootProcessor
 
     // ── private ─────────────────────────────────────────────────────────
 
-    private static Manifest? ReadManifest(string tarPath)
+    private static BackupManifest? ReadManifest(string tarPath)
     {
         using var fs = File.OpenRead(tarPath);
         using var reader = new TarReader(fs);
         TarEntry? entry;
         while ((entry = reader.GetNextEntry(copyData: true)) != null)
         {
-            if (entry.Name == ManifestEntryName && entry.DataStream != null)
+            if (entry.Name == BackupServiceConstants.ManifestEntryName && entry.DataStream != null)
             {
                 using var ms = new MemoryStream();
                 entry.DataStream.CopyTo(ms);
                 ms.Position = 0;
-                return JsonSerializer.Deserialize<Manifest>(ms);
+                return JsonSerializer.Deserialize<BackupManifest>(ms);
             }
         }
         return null;
     }
 
-    private static void ExtractArchive(
-        string tarPath, string dumpOutputPath,
-        string uploadRoot, string thumbnailRoot,
-        Manifest manifest, ILogger logger)
+    private static IEnumerable<string> EnumerateEntryNames(string tarPath)
     {
+        using var fs = File.OpenRead(tarPath);
+        using var reader = new TarReader(fs);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry(copyData: false)) != null)
+        {
+            yield return entry.Name;
+        }
+    }
+
+    private static void ExtractDatabaseDumpOnly(string tarPath, string dumpOutputPath, ILogger logger)
+    {
+        using var fs = File.OpenRead(tarPath);
+        using var reader = new TarReader(fs);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry(copyData: true)) != null)
+        {
+            if (entry.Name == BackupServiceConstants.DatabaseDumpEntryName && entry.DataStream != null)
+            {
+                using var outFs = File.Create(dumpOutputPath);
+                entry.DataStream.CopyTo(outFs);
+                outFs.Flush(flushToDisk: true);
+                return;
+            }
+        }
+        throw new InvalidOperationException("Archive did not contain database.dump (pre-validation should have caught this).");
+    }
+
+    private static (int uploads, int thumbnails) ExtractDataEntries(
+        string tarPath,
+        string uploadRoot,
+        string thumbnailRoot,
+        BackupManifest manifest)
+    {
+        var uploads = 0;
+        var thumbnails = 0;
+
         using var fs = File.OpenRead(tarPath);
         using var reader = new TarReader(fs);
         TarEntry? entry;
         while ((entry = reader.GetNextEntry(copyData: true)) != null)
         {
             if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile)) continue;
-
-            if (entry.Name == ManifestEntryName) continue; // already read
-
-            if (entry.Name == DatabaseDumpEntryName)
-            {
-                using var outFs = File.Create(dumpOutputPath);
-                entry.DataStream!.CopyTo(outFs);
-                continue;
-            }
+            if (entry.Name == BackupServiceConstants.ManifestEntryName) continue;
+            if (entry.Name == BackupServiceConstants.DatabaseDumpEntryName) continue;
 
             string? targetPath = null;
-            if (entry.Name.StartsWith(UploadsPrefix, StringComparison.Ordinal))
+            if (entry.Name.StartsWith(BackupServiceConstants.UploadsPrefix, StringComparison.Ordinal))
             {
-                var rel = entry.Name[UploadsPrefix.Length..];
+                var rel = entry.Name[BackupServiceConstants.UploadsPrefix.Length..];
                 targetPath = SafeCombine(uploadRoot, rel);
+                uploads++;
             }
-            else if (entry.Name.StartsWith(ThumbnailsPrefix, StringComparison.Ordinal) && manifest.Scope.Thumbnails)
+            else if (entry.Name.StartsWith(BackupServiceConstants.ThumbnailsPrefix, StringComparison.Ordinal)
+                     && manifest.Scope.Thumbnails)
             {
-                var rel = entry.Name[ThumbnailsPrefix.Length..];
+                var rel = entry.Name[BackupServiceConstants.ThumbnailsPrefix.Length..];
                 targetPath = SafeCombine(thumbnailRoot, rel);
+                thumbnails++;
             }
 
             if (targetPath == null) continue;
 
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-            using var outFs2 = File.Create(targetPath);
-            entry.DataStream!.CopyTo(outFs2);
+            using var outFs = File.Create(targetPath);
+            entry.DataStream!.CopyTo(outFs);
         }
 
-        logger.LogInformation("Archive extracted to disk.");
+        return (uploads, thumbnails);
     }
 
     private static string SafeCombine(string root, string relative)
@@ -195,6 +327,7 @@ public static class RestoreOnBootProcessor
             {
                 "--clean", "--if-exists",
                 "--no-owner", "--no-privileges",
+                "--exit-on-error", // bail on the first real failure rather than continuing past errors
                 "-h", host,
                 "-p", port.ToString(),
                 "-U", user,
@@ -213,10 +346,12 @@ public static class RestoreOnBootProcessor
         await p.WaitForExitAsync();
         if (p.ExitCode != 0)
         {
+            // With --exit-on-error in place, any non-zero exit means a real failure
+            // (not a benign "object did not exist" warning suppressed by --if-exists).
             throw new InvalidOperationException(
                 $"pg_restore exited with code {p.ExitCode}. stdout: {stdout}. stderr: {stderr}");
         }
-        logger.LogInformation("pg_restore completed.");
+        logger.LogInformation("pg_restore completed successfully.");
     }
 
     private static async Task WaitForPostgresAsync(
@@ -252,9 +387,46 @@ public static class RestoreOnBootProcessor
         throw new InvalidOperationException("Postgres did not become ready within 30 seconds.");
     }
 
-    private static string StageExistingTree(string root, string suffix, ILogger logger)
+    private static async Task<int> GetPostgresMajorVersionAsync(
+        string host, int port, string user, string password, string db)
     {
-        if (!Directory.Exists(root)) return Path.Combine(root, suffix);
+        var psi = new ProcessStartInfo
+        {
+            FileName = "psql",
+            ArgumentList =
+            {
+                "-h", host,
+                "-p", port.ToString(),
+                "-U", user,
+                "-d", db,
+                "-t", "-A",
+                "-c", "SHOW server_version_num",
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["PGPASSWORD"] = password;
+
+        using var p = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch psql for version probe.");
+        var output = (await p.StandardOutput.ReadToEndAsync()).Trim();
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0 || !int.TryParse(output, out var verNum))
+        {
+            throw new InvalidOperationException($"Failed to read postgres version (exit {p.ExitCode}): '{output}'");
+        }
+        return verNum / 10000;
+    }
+
+    /// <summary>
+    /// Moves every direct entry of <paramref name="root"/> into a sibling
+    /// <c>{root}/{suffix}</c> directory. Throws if ANY entry cannot be moved —
+    /// a partial stage would leave live files mixed with restored files after
+    /// extraction, producing silent inconsistency.
+    /// </summary>
+    private static string StageExistingTreeStrict(string root, string suffix, ILogger logger)
+    {
         Directory.CreateDirectory(root);
         var stageDir = Path.Combine(root, suffix);
         Directory.CreateDirectory(stageDir);
@@ -263,26 +435,38 @@ public static class RestoreOnBootProcessor
         {
             var name = Path.GetFileName(entry);
             if (string.Equals(name, suffix, StringComparison.Ordinal)) continue;
-            if (name.StartsWith(".pre-restore-", StringComparison.Ordinal)) continue; // already-staged dirs from this run
+            if (name.StartsWith(".pre-restore-", StringComparison.Ordinal)) continue;
             try
             {
                 Directory.Move(entry, Path.Combine(stageDir, name));
             }
             catch (IOException ex)
             {
-                logger.LogWarning(ex, "Failed to stage {Entry}", entry);
+                throw new InvalidOperationException(
+                    $"Failed to stage live entry {entry} into {stageDir}. The restore has been aborted " +
+                    "with live data still in place — fix the cause and retry.", ex);
             }
         }
+        logger.LogInformation("Staged existing tree from {Root} into {StageDir}", root, stageDir);
         return stageDir;
     }
 
-    private static void SweepStalePreRestoreDirs(string root, ILogger logger)
+    private static bool HasStalePreRestoreDirs(string root)
+    {
+        if (!Directory.Exists(root)) return false;
+        return Directory.EnumerateDirectories(root, ".pre-restore-*").Any();
+    }
+
+    private static void WarnAboutStalePreRestoreDirs(string root, ILogger logger)
     {
         if (!Directory.Exists(root)) return;
         foreach (var dir in Directory.EnumerateDirectories(root, ".pre-restore-*"))
         {
-            logger.LogInformation("Removing stale pre-restore directory {Dir}", dir);
-            DeleteDirectoryQuiet(dir, logger);
+            logger.LogWarning(
+                "Pre-restore directory {Dir} still exists from a previous failed restore. " +
+                "It holds the only on-disk copy of your live data from that point. Delete it " +
+                "manually after confirming the current tree is intact.",
+                dir);
         }
     }
 
@@ -298,37 +482,71 @@ public static class RestoreOnBootProcessor
         }
     }
 
+    private static async Task<string> ComputeSha256Async(string filePath)
+    {
+        await using var fs = File.OpenRead(filePath);
+        using var sha = SHA256.Create();
+        var hash = await sha.ComputeHashAsync(fs);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
     private static async Task MoveToFailedAsync(string archive, string failedDir, string reason, ILogger logger)
     {
         logger.LogError("Refusing to restore archive {Archive}: {Reason}", archive, reason);
-        var target = Path.Combine(failedDir, Path.GetFileName(archive));
+        await EnsureArchiveOutOfStagingAsync(archive, failedDir, reason, logger);
+    }
+
+    /// <summary>
+    /// Guarantees the archive does NOT remain at its current path. The primary
+    /// strategy is moving it to <paramref name="failedDir"/>. If that fails, the
+    /// fallback renames it with a <c>.invalid</c> suffix in place, so the next
+    /// boot's <c>*.tar</c> glob ignores it and the container doesn't crash-loop.
+    /// </summary>
+    private static async Task EnsureArchiveOutOfStagingAsync(
+        string archive, string failedDir, string reason, ILogger logger)
+    {
+        if (!File.Exists(archive)) return;
+
+        var fileName = Path.GetFileName(archive);
+        var target = Path.Combine(failedDir, fileName);
         try
         {
+            Directory.CreateDirectory(failedDir);
             if (File.Exists(target)) File.Delete(target);
             File.Move(archive, target);
             await File.WriteAllTextAsync(target + ".error.txt", reason);
+            return;
         }
-        catch (IOException ex)
+        catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to move archive to failed/");
+            logger.LogError(ex,
+                "Could not move archive to failed/. Falling back to in-place rename so it is not retried on next boot.");
+        }
+
+        // Fallback: rename in place with a non-.tar extension so the next boot
+        // skips it. Crash-loop prevention is the priority here.
+        try
+        {
+            var renamed = archive + ".invalid";
+            if (File.Exists(renamed)) File.Delete(renamed);
+            File.Move(archive, renamed);
+            try { await File.WriteAllTextAsync(renamed + ".error.txt", reason); } catch { /* swallow */ }
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex,
+                "Could not rename failed archive in place. Manual cleanup required: delete {Archive} or move it to {FailedDir}.",
+                archive, failedDir);
+            // We deliberately do not throw — the original failure (which the caller
+            // is about to re-throw) is the real issue. This is best-effort cleanup.
         }
     }
+}
 
-    // ── manifest mirror (kept in sync with BackupService.BackupManifest) ─
-
-    private sealed record Manifest(
-        int ManifestVersion,
-        DateTime CreatedAtUtc,
-        int PostgresMajorVersion,
-        ManifestScopeData Scope,
-        ManifestStatsData Stats);
-
-    private sealed record ManifestScopeData(bool Database, bool Uploads, bool Thumbnails);
-
-    private sealed record ManifestStatsData(
-        int UploadsCount,
-        long UploadsBytes,
-        int ThumbnailsCount,
-        long ThumbnailsBytes,
-        long DatabaseDumpBytes);
+internal static class BackupServiceConstants
+{
+    public const string ManifestEntryName = "manifest.json";
+    public const string DatabaseDumpEntryName = "database.dump";
+    public const string UploadsPrefix = "uploads/";
+    public const string ThumbnailsPrefix = "thumbnails/";
 }

--- a/src/WebApi/Infrastructure/RestoreOnBootProcessor.cs
+++ b/src/WebApi/Infrastructure/RestoreOnBootProcessor.cs
@@ -1,0 +1,334 @@
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.Text.Json;
+
+namespace WebApi.Infrastructure;
+
+/// <summary>
+/// Runs before the host is built. If a .tar archive is present in the restore
+/// directory, validates its manifest, then restores Postgres (pg_restore --clean)
+/// and replaces the uploads/thumbnails trees. On success the archive is moved to
+/// restore/processed/. On validation failure it is moved to restore/failed/ and
+/// boot proceeds normally — never destroy live data because of a bad archive.
+/// </summary>
+public static class RestoreOnBootProcessor
+{
+    private const string ManifestEntryName = "manifest.json";
+    private const string DatabaseDumpEntryName = "database.dump";
+    private const string UploadsPrefix = "uploads/";
+    private const string ThumbnailsPrefix = "thumbnails/";
+
+    public static async Task RunAsync(IConfiguration configuration, ILogger logger)
+    {
+        var restoreRoot = configuration["RESTORE_STORAGE_PATH"] ?? "/var/lib/modelibr/restore";
+        var uploadRoot = configuration["UPLOAD_STORAGE_PATH"] ?? "/var/lib/modelibr/uploads";
+        var thumbnailRoot = configuration["THUMBNAIL_STORAGE_PATH"] ?? "/var/lib/modelibr/thumbnails";
+        var processedDir = Path.Combine(restoreRoot, "processed");
+        var failedDir = Path.Combine(restoreRoot, "failed");
+
+        Directory.CreateDirectory(restoreRoot);
+        Directory.CreateDirectory(processedDir);
+        Directory.CreateDirectory(failedDir);
+
+        // Clean up stale .pre-restore-* directories from any previous incomplete run.
+        SweepStalePreRestoreDirs(uploadRoot, logger);
+        SweepStalePreRestoreDirs(thumbnailRoot, logger);
+
+        var archive = Directory.EnumerateFiles(restoreRoot, "*.tar")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (archive == null) return;
+
+        logger.LogInformation("Found staged restore archive {Archive}", archive);
+
+        Manifest? manifest;
+        try
+        {
+            manifest = ReadManifest(archive)
+                ?? throw new InvalidOperationException("Archive does not contain manifest.json.");
+        }
+        catch (Exception ex)
+        {
+            await MoveToFailedAsync(archive, failedDir, $"Manifest read failed: {ex.Message}", logger);
+            return;
+        }
+
+        if (manifest.PostgresMajorVersion != 16)
+        {
+            await MoveToFailedAsync(archive, failedDir,
+                $"Backup Postgres major version {manifest.PostgresMajorVersion} does not match current 16.", logger);
+            return;
+        }
+
+        var host = configuration["POSTGRES_HOST"] ?? "postgres";
+        var port = int.TryParse(configuration["POSTGRES_PORT"], out var p) ? p : 5432;
+        var db = configuration["POSTGRES_DB"] ?? "Modelibr";
+        var user = configuration["POSTGRES_USER"] ?? "modelibr";
+        var password = configuration["POSTGRES_PASSWORD"] ?? string.Empty;
+
+        await WaitForPostgresAsync(host, port, user, password, db, logger);
+
+        // Stage the existing uploads/thumbnails trees to .pre-restore-<ts>/ — preserved
+        // until the entire restore succeeds so we can recover manually on failure.
+        var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
+        var uploadsPreRestore = StageExistingTree(uploadRoot, $".pre-restore-{stamp}", logger);
+        var thumbnailsPreRestore = manifest.Scope.Thumbnails
+            ? StageExistingTree(thumbnailRoot, $".pre-restore-{stamp}", logger)
+            : null;
+
+        var dumpPath = Path.Combine(restoreRoot, $".dump-{stamp}");
+        try
+        {
+            ExtractArchive(archive, dumpPath, uploadRoot, thumbnailRoot, manifest, logger);
+
+            await RunPgRestoreAsync(dumpPath, host, port, user, password, db, logger);
+
+            // Success — drop the pre-restore copies.
+            DeleteDirectoryQuiet(uploadsPreRestore, logger);
+            if (thumbnailsPreRestore != null) DeleteDirectoryQuiet(thumbnailsPreRestore, logger);
+
+            // Move the archive into processed/.
+            var processedPath = Path.Combine(processedDir, $"{stamp}-{Path.GetFileName(archive)}");
+            File.Move(archive, processedPath);
+            logger.LogInformation("Restore completed successfully. Archive moved to {Path}", processedPath);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Restore failed. Pre-restore data preserved at {UploadsBackup}", uploadsPreRestore);
+            await MoveToFailedAsync(archive, failedDir, $"Restore execution failed: {ex.Message}", logger);
+            // Note: pre-restore-* directories are left in place so the operator can recover manually.
+            throw;
+        }
+        finally
+        {
+            if (File.Exists(dumpPath))
+            {
+                try { File.Delete(dumpPath); }
+                catch (IOException ex) { logger.LogWarning(ex, "Failed to delete temp dump {Path}", dumpPath); }
+            }
+        }
+    }
+
+    // ── private ─────────────────────────────────────────────────────────
+
+    private static Manifest? ReadManifest(string tarPath)
+    {
+        using var fs = File.OpenRead(tarPath);
+        using var reader = new TarReader(fs);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry(copyData: true)) != null)
+        {
+            if (entry.Name == ManifestEntryName && entry.DataStream != null)
+            {
+                using var ms = new MemoryStream();
+                entry.DataStream.CopyTo(ms);
+                ms.Position = 0;
+                return JsonSerializer.Deserialize<Manifest>(ms);
+            }
+        }
+        return null;
+    }
+
+    private static void ExtractArchive(
+        string tarPath, string dumpOutputPath,
+        string uploadRoot, string thumbnailRoot,
+        Manifest manifest, ILogger logger)
+    {
+        using var fs = File.OpenRead(tarPath);
+        using var reader = new TarReader(fs);
+        TarEntry? entry;
+        while ((entry = reader.GetNextEntry(copyData: true)) != null)
+        {
+            if (entry.EntryType is not (TarEntryType.RegularFile or TarEntryType.V7RegularFile)) continue;
+
+            if (entry.Name == ManifestEntryName) continue; // already read
+
+            if (entry.Name == DatabaseDumpEntryName)
+            {
+                using var outFs = File.Create(dumpOutputPath);
+                entry.DataStream!.CopyTo(outFs);
+                continue;
+            }
+
+            string? targetPath = null;
+            if (entry.Name.StartsWith(UploadsPrefix, StringComparison.Ordinal))
+            {
+                var rel = entry.Name[UploadsPrefix.Length..];
+                targetPath = SafeCombine(uploadRoot, rel);
+            }
+            else if (entry.Name.StartsWith(ThumbnailsPrefix, StringComparison.Ordinal) && manifest.Scope.Thumbnails)
+            {
+                var rel = entry.Name[ThumbnailsPrefix.Length..];
+                targetPath = SafeCombine(thumbnailRoot, rel);
+            }
+
+            if (targetPath == null) continue;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            using var outFs2 = File.Create(targetPath);
+            entry.DataStream!.CopyTo(outFs2);
+        }
+
+        logger.LogInformation("Archive extracted to disk.");
+    }
+
+    private static string SafeCombine(string root, string relative)
+    {
+        // Defense against zip-slip: ensure the resolved path stays under root.
+        var combined = Path.GetFullPath(Path.Combine(root, relative));
+        var rootFull = Path.GetFullPath(root);
+        if (!combined.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            && combined != rootFull)
+        {
+            throw new InvalidOperationException($"Archive entry escapes root: {relative}");
+        }
+        return combined;
+    }
+
+    private static async Task RunPgRestoreAsync(
+        string dumpPath, string host, int port, string user, string password, string db, ILogger logger)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "pg_restore",
+            ArgumentList =
+            {
+                "--clean", "--if-exists",
+                "--no-owner", "--no-privileges",
+                "-h", host,
+                "-p", port.ToString(),
+                "-U", user,
+                "-d", db,
+                dumpPath,
+            },
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["PGPASSWORD"] = password;
+
+        using var p = Process.Start(psi) ?? throw new InvalidOperationException("Failed to launch pg_restore.");
+        var stderr = await p.StandardError.ReadToEndAsync();
+        var stdout = await p.StandardOutput.ReadToEndAsync();
+        await p.WaitForExitAsync();
+        if (p.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"pg_restore exited with code {p.ExitCode}. stdout: {stdout}. stderr: {stderr}");
+        }
+        logger.LogInformation("pg_restore completed.");
+    }
+
+    private static async Task WaitForPostgresAsync(
+        string host, int port, string user, string password, string db, ILogger logger)
+    {
+        for (var attempt = 1; attempt <= 30; attempt++)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "pg_isready",
+                ArgumentList = { "-h", host, "-p", port.ToString(), "-U", user, "-d", db },
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            };
+            psi.Environment["PGPASSWORD"] = password;
+            try
+            {
+                using var p = Process.Start(psi);
+                if (p != null)
+                {
+                    await p.WaitForExitAsync();
+                    if (p.ExitCode == 0) return;
+                }
+            }
+            catch
+            {
+                // try again
+            }
+            logger.LogInformation("Postgres not ready (attempt {Attempt}/30), retrying...", attempt);
+            await Task.Delay(1000);
+        }
+        throw new InvalidOperationException("Postgres did not become ready within 30 seconds.");
+    }
+
+    private static string StageExistingTree(string root, string suffix, ILogger logger)
+    {
+        if (!Directory.Exists(root)) return Path.Combine(root, suffix);
+        Directory.CreateDirectory(root);
+        var stageDir = Path.Combine(root, suffix);
+        Directory.CreateDirectory(stageDir);
+
+        foreach (var entry in Directory.EnumerateFileSystemEntries(root))
+        {
+            var name = Path.GetFileName(entry);
+            if (string.Equals(name, suffix, StringComparison.Ordinal)) continue;
+            if (name.StartsWith(".pre-restore-", StringComparison.Ordinal)) continue; // already-staged dirs from this run
+            try
+            {
+                Directory.Move(entry, Path.Combine(stageDir, name));
+            }
+            catch (IOException ex)
+            {
+                logger.LogWarning(ex, "Failed to stage {Entry}", entry);
+            }
+        }
+        return stageDir;
+    }
+
+    private static void SweepStalePreRestoreDirs(string root, ILogger logger)
+    {
+        if (!Directory.Exists(root)) return;
+        foreach (var dir in Directory.EnumerateDirectories(root, ".pre-restore-*"))
+        {
+            logger.LogInformation("Removing stale pre-restore directory {Dir}", dir);
+            DeleteDirectoryQuiet(dir, logger);
+        }
+    }
+
+    private static void DeleteDirectoryQuiet(string dir, ILogger logger)
+    {
+        try
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+        catch (IOException ex)
+        {
+            logger.LogWarning(ex, "Failed to delete {Dir}", dir);
+        }
+    }
+
+    private static async Task MoveToFailedAsync(string archive, string failedDir, string reason, ILogger logger)
+    {
+        logger.LogError("Refusing to restore archive {Archive}: {Reason}", archive, reason);
+        var target = Path.Combine(failedDir, Path.GetFileName(archive));
+        try
+        {
+            if (File.Exists(target)) File.Delete(target);
+            File.Move(archive, target);
+            await File.WriteAllTextAsync(target + ".error.txt", reason);
+        }
+        catch (IOException ex)
+        {
+            logger.LogError(ex, "Failed to move archive to failed/");
+        }
+    }
+
+    // ── manifest mirror (kept in sync with BackupService.BackupManifest) ─
+
+    private sealed record Manifest(
+        int ManifestVersion,
+        DateTime CreatedAtUtc,
+        int PostgresMajorVersion,
+        ManifestScopeData Scope,
+        ManifestStatsData Stats);
+
+    private sealed record ManifestScopeData(bool Database, bool Uploads, bool Thumbnails);
+
+    private sealed record ManifestStatsData(
+        int UploadsCount,
+        long UploadsBytes,
+        int ThumbnailsCount,
+        long ThumbnailsBytes,
+        long DatabaseDumpBytes);
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -23,6 +23,13 @@ namespace WebApi
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            // Process any backup archive staged in the restore directory BEFORE
+            // any database connections are opened. If an archive is present and
+            // valid, it replaces the current DB + uploads tree. Validation failures
+            // move the archive to restore/failed/ and boot continues normally.
+            await RestoreOnBootProcessor.RunAsync(builder.Configuration,
+                LoggerFactory.Create(b => b.AddConsole()).CreateLogger("RestoreOnBoot"));
+
             // Allow uploads up to 1 GB (Kestrel + form options)
             const long maxFileSize = 1L * 1024 * 1024 * 1024; // 1 GB
 
@@ -143,6 +150,7 @@ namespace WebApi
             app.MapEnvironmentMapEndpoints();
             app.MapBlenderEndpoints();
             app.MapAudioSelectionEndpoints();
+            app.MapBackupEndpoints();
 
             // Map SignalR hubs
             app.MapHub<ThumbnailHub>("/thumbnailHub");

--- a/src/frontend/src/components/tabs/Settings.css
+++ b/src/frontend/src/components/tabs/Settings.css
@@ -681,3 +681,184 @@
 .webdav-status-badge {
   font-size: 0.82em;
 }
+
+/* ── Backups & Restore ─────────────────────────────────────────────── */
+
+.backups-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.backups-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.backups-storage-line code {
+  background: var(--surface-card, rgba(255, 255, 255, 0.05));
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.backups-empty {
+  padding: 1rem;
+  font-style: italic;
+}
+
+.backups-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+
+.backups-table th,
+.backups-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--surface-border);
+  vertical-align: top;
+}
+
+.backups-table th {
+  font-weight: 600;
+  color: var(--text-color-secondary);
+  font-size: 0.82em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.backups-row--in_progress {
+  opacity: 0.85;
+}
+
+.backups-row--failed {
+  background: rgba(255, 0, 0, 0.06);
+}
+
+.backups-filename {
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.backups-pathline {
+  font-size: 0.82em;
+  color: var(--text-color-secondary);
+  margin-top: 0.15rem;
+}
+
+.backups-pathline code {
+  background: var(--surface-card, rgba(255, 255, 255, 0.05));
+  padding: 1px 5px;
+  border-radius: 3px;
+  word-break: break-all;
+}
+
+.backups-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.backups-badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.82em;
+  border-radius: 3px;
+  border: 1px solid transparent;
+}
+
+.backups-badge--progress {
+  background: rgba(50, 115, 220, 0.15);
+  border-color: rgba(50, 115, 220, 0.4);
+  color: var(--text-color);
+}
+
+.backups-badge--failed {
+  background: rgba(220, 50, 50, 0.15);
+  border-color: rgba(220, 50, 50, 0.5);
+  color: #ffb3b3;
+}
+
+.backups-help-details {
+  margin-top: 0.5rem;
+  font-size: 0.9em;
+}
+
+.backups-help-details summary {
+  cursor: pointer;
+  color: var(--text-color-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.backups-help-details code {
+  background: var(--surface-card, rgba(255, 255, 255, 0.05));
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+/* ── Create backup modal ──────────────────────────────────────────── */
+
+.backups-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.backups-modal {
+  background: var(--surface-ground);
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  padding: 1.5rem;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+  color: var(--text-color);
+}
+
+.backups-modal-title {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.backups-modal-intro {
+  margin: 0 0 0.5rem 0;
+  color: var(--text-color-secondary);
+}
+
+.backups-modal-body label {
+  margin-bottom: 0.4rem;
+}
+
+.backups-modal-size {
+  margin-left: 0.5rem;
+  font-size: 0.82em;
+  color: var(--text-color-secondary);
+}
+
+.backups-modal-help {
+  display: block;
+  margin: 0.25rem 0 0.75rem 1.6rem;
+}
+
+.backups-modal-estimate {
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--surface-card, rgba(255, 255, 255, 0.05));
+  border-radius: 4px;
+  font-size: 0.92em;
+}
+
+.backups-modal-actions {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/src/frontend/src/components/tabs/Settings.tsx
+++ b/src/frontend/src/components/tabs/Settings.tsx
@@ -33,6 +33,8 @@ import {
   useUIPreferencesStore,
 } from '@/stores/uiPreferencesStore'
 
+import { BackupsSection } from '@/features/settings/BackupsSection'
+
 import { WebDavInstructions } from './WebDavInstructions'
 
 interface SettingsData {
@@ -92,9 +94,9 @@ export function Settings(): JSX.Element {
   const [webDavInstructionsExpanded, setWebDavInstructionsExpanded] =
     useState(false)
 
-  // Accordion state — in demo mode sections 5 (Blender), 6 (SSL), 7 (WebDAV) stay collapsed
+  // Accordion state — in demo mode sections 5 (Blender), 6 (SSL), 7 (WebDAV), 8 (Backups) stay collapsed
   const [activeIndex, setActiveIndex] = useState<number | number[]>(
-    isDemo ? [0, 1, 2, 3, 4] : [0, 1, 2, 3, 4, 5, 6, 7]
+    isDemo ? [0, 1, 2, 3, 4] : [0, 1, 2, 3, 4, 5, 6, 7, 8]
   )
 
   // Model duplicate name policy state
@@ -1360,6 +1362,40 @@ export function Settings(): JSX.Element {
                 </div>
               </div>
             )}
+          </div>
+
+          {/* ── Backup & Restore ───────────────────────────────────── */}
+          <div className="settings-section">
+            <div
+              className={`settings-section-header${isDemo ? ' settings-section-header--locked' : ''}`}
+              onClick={() => {
+                if (isDemo) return
+                setActiveIndex(prev =>
+                  Array.isArray(prev)
+                    ? prev.includes(8)
+                      ? prev.filter(i => i !== 8)
+                      : [...prev, 8]
+                    : [8]
+                )
+              }}
+            >
+              <span>
+                {isDemo
+                  ? '🔒'
+                  : Array.isArray(activeIndex) && activeIndex.includes(8)
+                    ? '▼'
+                    : '▶'}{' '}
+                Backup &amp; Restore
+              </span>
+              {isDemo && (
+                <span className="settings-demo-notice">
+                  Not available in demo mode
+                </span>
+              )}
+            </div>
+            {!isDemo &&
+              Array.isArray(activeIndex) &&
+              activeIndex.includes(8) && <BackupsSection />}
           </div>
         </div>
 

--- a/src/frontend/src/components/tabs/Settings.tsx
+++ b/src/frontend/src/components/tabs/Settings.tsx
@@ -25,6 +25,7 @@ import {
   updateSetting,
   updateSettings,
 } from '@/features/settings/api/settingsApi'
+import { BackupsSection } from '@/features/settings/BackupsSection'
 import { useTheme } from '@/hooks/useTheme'
 import { settingsFormSchema } from '@/shared/validation/formSchemas'
 import { useBlenderEnabledStore } from '@/stores/blenderEnabledStore'
@@ -32,8 +33,6 @@ import {
   type MobileBarPosition,
   useUIPreferencesStore,
 } from '@/stores/uiPreferencesStore'
-
-import { BackupsSection } from '@/features/settings/BackupsSection'
 
 import { WebDavInstructions } from './WebDavInstructions'
 

--- a/src/frontend/src/features/settings/BackupsSection.tsx
+++ b/src/frontend/src/features/settings/BackupsSection.tsx
@@ -1,0 +1,387 @@
+import { confirmDialog } from 'primereact/confirmdialog'
+import { type JSX, useCallback, useEffect, useState } from 'react'
+
+import {
+  type BackupSizeEstimate,
+  type BackupStorageInfo,
+  type BackupSummary,
+  createBackup,
+  deleteBackup,
+  getBackupDownloadUrl,
+  getBackupSizeEstimate,
+  getBackupStorageInfo,
+  listBackups,
+  stageRestore,
+} from './api/backupsApi'
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)))
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+interface CreateModalProps {
+  estimate: BackupSizeEstimate | null
+  onCancel: () => void
+  onCreate: (includeThumbnails: boolean) => Promise<void>
+  isSubmitting: boolean
+}
+
+function CreateBackupModal({
+  estimate,
+  onCancel,
+  onCreate,
+  isSubmitting,
+}: CreateModalProps): JSX.Element {
+  const [includeThumbnails, setIncludeThumbnails] = useState(false)
+
+  const projected =
+    estimate == null
+      ? null
+      : estimate.databaseBytes +
+        estimate.uploadsBytes +
+        (includeThumbnails ? estimate.thumbnailsBytes : 0)
+
+  return (
+    <div className="backups-modal-overlay" role="dialog" aria-modal="true">
+      <div className="backups-modal">
+        <h3 className="backups-modal-title">Create backup</h3>
+        <div className="backups-modal-body">
+          <p className="backups-modal-intro">Include:</p>
+
+          <label className="settings-checkbox-label">
+            <input type="checkbox" checked disabled />
+            <span>
+              Database <em>(always — required)</em>
+              {estimate && (
+                <span className="backups-modal-size">
+                  ~{formatBytes(estimate.databaseBytes)}
+                </span>
+              )}
+            </span>
+          </label>
+
+          <label className="settings-checkbox-label">
+            <input type="checkbox" checked disabled />
+            <span>
+              Uploaded files <em>(always — required)</em>
+              {estimate && (
+                <span className="backups-modal-size">
+                  ~{formatBytes(estimate.uploadsBytes)}
+                </span>
+              )}
+            </span>
+          </label>
+
+          <label className="settings-checkbox-label">
+            <input
+              type="checkbox"
+              checked={includeThumbnails}
+              onChange={e => setIncludeThumbnails(e.target.checked)}
+              disabled={isSubmitting}
+            />
+            <span>
+              Thumbnails <em>(optional)</em>
+              {estimate && (
+                <span className="backups-modal-size">
+                  ~{formatBytes(estimate.thumbnailsBytes)}
+                </span>
+              )}
+            </span>
+          </label>
+          <span className="settings-help backups-modal-help">
+            Auto-generated thumbnails can be regenerated, but custom-uploaded
+            thumbnails cannot — include this if you've uploaded custom ones.
+          </span>
+
+          {projected != null && (
+            <div className="backups-modal-estimate">
+              Projected archive size: <strong>~{formatBytes(projected)}</strong>
+            </div>
+          )}
+        </div>
+
+        <div className="backups-modal-actions">
+          <button
+            type="button"
+            className="settings-button settings-button-secondary"
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="settings-button settings-button-primary"
+            onClick={() => void onCreate(includeThumbnails)}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Starting…' : 'Create backup'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function BackupsSection(): JSX.Element {
+  const [backups, setBackups] = useState<BackupSummary[]>([])
+  const [storage, setStorage] = useState<BackupStorageInfo | null>(null)
+  const [estimate, setEstimate] = useState<BackupSizeEstimate | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      const [list, store] = await Promise.all([
+        listBackups(),
+        getBackupStorageInfo(),
+      ])
+      setBackups(list.backups)
+      setStorage(store)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load backups')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  // Poll while a backup is in progress.
+  useEffect(() => {
+    const hasInProgress = backups.some(b => b.status === 'in_progress')
+    if (!hasInProgress) return
+    const interval = setInterval(() => {
+      void refresh()
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [backups, refresh])
+
+  const openCreate = async () => {
+    setShowCreate(true)
+    try {
+      const e = await getBackupSizeEstimate()
+      setEstimate(e)
+    } catch {
+      setEstimate(null)
+    }
+  }
+
+  const handleCreate = async (includeThumbnails: boolean) => {
+    setIsCreating(true)
+    setError(null)
+    setInfo(null)
+    try {
+      const created = await createBackup(includeThumbnails)
+      setInfo(`Backup ${created.fileName} started.`)
+      setShowCreate(false)
+      void refresh()
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to start backup'
+      )
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const handleDelete = (fileName: string) => {
+    confirmDialog({
+      message: `Delete backup ${fileName}? This frees disk space but cannot be undone.`,
+      header: 'Delete backup',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'Delete',
+      rejectLabel: 'Cancel',
+      acceptClassName: 'p-button-danger',
+      accept: async () => {
+        try {
+          await deleteBackup(fileName)
+          setInfo(`Deleted ${fileName}.`)
+          void refresh()
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to delete backup'
+          )
+        }
+      },
+    })
+  }
+
+  const handleRestore = (fileName: string) => {
+    confirmDialog({
+      message: `Restore ${fileName}? On next webapi restart this backup will REPLACE the current database and uploads. The existing data will be preserved in pre-restore directories until the restore completes successfully.`,
+      header: 'Stage backup for restore',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'Stage restore',
+      rejectLabel: 'Cancel',
+      acceptClassName: 'p-button-danger',
+      accept: async () => {
+        try {
+          const result = await stageRestore(fileName)
+          setInfo(result.message)
+        } catch (err) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to stage restore'
+          )
+        }
+      },
+    })
+  }
+
+  return (
+    <div className="settings-section-content backups-section">
+      {error && (
+        <div className="settings-error">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+      {info && <div className="settings-success">{info}</div>}
+
+      <div className="backups-toolbar">
+        <button
+          type="button"
+          onClick={() => void openCreate()}
+          className="settings-button settings-button-primary"
+          disabled={backups.some(b => b.status === 'in_progress')}
+        >
+          Create backup
+        </button>
+        {storage && (
+          <span className="settings-help backups-storage-line">
+            <code>{storage.hostPath}</code> on host —{' '}
+            <strong>{formatBytes(storage.totalUsedBytes)}</strong> used by{' '}
+            {backups.length} archive{backups.length === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="settings-help">Loading backups…</div>
+      ) : backups.length === 0 ? (
+        <div className="settings-help backups-empty">
+          No backups yet. Click <em>Create backup</em> to make the first one.
+        </div>
+      ) : (
+        <table className="backups-table">
+          <thead>
+            <tr>
+              <th>File</th>
+              <th>Created</th>
+              <th>Size</th>
+              <th>Contents</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {backups.map(b => (
+              <tr key={b.fileName} className={`backups-row backups-row--${b.status}`}>
+                <td>
+                  <div className="backups-filename">{b.fileName}</div>
+                  <div className="backups-pathline">
+                    <code>{b.hostPath}</code>
+                  </div>
+                </td>
+                <td>{formatDate(b.createdAtUtc)}</td>
+                <td>
+                  {b.status === 'in_progress'
+                    ? '—'
+                    : formatBytes(b.sizeBytes)}
+                </td>
+                <td>
+                  DB + uploads
+                  {b.includesThumbnails ? ' + thumbnails' : ''}
+                </td>
+                <td className="backups-actions">
+                  {b.status === 'in_progress' ? (
+                    <span className="backups-badge backups-badge--progress">
+                      Creating…
+                    </span>
+                  ) : b.status === 'failed' ? (
+                    <span
+                      className="backups-badge backups-badge--failed"
+                      title={b.error ?? ''}
+                    >
+                      Failed
+                    </span>
+                  ) : (
+                    <>
+                      <a
+                        className="settings-button-small primary"
+                        href={getBackupDownloadUrl(b.fileName)}
+                        download={b.fileName}
+                      >
+                        Download
+                      </a>
+                      <button
+                        type="button"
+                        className="settings-button-small"
+                        onClick={() => handleRestore(b.fileName)}
+                      >
+                        Restore
+                      </button>
+                      <button
+                        type="button"
+                        className="settings-button-small danger"
+                        onClick={() => handleDelete(b.fileName)}
+                      >
+                        Delete
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <details className="backups-help-details">
+        <summary>About backup and restore</summary>
+        <ul>
+          <li>
+            Backups are stored on the server at{' '}
+            <code>{storage?.hostPath ?? './data/backups'}</code>. Copy the file
+            off-host (scp, rsync, NAS, S3) to satisfy the 3-2-1 rule.
+          </li>
+          <li>
+            Restore works by staging the archive into <code>./data/restore/</code>{' '}
+            and restarting the webapi container. On boot, the database and
+            uploads are replaced; pre-existing data is preserved in{' '}
+            <code>.pre-restore-*</code> directories until the restore
+            completes successfully.
+          </li>
+          <li>
+            Postgres major version of the backup must match the running server
+            (currently 16). Mismatched archives are moved to{' '}
+            <code>./data/restore/failed/</code> without touching live data.
+          </li>
+        </ul>
+      </details>
+
+      {showCreate && (
+        <CreateBackupModal
+          estimate={estimate}
+          onCancel={() => setShowCreate(false)}
+          onCreate={handleCreate}
+          isSubmitting={isCreating}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/frontend/src/features/settings/BackupsSection.tsx
+++ b/src/frontend/src/features/settings/BackupsSection.tsx
@@ -17,7 +17,10 @@ import {
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
-  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)))
+  const i = Math.min(
+    units.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024))
+  )
   return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`
 }
 
@@ -193,9 +196,7 @@ export function BackupsSection(): JSX.Element {
       setShowCreate(false)
       void refresh()
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to start backup'
-      )
+      setError(err instanceof Error ? err.message : 'Failed to start backup')
     } finally {
       setIsCreating(false)
     }
@@ -290,7 +291,10 @@ export function BackupsSection(): JSX.Element {
           </thead>
           <tbody>
             {backups.map(b => (
-              <tr key={b.fileName} className={`backups-row backups-row--${b.status}`}>
+              <tr
+                key={b.fileName}
+                className={`backups-row backups-row--${b.status}`}
+              >
                 <td>
                   <div className="backups-filename">{b.fileName}</div>
                   <div className="backups-pathline">
@@ -299,9 +303,7 @@ export function BackupsSection(): JSX.Element {
                 </td>
                 <td>{formatDate(b.createdAtUtc)}</td>
                 <td>
-                  {b.status === 'in_progress'
-                    ? '—'
-                    : formatBytes(b.sizeBytes)}
+                  {b.status === 'in_progress' ? '—' : formatBytes(b.sizeBytes)}
                 </td>
                 <td>
                   DB + uploads
@@ -360,11 +362,11 @@ export function BackupsSection(): JSX.Element {
             off-host (scp, rsync, NAS, S3) to satisfy the 3-2-1 rule.
           </li>
           <li>
-            Restore works by staging the archive into <code>./data/restore/</code>{' '}
-            and restarting the webapi container. On boot, the database and
-            uploads are replaced; pre-existing data is preserved in{' '}
-            <code>.pre-restore-*</code> directories until the restore
-            completes successfully.
+            Restore works by staging the archive into{' '}
+            <code>./data/restore/</code> and restarting the webapi container. On
+            boot, the database and uploads are replaced; pre-existing data is
+            preserved in <code>.pre-restore-*</code> directories until the
+            restore completes successfully.
           </li>
           <li>
             Postgres major version of the backup must match the running server

--- a/src/frontend/src/features/settings/api/backupsApi.ts
+++ b/src/frontend/src/features/settings/api/backupsApi.ts
@@ -1,0 +1,66 @@
+import { baseURL, client } from '@/lib/apiBase'
+
+export interface BackupSummary {
+  fileName: string
+  sizeBytes: number
+  createdAtUtc: string
+  status: 'in_progress' | 'ready' | 'failed'
+  hostPath: string
+  containerPath: string
+  includesThumbnails: boolean
+  error: string | null
+}
+
+export interface BackupStorageInfo {
+  hostPath: string
+  containerPath: string
+  totalUsedBytes: number
+}
+
+export interface BackupSizeEstimate {
+  databaseBytes: number
+  uploadsBytes: number
+  thumbnailsBytes: number
+}
+
+export async function listBackups(): Promise<{ backups: BackupSummary[] }> {
+  const response = await client.get('/backups')
+  return response.data
+}
+
+export async function getBackupStorageInfo(): Promise<BackupStorageInfo> {
+  const response = await client.get('/backups/storage')
+  return response.data
+}
+
+export async function getBackupSizeEstimate(): Promise<BackupSizeEstimate> {
+  const response = await client.get('/backups/estimate')
+  return response.data
+}
+
+export async function createBackup(
+  includeThumbnails: boolean
+): Promise<BackupSummary> {
+  const response = await client.post('/backups', { includeThumbnails })
+  return response.data
+}
+
+export async function deleteBackup(fileName: string): Promise<void> {
+  await client.delete(`/backups/${encodeURIComponent(fileName)}`)
+}
+
+export async function stageRestore(
+  fileName: string
+): Promise<{ staged: boolean; message: string }> {
+  const response = await client.post(
+    `/backups/${encodeURIComponent(fileName)}/restore`
+  )
+  return response.data
+}
+
+export function getBackupDownloadUrl(fileName: string): string {
+  const path = `/backups/${encodeURIComponent(fileName)}`
+  // baseURL may be relative ("/api") or absolute ("http://...") — match either.
+  if (baseURL.startsWith('/')) return `${baseURL}${path}`
+  return new URL(path, baseURL).toString()
+}

--- a/tests/backup-restore-e2e/.gitignore
+++ b/tests/backup-restore-e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+data/
+test-results/
+playwright-report/
+*.log

--- a/tests/backup-restore-e2e/README.md
+++ b/tests/backup-restore-e2e/README.md
@@ -1,0 +1,73 @@
+# Backup & Restore E2E
+
+Isolated end-to-end test suite covering the `/backups` API and the Settings UI
+"Backup & Restore" section, plus the restore-on-boot path that runs in
+`Program.Main` before the host is built.
+
+Lives in its own docker-compose stack so it never interferes with the main
+`tests/e2e/` suite — different container names, different ports, different
+named volumes, and the `data/` directory is bind-mounted locally so specs can
+inspect and mutate it.
+
+## What's covered
+
+| Spec | Surface | Coverage |
+| --- | --- | --- |
+| `01-create-list-download.spec.ts` | UI + API | Creating a backup via the modal, watching the row flip from `in_progress` → `ready`, downloading it (verifying the first tar entry is `database.dump`), and deleting it. |
+| `02-restore-roundtrip.spec.ts` | UI + Docker | Seed a model → backup → soft-delete the model → stage restore via the UI button → restart `webapi-backup-e2e` → assert the model is back and the archive was moved to `restore/processed/`. |
+| `03-concurrent-conflict.spec.ts` | API | Two simultaneous `POST /backups` → second returns 409. Path-traversal in delete returns 400. Download of unknown filename returns 404. |
+| `04-bad-archive-rejected.spec.ts` | API + Docker | Drop garbage bytes into `data/restore/` → restart → assert the archive lands in `restore/failed/` with an `.error.txt` sibling and live data is untouched. |
+
+## Stack layout
+
+| Service | Container | Host port |
+| --- | --- | --- |
+| `webapi-backup-e2e` | webapi | `8190` |
+| `frontend-backup-e2e` | frontend | `3102` |
+| `postgres-backup-e2e` | postgres | `5434` |
+
+Data is bind-mounted under `tests/backup-restore-e2e/data/` so the host can:
+
+- Inspect `data/backups/` after a backup runs.
+- Drop a corrupted archive into `data/restore/` to test rejection.
+- Confirm `data/restore/processed/` and `data/restore/failed/` after restart.
+
+## Running
+
+```bash
+cd tests/backup-restore-e2e
+npm install
+npm run test:setup        # playwright install + docker compose up --build + wait for /health
+npm test                  # run all specs
+npm run test:teardown     # docker compose down -v + rm -rf data/
+```
+
+`test:setup` runs `npx playwright install --with-deps chromium` for you — Playwright
+ships without browser binaries, and running specs without them gives the
+"Executable doesn't exist at .../chrome-headless-shell" error.
+
+Or, all-in-one (sets up, runs, tears down — exits with the test runner's status):
+
+```bash
+npm run test:full
+```
+
+The HTML report is at `playwright-report/index.html`:
+
+```bash
+npm run test:report
+```
+
+## Notes
+
+- This suite uses Playwright's runner but only one project, `workers: 1`,
+  `fullyParallel: false` — restore-on-boot tests restart the webapi container
+  and cannot share a stack.
+- The `01-` and `03-` specs delete pre-existing backups in `beforeAll` so each
+  run starts clean. The `02-` and `04-` specs mutate the running stack and
+  expect to own it for their duration.
+- Test assets are pulled from `../e2e/assets/test-cube.glb`. If you remove the
+  main e2e suite's assets these specs will skip themselves.
+- `postgresql-client-16` is installed in the WebApi image at build time
+  (matching `postgres:16-alpine`). The first `test:setup` therefore takes a
+  bit longer; subsequent runs hit the layer cache.

--- a/tests/backup-restore-e2e/docker-compose.backup-e2e.yml
+++ b/tests/backup-restore-e2e/docker-compose.backup-e2e.yml
@@ -1,0 +1,86 @@
+services:
+    webapi-backup-e2e:
+        build:
+            context: ../../
+            dockerfile: src/WebApi/Dockerfile
+            args:
+                APP_UID: ${HOST_UID:-1000}
+                APP_GID: ${HOST_GID:-1000}
+        container_name: webapi-backup-e2e
+        environment:
+            - ASPNETCORE_ENVIRONMENT=Development
+            - ASPNETCORE_HTTP_PORTS=8080
+            - UPLOAD_STORAGE_PATH=/var/lib/modelibr/uploads
+            - BACKUP_STORAGE_PATH=/var/lib/modelibr/backups
+            - RESTORE_STORAGE_PATH=/var/lib/modelibr/restore
+            - THUMBNAIL_STORAGE_PATH=/var/lib/modelibr/thumbnails
+            - POSTGRES_HOST=postgres-backup-e2e
+            - POSTGRES_PORT=5432
+            - POSTGRES_DB=Modelibr
+            - POSTGRES_USER=modelibr
+            - POSTGRES_PASSWORD=backup_e2e_password
+            - ConnectionStrings__Default=Host=postgres-backup-e2e;Port=5432;Database=Modelibr;Username=modelibr;Password=backup_e2e_password;
+            - DisableHttpsRedirection=true
+            - AllowedOrigins__0=http://localhost:3102
+            - AllowedOrigins__1=http://localhost:8190
+            - BLENDER_INSTALL_PATH=/var/lib/modelibr/blender
+        ports:
+            - "8190:8080"
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+            start_period: 30s
+        volumes:
+            # Bind-mount everything under ./data/ so tests can inspect and
+            # manipulate files directly (e.g. drop a bad archive into restore/).
+            - ./data/uploads:/var/lib/modelibr/uploads
+            - ./data/backups:/var/lib/modelibr/backups
+            - ./data/restore:/var/lib/modelibr/restore
+            - ./data/thumbnails:/var/lib/modelibr/thumbnails
+            - blender-data-backup:/var/lib/modelibr/blender
+        depends_on:
+            postgres-backup-e2e:
+                condition: service_healthy
+        networks:
+            - backup-e2e-net
+    frontend-backup-e2e:
+        build:
+            context: ../../src/frontend
+            dockerfile: Dockerfile
+            target: production
+            additional_contexts:
+                asset-processor: ../../src/asset-processor
+            args:
+                VITE_API_BASE_URL: http://localhost:8190
+        container_name: frontend-backup-e2e
+        ports:
+            - "3102:80"
+        networks:
+            - backup-e2e-net
+    postgres-backup-e2e:
+        image: postgres:16-alpine
+        container_name: postgres-backup-e2e
+        environment:
+            POSTGRES_DB: Modelibr
+            POSTGRES_USER: modelibr
+            POSTGRES_PASSWORD: backup_e2e_password
+        ports:
+            - "5434:5432"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U modelibr -d Modelibr"]
+            interval: 5s
+            timeout: 5s
+            retries: 10
+        volumes:
+            - ./data/postgres:/var/lib/postgresql/data
+        networks:
+            - backup-e2e-net
+
+networks:
+    backup-e2e-net:
+        driver: bridge
+
+volumes:
+    blender-data-backup:

--- a/tests/backup-restore-e2e/helpers/backup-api.ts
+++ b/tests/backup-restore-e2e/helpers/backup-api.ts
@@ -1,0 +1,252 @@
+import axios, { AxiosInstance } from "axios";
+import FormData from "form-data";
+import fs from "fs";
+
+export interface BackupSummary {
+    fileName: string;
+    sizeBytes: number;
+    createdAtUtc: string;
+    status: "in_progress" | "ready" | "failed";
+    hostPath: string;
+    containerPath: string;
+    includesThumbnails: boolean;
+    error: string | null;
+}
+
+export class BackupApi {
+    public readonly baseURL: string;
+    private client: AxiosInstance;
+
+    constructor(baseURL: string = process.env.API_BASE_URL || "http://localhost:8190") {
+        this.baseURL = baseURL;
+        this.client = axios.create({
+            baseURL,
+            timeout: 120000,
+            validateStatus: () => true,
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity,
+        });
+    }
+
+    async health(): Promise<number> {
+        const r = await this.client.get("/health");
+        return r.status;
+    }
+
+    // ── Backups ─────────────────────────────────────────────────────────
+
+    async listBackups(): Promise<BackupSummary[]> {
+        const r = await this.client.get("/backups");
+        if (r.status !== 200) throw new Error(`list /backups → ${r.status}`);
+        return r.data.backups;
+    }
+
+    async createBackup(includeThumbnails: boolean): Promise<{ status: number; data: BackupSummary }> {
+        const r = await this.client.post("/backups", { includeThumbnails });
+        return { status: r.status, data: r.data };
+    }
+
+    async deleteBackup(fileName: string): Promise<number> {
+        const r = await this.client.delete(`/backups/${encodeURIComponent(fileName)}`);
+        return r.status;
+    }
+
+    async downloadBackup(fileName: string): Promise<{ status: number; bytes: Buffer; contentType?: string }> {
+        const r = await this.client.get(`/backups/${encodeURIComponent(fileName)}`, {
+            responseType: "arraybuffer",
+        });
+        const ct = r.headers["content-type"];
+        return {
+            status: r.status,
+            bytes: Buffer.from(r.data),
+            contentType: typeof ct === "string" ? ct : undefined,
+        };
+    }
+
+    async stageRestore(fileName: string): Promise<{ status: number; data: any }> {
+        const r = await this.client.post(`/backups/${encodeURIComponent(fileName)}/restore`);
+        return { status: r.status, data: r.data };
+    }
+
+    async storageInfo(): Promise<{ hostPath: string; containerPath: string; totalUsedBytes: number }> {
+        const r = await this.client.get("/backups/storage");
+        if (r.status !== 200) throw new Error(`storage → ${r.status}`);
+        return r.data;
+    }
+
+    async waitForBackupReady(fileName: string, timeoutMs: number = 120000): Promise<BackupSummary> {
+        const deadline = Date.now() + timeoutMs;
+        let lastSummary: BackupSummary | undefined;
+        while (Date.now() < deadline) {
+            const list = await this.listBackups();
+            const match = list.find((b) => b.fileName === fileName);
+            if (match) {
+                lastSummary = match;
+                if (match.status === "ready") return match;
+                if (match.status === "failed") {
+                    throw new Error(`Backup ${fileName} failed: ${match.error}`);
+                }
+            }
+            await new Promise((r) => setTimeout(r, 500));
+        }
+        throw new Error(
+            `Backup ${fileName} did not become ready within ${timeoutMs}ms. Last status: ${lastSummary?.status ?? "missing"}`,
+        );
+    }
+
+    // ── Models ──────────────────────────────────────────────────────────
+
+    async uploadModel(filePath: string): Promise<{ status: number; data: any }> {
+        const formData = new FormData();
+        formData.append("file", fs.createReadStream(filePath));
+        const r = await this.client.post("/models", formData, {
+            headers: formData.getHeaders(),
+        });
+        return { status: r.status, data: r.data };
+    }
+
+    async createModelVersion(modelId: number, filePath: string): Promise<{ status: number; data: any }> {
+        const formData = new FormData();
+        formData.append("file", fs.createReadStream(filePath));
+        const r = await this.client.post(`/models/${modelId}/versions?setAsActive=true`, formData, {
+            headers: formData.getHeaders(),
+        });
+        return { status: r.status, data: r.data };
+    }
+
+    async listModels(): Promise<any[]> {
+        const r = await this.client.get("/models");
+        if (r.status !== 200) throw new Error(`list /models → ${r.status}`);
+        return Array.isArray(r.data) ? r.data : r.data?.models ?? [];
+    }
+
+    async getModelVersions(modelId: number): Promise<any[]> {
+        const r = await this.client.get(`/models/${modelId}/versions`);
+        if (r.status !== 200) throw new Error(`get versions → ${r.status}`);
+        return r.data?.value || r.data || [];
+    }
+
+    async softDeleteModel(modelId: number): Promise<number> {
+        const r = await this.client.delete(`/models/${modelId}`);
+        return r.status;
+    }
+
+    // ── Texture sets ────────────────────────────────────────────────────
+
+    async createTextureSetWithFile(
+        name: string,
+        filePath: string,
+        textureType: number = 1,
+    ): Promise<{ status: number; data: any }> {
+        const formData = new FormData();
+        formData.append("file", fs.createReadStream(filePath));
+        const r = await this.client.post(
+            `/texture-sets/with-file?name=${encodeURIComponent(name)}&textureType=${textureType}`,
+            formData,
+            { headers: formData.getHeaders() },
+        );
+        return { status: r.status, data: r.data };
+    }
+
+    async listTextureSets(): Promise<any[]> {
+        const r = await this.client.get("/texture-sets");
+        if (r.status !== 200) throw new Error(`list /texture-sets → ${r.status}`);
+        return r.data?.textureSets || [];
+    }
+
+    async getTextureSet(id: number): Promise<any> {
+        const r = await this.client.get(`/texture-sets/${id}`);
+        if (r.status !== 200) throw new Error(`get texture set ${id} → ${r.status}`);
+        return r.data;
+    }
+
+    // ── Packs ───────────────────────────────────────────────────────────
+
+    async createPack(name: string, description: string = ""): Promise<{ status: number; data: any }> {
+        const r = await this.client.post("/packs", { name, description });
+        return { status: r.status, data: r.data };
+    }
+
+    async addModelToPack(packId: number, modelId: number): Promise<number> {
+        const r = await this.client.post(`/packs/${packId}/models/${modelId}`);
+        return r.status;
+    }
+
+    async listPacks(): Promise<any[]> {
+        const r = await this.client.get("/packs");
+        if (r.status !== 200) throw new Error(`list /packs → ${r.status}`);
+        return Array.isArray(r.data) ? r.data : r.data?.packs ?? [];
+    }
+
+    async getPack(id: number): Promise<any> {
+        const r = await this.client.get(`/packs/${id}`);
+        if (r.status !== 200) throw new Error(`get pack ${id} → ${r.status}`);
+        return r.data;
+    }
+
+    // ── Projects ────────────────────────────────────────────────────────
+
+    async createProject(name: string, description: string = ""): Promise<{ status: number; data: any }> {
+        const r = await this.client.post("/projects", { name, description });
+        return { status: r.status, data: r.data };
+    }
+
+    async addModelToProject(projectId: number, modelId: number): Promise<number> {
+        const r = await this.client.post(`/projects/${projectId}/models/${modelId}`);
+        return r.status;
+    }
+
+    async listProjects(): Promise<any[]> {
+        const r = await this.client.get("/projects");
+        if (r.status !== 200) throw new Error(`list /projects → ${r.status}`);
+        return Array.isArray(r.data) ? r.data : r.data?.projects ?? [];
+    }
+
+    async getProject(id: number): Promise<any> {
+        const r = await this.client.get(`/projects/${id}`);
+        if (r.status !== 200) throw new Error(`get project ${id} → ${r.status}`);
+        return r.data;
+    }
+
+    // ── Recycled ────────────────────────────────────────────────────────
+
+    /**
+     * Returns a flattened recycle-bin listing as `{entityType, entityId, name?}`.
+     * The /recycled endpoint groups by category (Models, ModelVersions, Files,
+     * TextureSets, Textures, Sprites, Sounds, EnvironmentMaps, EnvironmentMapVariants);
+     * we collapse those into one list so callers don't need to know the schema.
+     */
+    async listRecycled(): Promise<Array<{ entityType: string; entityId: number; name?: string }>> {
+        const r = await this.client.get("/recycled");
+        if (r.status !== 200) throw new Error(`list /recycled → ${r.status}`);
+        const data = r.data ?? {};
+
+        const out: Array<{ entityType: string; entityId: number; name?: string }> = [];
+        const push = (entityType: string, arr: any[] | undefined, idKey: string = "id", nameKey?: string) => {
+            for (const item of arr ?? []) {
+                const id = item?.[idKey];
+                if (typeof id !== "number") continue;
+                out.push({ entityType, entityId: id, name: nameKey ? item?.[nameKey] : item?.name });
+            }
+        };
+
+        // Field names mirror GetAllRecycledQueryResponse on the server (camelCased by JSON).
+        push("Model", data.models, "id", "name");
+        push("ModelVersion", data.modelVersions, "id");
+        push("File", data.files, "id", "originalFileName");
+        push("TextureSet", data.textureSets, "id", "name");
+        push("Texture", data.textures, "id");
+        push("Sprite", data.sprites, "id", "name");
+        push("Sound", data.sounds, "id", "name");
+        push("EnvironmentMap", data.environmentMaps, "id", "name");
+        push("EnvironmentMapVariant", data.environmentMapVariants, "id");
+        return out;
+    }
+
+    // ── Settings ────────────────────────────────────────────────────────
+
+    async setSetting(key: string, value: string): Promise<number> {
+        const r = await this.client.put(`/settings/${encodeURIComponent(key)}`, { value });
+        return r.status;
+    }
+}

--- a/tests/backup-restore-e2e/helpers/docker-stack.ts
+++ b/tests/backup-restore-e2e/helpers/docker-stack.ts
@@ -84,3 +84,23 @@ export function listHostDir(relativePath: string): string[] {
     if (!fs.existsSync(full)) return [];
     return fs.readdirSync(full);
 }
+
+/**
+ * Delete any `.pre-restore-*` directory under `<HOST_DATA_DIR>/<root>`. The
+ * production restore processor refuses to run if these exist — they're the
+ * only on-disk copy of the operator's pre-restore data, and silently sweeping
+ * them would be a data-loss bug. In tests we know the previous run was a
+ * controlled experiment so it's safe to purge them on setup.
+ */
+export function purgePreRestoreDirs(root: "uploads" | "thumbnails"): void {
+    const dir = path.join(HOST_DATA_DIR, root);
+    if (!fs.existsSync(dir)) return;
+    for (const name of fs.readdirSync(dir)) {
+        if (!name.startsWith(".pre-restore-")) continue;
+        try {
+            fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+        } catch {
+            // best-effort
+        }
+    }
+}

--- a/tests/backup-restore-e2e/helpers/docker-stack.ts
+++ b/tests/backup-restore-e2e/helpers/docker-stack.ts
@@ -1,0 +1,86 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execAsync = promisify(exec);
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const STACK_DIR = path.resolve(HERE, "..");
+const COMPOSE_FILE = path.join(STACK_DIR, "docker-compose.backup-e2e.yml");
+const WEBAPI_CONTAINER = "webapi-backup-e2e";
+const POSTGRES_CONTAINER = "postgres-backup-e2e";
+
+export const HOST_DATA_DIR = path.join(STACK_DIR, "data");
+
+/** Restart only the webapi service. Postgres + frontend stay up. */
+export async function restartWebapi(): Promise<void> {
+    await execAsync(
+        `docker compose -f "${COMPOSE_FILE}" restart ${WEBAPI_CONTAINER}`,
+        { cwd: STACK_DIR },
+    );
+}
+
+/** Wait for the webapi's /health to return 2xx. */
+export async function waitForWebapi(timeoutMs: number = 120000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        try {
+            const r = await fetch("http://localhost:8190/health");
+            if (r.ok) return;
+        } catch {
+            // retry
+        }
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error(`webapi did not come back within ${timeoutMs}ms`);
+}
+
+/** Get recent webapi logs (helpful when a test fails). */
+export async function getWebapiLogs(lines: number = 200): Promise<string> {
+    try {
+        const { stdout, stderr } = await execAsync(
+            `docker logs --tail ${lines} ${WEBAPI_CONTAINER}`,
+        );
+        return stdout + stderr;
+    } catch (e: any) {
+        return `Failed to read webapi logs: ${e.message}`;
+    }
+}
+
+/** Drop a stale row from a Postgres table via psql, useful to mutate the DB between tests. */
+export async function execPsql(sql: string): Promise<string> {
+    const escaped = sql.replace(/"/g, '\\"');
+    const { stdout } = await execAsync(
+        `docker exec -e PGPASSWORD=backup_e2e_password ${POSTGRES_CONTAINER} psql -U modelibr -d Modelibr -c "${escaped}"`,
+    );
+    return stdout;
+}
+
+/** Drop ALL public-schema tables and re-create the empty schema. Simulates a wipe scenario. */
+export async function wipePostgresPublicSchema(): Promise<void> {
+    await execAsync(
+        `docker exec -e PGPASSWORD=backup_e2e_password ${POSTGRES_CONTAINER} psql -U modelibr -d Modelibr -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"`,
+    );
+}
+
+export function readHostFile(relativePath: string): Buffer {
+    return fs.readFileSync(path.join(HOST_DATA_DIR, relativePath));
+}
+
+export function writeHostFile(relativePath: string, contents: Buffer | string): void {
+    const full = path.join(HOST_DATA_DIR, relativePath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+}
+
+export function hostPathExists(relativePath: string): boolean {
+    return fs.existsSync(path.join(HOST_DATA_DIR, relativePath));
+}
+
+export function listHostDir(relativePath: string): string[] {
+    const full = path.join(HOST_DATA_DIR, relativePath);
+    if (!fs.existsSync(full)) return [];
+    return fs.readdirSync(full);
+}

--- a/tests/backup-restore-e2e/helpers/docker-stack.ts
+++ b/tests/backup-restore-e2e/helpers/docker-stack.ts
@@ -10,7 +10,6 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const STACK_DIR = path.resolve(HERE, "..");
 const COMPOSE_FILE = path.join(STACK_DIR, "docker-compose.backup-e2e.yml");
 const WEBAPI_CONTAINER = "webapi-backup-e2e";
-const POSTGRES_CONTAINER = "postgres-backup-e2e";
 
 export const HOST_DATA_DIR = path.join(STACK_DIR, "data");
 
@@ -47,22 +46,6 @@ export async function getWebapiLogs(lines: number = 200): Promise<string> {
     } catch (e: any) {
         return `Failed to read webapi logs: ${e.message}`;
     }
-}
-
-/** Drop a stale row from a Postgres table via psql, useful to mutate the DB between tests. */
-export async function execPsql(sql: string): Promise<string> {
-    const escaped = sql.replace(/"/g, '\\"');
-    const { stdout } = await execAsync(
-        `docker exec -e PGPASSWORD=backup_e2e_password ${POSTGRES_CONTAINER} psql -U modelibr -d Modelibr -c "${escaped}"`,
-    );
-    return stdout;
-}
-
-/** Drop ALL public-schema tables and re-create the empty schema. Simulates a wipe scenario. */
-export async function wipePostgresPublicSchema(): Promise<void> {
-    await execAsync(
-        `docker exec -e PGPASSWORD=backup_e2e_password ${POSTGRES_CONTAINER} psql -U modelibr -d Modelibr -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"`,
-    );
 }
 
 export function readHostFile(relativePath: string): Buffer {

--- a/tests/backup-restore-e2e/helpers/seed-and-snapshot.ts
+++ b/tests/backup-restore-e2e/helpers/seed-and-snapshot.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BackupApi } from "./backup-api.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const ASSETS_DIR = path.resolve(HERE, "../../e2e/assets");
+
+export interface SeedResult {
+    modelIds: number[];
+    textureSetIds: number[];
+    packIds: number[];
+    projectIds: number[];
+    // Model that gets a second version, for history coverage.
+    versionedModelId: number;
+    // Model that gets soft-deleted before backup, for recycled-files coverage.
+    recycledModelId: number;
+}
+
+/**
+ * Seeds a known dataset covering every entity type that should survive a
+ * backup/restore round-trip: models with multiple versions, texture sets with
+ * file content, packs, projects with model associations, and a recycled
+ * (soft-deleted) model.
+ *
+ * All asset files come from `tests/e2e/assets/`.
+ */
+export async function seedDataset(api: BackupApi): Promise<SeedResult> {
+    const modelFiles = [
+        "test-cube.glb",
+        "test-cone.fbx",
+        "test-cylinder.fbx",
+        "test-icosphere.fbx",
+        "test-torus.fbx",
+    ].map((f) => path.join(ASSETS_DIR, f));
+
+    for (const f of modelFiles) {
+        if (!fs.existsSync(f)) {
+            throw new Error(`Test asset missing: ${f}`);
+        }
+    }
+
+    // ── Models (5 separate ones)
+    const modelIds: number[] = [];
+    for (const file of modelFiles) {
+        const r = await api.uploadModel(file);
+        if (![200, 201].includes(r.status)) {
+            throw new Error(`uploadModel ${file} → ${r.status}: ${JSON.stringify(r.data)}`);
+        }
+        const id = r.data.id ?? r.data.modelId;
+        if (!id) throw new Error(`uploadModel ${file} returned no id`);
+        modelIds.push(id);
+    }
+
+    // ── A second version for the first model (history coverage).
+    // The new version must reference a DIFFERENT file by content — content-
+    // addressable storage rejects uploading the same hash as another version.
+    // test.blend is unique to this v2 (not used by any model in the seed list).
+    const versionedModelId = modelIds[0];
+    const v2File = path.join(ASSETS_DIR, "test.blend");
+    if (!fs.existsSync(v2File)) {
+        throw new Error(`Test asset missing for model version: ${v2File}`);
+    }
+    const versionR = await api.createModelVersion(versionedModelId, v2File);
+    if (![200, 201].includes(versionR.status)) {
+        throw new Error(`createModelVersion → ${versionR.status}: ${JSON.stringify(versionR.data)}`);
+    }
+
+    // ── Texture sets (2, with files so uploads/ has content tied to them)
+    const ts1 = await api.createTextureSetWithFile(
+        `seed-ts-albedo`,
+        path.join(ASSETS_DIR, "texture_albedo.png"),
+        1, // Albedo
+    );
+    if (![200, 201].includes(ts1.status)) {
+        throw new Error(`createTextureSetWithFile → ${ts1.status}: ${JSON.stringify(ts1.data)}`);
+    }
+    const ts2 = await api.createTextureSetWithFile(
+        `seed-ts-orm`,
+        path.join(ASSETS_DIR, "texture_orm.png"),
+        4, // AO
+    );
+    if (![200, 201].includes(ts2.status)) {
+        throw new Error(`createTextureSetWithFile → ${ts2.status}: ${JSON.stringify(ts2.data)}`);
+    }
+    const textureSetIds = [
+        ts1.data.textureSetId ?? ts1.data.id,
+        ts2.data.textureSetId ?? ts2.data.id,
+    ];
+
+    // ── Packs (2) — second one gets a couple of models
+    const packA = await api.createPack("seed-pack-A", "Pack A description");
+    const packB = await api.createPack("seed-pack-B", "Pack B description");
+    if (![200, 201].includes(packA.status) || ![200, 201].includes(packB.status)) {
+        throw new Error(`createPack failed: ${packA.status} / ${packB.status}`);
+    }
+    const packIds = [packA.data.id, packB.data.id];
+    await api.addModelToPack(packIds[1], modelIds[1]);
+    await api.addModelToPack(packIds[1], modelIds[2]);
+
+    // ── Projects (2) — first one gets a model
+    const projA = await api.createProject("seed-project-A", "Project A");
+    const projB = await api.createProject("seed-project-B", "Project B");
+    if (![200, 201].includes(projA.status) || ![200, 201].includes(projB.status)) {
+        throw new Error(`createProject failed: ${projA.status} / ${projB.status}`);
+    }
+    const projectIds = [projA.data.id, projB.data.id];
+    await api.addModelToProject(projectIds[0], modelIds[3]);
+
+    // ── Recycled: soft-delete one model so it lives in the recycle bin at backup time
+    const recycledModelId = modelIds[4];
+    const delStatus = await api.softDeleteModel(recycledModelId);
+    if (![200, 204].includes(delStatus)) {
+        throw new Error(`softDeleteModel → ${delStatus}`);
+    }
+
+    return {
+        modelIds,
+        textureSetIds,
+        packIds,
+        projectIds,
+        versionedModelId,
+        recycledModelId,
+    };
+}
+
+// ── Snapshot ────────────────────────────────────────────────────────────
+
+export interface Snapshot {
+    modelIds: number[];                            // active (non-deleted) model IDs
+    modelHashesById: Record<number, string[]>;    // model id → sorted list of file SHA-256s
+    versionCountById: Record<number, number>;     // model id → version count
+    textureSetIds: number[];
+    textureSetNameById: Record<number, string>;
+    textureCountById: Record<number, number>;     // texture set → texture count
+    packIds: number[];
+    packNameById: Record<number, string>;
+    packModelCountById: Record<number, number>;
+    projectIds: number[];
+    projectNameById: Record<number, string>;
+    projectModelCountById: Record<number, number>;
+    recycledEntries: Array<{ entityType: string; entityId: number; name?: string }>;
+}
+
+/**
+ * Takes a structural snapshot of the live state. Returned objects are sorted
+ * so the snapshot is order-independent and safe to deep-compare.
+ */
+export async function takeSnapshot(api: BackupApi): Promise<Snapshot> {
+    const models = await api.listModels();
+    const modelIds = models.map((m: any) => m.id).sort((a: number, b: number) => a - b);
+
+    const modelHashesById: Record<number, string[]> = {};
+    const versionCountById: Record<number, number> = {};
+    for (const id of modelIds) {
+        const versions = await api.getModelVersions(id);
+        versionCountById[id] = versions.length;
+        const hashes: string[] = [];
+        for (const v of versions) {
+            const files = v.files ?? [];
+            for (const f of files) {
+                if (f.sha256 || f.hash) hashes.push((f.sha256 || f.hash) as string);
+            }
+        }
+        modelHashesById[id] = hashes.sort();
+    }
+
+    const textureSets = await api.listTextureSets();
+    const textureSetIds = textureSets
+        .map((t: any) => t.id)
+        .sort((a: number, b: number) => a - b);
+    const textureSetNameById: Record<number, string> = {};
+    const textureCountById: Record<number, number> = {};
+    for (const ts of textureSets) {
+        textureSetNameById[ts.id] = ts.name;
+        // Some list responses include textures, others need a per-id fetch.
+        const details = Array.isArray(ts.textures) ? ts : await api.getTextureSet(ts.id);
+        textureCountById[ts.id] = (details?.textures ?? []).length;
+    }
+
+    const packs = await api.listPacks();
+    const packIds = packs.map((p: any) => p.id).sort((a: number, b: number) => a - b);
+    const packNameById: Record<number, string> = {};
+    const packModelCountById: Record<number, number> = {};
+    for (const p of packs) {
+        packNameById[p.id] = p.name;
+        const detail = (await api.getPack(p.id)) ?? p;
+        const ids = detail?.modelIds ?? detail?.models?.map((m: any) => m.id) ?? [];
+        packModelCountById[p.id] = ids.length;
+    }
+
+    const projects = await api.listProjects();
+    const projectIds = projects.map((p: any) => p.id).sort((a: number, b: number) => a - b);
+    const projectNameById: Record<number, string> = {};
+    const projectModelCountById: Record<number, number> = {};
+    for (const p of projects) {
+        projectNameById[p.id] = p.name;
+        const detail = (await api.getProject(p.id)) ?? p;
+        const ids = detail?.modelIds ?? detail?.models?.map((m: any) => m.id) ?? [];
+        projectModelCountById[p.id] = ids.length;
+    }
+
+    const recycledEntries = (await api.listRecycled()).sort((a, b) => {
+        if (a.entityType !== b.entityType) return a.entityType.localeCompare(b.entityType);
+        return a.entityId - b.entityId;
+    });
+
+    return {
+        modelIds,
+        modelHashesById,
+        versionCountById,
+        textureSetIds,
+        textureSetNameById,
+        textureCountById,
+        packIds,
+        packNameById,
+        packModelCountById,
+        projectIds,
+        projectNameById,
+        projectModelCountById,
+        recycledEntries,
+    };
+}

--- a/tests/backup-restore-e2e/helpers/settings-page.ts
+++ b/tests/backup-restore-e2e/helpers/settings-page.ts
@@ -1,0 +1,160 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Page object for the Settings tab and its "Backup & Restore" accordion section.
+ *
+ * Modelibr opens tabs through a dock-bar "+" button → "New Tab" picker. The
+ * Settings tab type is reached by clicking the picker's "Settings" tile.
+ * This mirrors the main e2e suite's `openTabViaMenu` helper.
+ */
+export class SettingsPage {
+    constructor(public readonly page: Page) {}
+
+    async goto(): Promise<void> {
+        const baseUrl = process.env.FRONTEND_URL || "http://localhost:3102";
+        await this.page.goto(baseUrl);
+        await this.page.waitForSelector(".p-splitter", {
+            state: "visible",
+            timeout: 30000,
+        });
+        await this.openSettingsTab();
+        await this.expandBackupSection();
+    }
+
+    private async openSettingsTab(): Promise<void> {
+        // If Settings is already open in any panel, click that existing tab.
+        const existing = this.page
+            .locator(".draggable-tab:has(.pi-cog)")
+            .first();
+        if (await existing.count()) {
+            await existing.click();
+        } else {
+            // Open via the left dock bar's "+" button → New Tab page → Settings tile.
+            await this.page.locator(".dock-bar-left .dock-add-button").click();
+            const newtabPage = this.page.locator(".newtab-page").last();
+            await expect(newtabPage).toBeVisible({ timeout: 10000 });
+
+            const tile = newtabPage
+                .locator(".newtab-tile")
+                .filter({
+                    has: this.page.locator(".newtab-tile-title", {
+                        hasText: /^Settings$/,
+                    }),
+                })
+                .first();
+            await expect(tile).toBeVisible({ timeout: 10000 });
+            await tile.click();
+            await expect(newtabPage).toBeHidden({ timeout: 10000 });
+        }
+
+        await expect(
+            this.page.getByRole("heading", { name: /application settings/i }),
+        ).toBeVisible({ timeout: 30000 });
+    }
+
+    private async expandBackupSection(): Promise<void> {
+        const header = this.page
+            .locator(".settings-section-header")
+            .filter({ hasText: /backup\s*&\s*restore/i })
+            .first();
+        await expect(header).toBeVisible();
+        // Sections default to expanded for non-demo mode. If the body isn't
+        // already in the DOM (different layout, e.g. mobile), expand it.
+        const list = this.page.locator(".backups-section");
+        if (!(await list.isVisible())) {
+            await header.click();
+        }
+        await expect(list).toBeVisible();
+        // Scroll the section into view for stable button clicks.
+        await header.scrollIntoViewIfNeeded();
+    }
+
+    // ── Operations ──────────────────────────────────────────────────────
+
+    async clickCreateBackup(): Promise<void> {
+        await this.page
+            .locator(".backups-toolbar")
+            .getByRole("button", { name: /create backup/i })
+            .click();
+        await expect(this.page.locator(".backups-modal")).toBeVisible();
+    }
+
+    async setIncludeThumbnails(value: boolean): Promise<void> {
+        const checkboxes = this.page
+            .locator(".backups-modal .settings-checkbox-label input[type='checkbox']");
+        // Order: Database (disabled, checked), Uploads (disabled, checked), Thumbnails (enabled)
+        const thumb = checkboxes.nth(2);
+        if ((await thumb.isChecked()) !== value) {
+            await thumb.click();
+        }
+    }
+
+    async confirmCreateBackup(): Promise<void> {
+        await this.page
+            .locator(".backups-modal")
+            .getByRole("button", { name: /^create backup$/i })
+            .click();
+        await expect(this.page.locator(".backups-modal")).toBeHidden();
+    }
+
+    /** Wait until at least one row exists in the backups table. Returns its filename. */
+    async waitForFirstBackupRow(timeoutMs: number = 30000): Promise<string> {
+        const firstRow = this.page.locator(".backups-table tbody tr").first();
+        await expect(firstRow).toBeVisible({ timeout: timeoutMs });
+        return (await firstRow.locator(".backups-filename").innerText()).trim();
+    }
+
+    /** Wait until the row's status badge disappears (status flips to ready). */
+    async waitForRowReady(fileName: string, timeoutMs: number = 120000): Promise<void> {
+        const row = this.rowFor(fileName);
+        await expect(row).toBeVisible();
+        // "ready" rows have Download/Restore/Delete buttons rather than the badge.
+        await expect(row.getByRole("button", { name: /^delete$/i }))
+            .toBeVisible({ timeout: timeoutMs });
+    }
+
+    rowFor(fileName: string): Locator {
+        return this.page
+            .locator(".backups-table tbody tr")
+            .filter({ has: this.page.locator(".backups-filename", { hasText: fileName }) })
+            .first();
+    }
+
+    async clickDownload(fileName: string) {
+        const [download] = await Promise.all([
+            this.page.waitForEvent("download"),
+            this.rowFor(fileName).getByRole("link", { name: /download/i }).click(),
+        ]);
+        return download;
+    }
+
+    async clickRestore(fileName: string): Promise<void> {
+        await this.rowFor(fileName)
+            .getByRole("button", { name: /^restore$/i })
+            .click();
+        // PrimeReact's confirmDialog renders as a .p-dialog. Scope to it to
+        // avoid colliding with the "Restore" button on the row.
+        const dialog = this.page.locator(".p-confirm-dialog, .p-dialog").last();
+        await expect(dialog).toBeVisible({ timeout: 5000 });
+        await dialog
+            .getByRole("button", { name: /stage restore/i })
+            .click();
+        await expect(dialog).toBeHidden({ timeout: 5000 });
+    }
+
+    async clickDelete(fileName: string): Promise<void> {
+        await this.rowFor(fileName)
+            .getByRole("button", { name: /^delete$/i })
+            .click();
+        const dialog = this.page.locator(".p-confirm-dialog, .p-dialog").last();
+        await expect(dialog).toBeVisible({ timeout: 5000 });
+        await dialog
+            .getByRole("button", { name: /^delete$/i })
+            .click();
+        await expect(dialog).toBeHidden({ timeout: 5000 });
+    }
+
+    async getRowCount(): Promise<number> {
+        return this.page.locator(".backups-table tbody tr").count();
+    }
+}

--- a/tests/backup-restore-e2e/package-lock.json
+++ b/tests/backup-restore-e2e/package-lock.json
@@ -1,0 +1,446 @@
+{
+    "name": "modelibr-backup-restore-e2e",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "modelibr-backup-restore-e2e",
+            "version": "1.0.0",
+            "dependencies": {
+                "axios": "^1.13.2",
+                "form-data": "^4.0.5"
+            },
+            "devDependencies": {
+                "@playwright/test": "^1.49.1",
+                "@types/node": "^22.19.3",
+                "typescript": "^5.7.2"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.60.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "22.19.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/playwright": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.60.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        }
+    }
+}

--- a/tests/backup-restore-e2e/package.json
+++ b/tests/backup-restore-e2e/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "modelibr-backup-restore-e2e",
+    "version": "1.0.0",
+    "description": "E2E tests for backup & restore — runs in an isolated docker-compose stack separate from the main e2e suite.",
+    "type": "module",
+    "scripts": {
+        "test:setup": "npx playwright install --with-deps chromium && docker compose -f docker-compose.backup-e2e.yml up -d --build && node wait-for-services.js",
+        "test": "npx playwright test",
+        "test:headed": "npx playwright test --headed",
+        "test:teardown": "docker compose -f docker-compose.backup-e2e.yml down -v && node -e \"import('fs').then(({rmSync}) => rmSync('data',{recursive:true,force:true}))\"",
+        "test:full": "npm run test:setup && npm test; status=$?; npm run test:teardown; exit $status",
+        "test:report": "npx playwright show-report"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.49.1",
+        "@types/node": "^22.19.3",
+        "typescript": "^5.7.2"
+    },
+    "dependencies": {
+        "axios": "^1.13.2",
+        "form-data": "^4.0.5"
+    }
+}

--- a/tests/backup-restore-e2e/playwright.config.ts
+++ b/tests/backup-restore-e2e/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3102";
+
+export default defineConfig({
+    testDir: "./specs",
+    timeout: 180000, // 3 min — restore round-trip restarts the webapi container
+    fullyParallel: false, // Stack is shared; tests must run sequentially.
+    workers: 1,
+    retries: 0,
+    forbidOnly: !!process.env.CI,
+    reporter: [["list"], ["html", { open: "never" }]],
+    use: {
+        baseURL: FRONTEND_URL,
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+        ignoreHTTPSErrors: true,
+    },
+    projects: [
+        {
+            name: "backup-restore",
+            use: { ...devices["Desktop Chrome"] },
+        },
+    ],
+});

--- a/tests/backup-restore-e2e/specs/01-create-list-download.spec.ts
+++ b/tests/backup-restore-e2e/specs/01-create-list-download.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BackupApi } from "../helpers/backup-api.js";
+import { SettingsPage } from "../helpers/settings-page.js";
+import { listHostDir } from "../helpers/docker-stack.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TEST_ASSET = path.resolve(HERE, "../../e2e/assets/test-cube.glb");
+
+test.describe("Backup create / list / download / delete (UI)", () => {
+    let api: BackupApi;
+
+    test.beforeAll(async () => {
+        api = new BackupApi();
+
+        // Seed: upload a model so the backup has at least one upload file in it.
+        if (fs.existsSync(TEST_ASSET)) {
+            const seed = await api.uploadModel(TEST_ASSET);
+            expect([200, 201]).toContain(seed.status);
+        }
+
+        // Start clean: delete any existing backups from prior runs.
+        const existing = await api.listBackups();
+        for (const b of existing) {
+            await api.deleteBackup(b.fileName);
+        }
+    });
+
+    test("Create backup via UI, see it in the list, download it, and delete it", async ({ page }) => {
+        const settings = new SettingsPage(page);
+        await settings.goto();
+
+        // Open the create modal and submit it with thumbnails disabled.
+        await settings.clickCreateBackup();
+        await settings.setIncludeThumbnails(false);
+        await settings.confirmCreateBackup();
+
+        // A row appears — possibly in 'in_progress' state — then transitions to ready.
+        const fileName = await settings.waitForFirstBackupRow();
+        expect(fileName).toMatch(/^modelibr-\d{4}-\d{2}-\d{2}-\d{6}\.tar$/);
+        await settings.waitForRowReady(fileName);
+
+        // The archive appears on the host filesystem under data/backups/.
+        const hostFiles = listHostDir("backups");
+        expect(hostFiles).toContain(fileName);
+
+        // Download via the UI and verify the bytes look like a tar archive.
+        const download = await settings.clickDownload(fileName);
+        const stream = await download.createReadStream();
+        const chunks: Buffer[] = [];
+        for await (const c of stream) chunks.push(Buffer.from(c));
+        const bytes = Buffer.concat(chunks);
+        expect(bytes.length).toBeGreaterThan(0);
+
+        // BackupService writes a PAX-format tar containing `manifest.json`,
+        // `database.dump`, and `uploads/...`. Verify those names appear in the
+        // archive — substring search keeps this robust against PAX metadata
+        // blocks (`./PaxHeaders.N/...`) interleaving the real entries.
+        const ascii = bytes.toString("binary"); // 1-byte chars; no UTF-8 reinterpretation
+        expect(ascii).toContain("database.dump");
+        expect(ascii).toContain("manifest.json");
+        expect(ascii).toContain("uploads/");
+
+        // Delete via UI and confirm the row is gone.
+        await settings.clickDelete(fileName);
+        await expect(settings.rowFor(fileName)).toHaveCount(0, { timeout: 10000 });
+        expect(listHostDir("backups")).not.toContain(fileName);
+    });
+
+    test("Listing /backups via API matches what the UI shows", async () => {
+        // Create a fresh backup via API and confirm it surfaces.
+        const created = await api.createBackup(false);
+        expect(created.status).toBe(202);
+        const ready = await api.waitForBackupReady(created.data.fileName);
+        expect(ready.status).toBe("ready");
+        expect(ready.includesThumbnails).toBe(false);
+
+        const list = await api.listBackups();
+        const found = list.find((b) => b.fileName === created.data.fileName);
+        expect(found).toBeDefined();
+        expect(found?.sizeBytes).toBeGreaterThan(0);
+        expect(found?.hostPath).toMatch(/^\.\/data\/backups\//);
+
+        // Cleanup
+        const del = await api.deleteBackup(created.data.fileName);
+        expect([200, 204]).toContain(del);
+    });
+});

--- a/tests/backup-restore-e2e/specs/02-restore-roundtrip.spec.ts
+++ b/tests/backup-restore-e2e/specs/02-restore-roundtrip.spec.ts
@@ -5,6 +5,7 @@ import { SettingsPage } from "../helpers/settings-page.js";
 import {
     getWebapiLogs,
     listHostDir,
+    purgePreRestoreDirs,
     restartWebapi,
     waitForWebapi,
 } from "../helpers/docker-stack.js";
@@ -29,6 +30,12 @@ test.describe.serial("Restore round-trip — verify every entity survives intact
         // Clear any backups from previous runs so this test owns the list.
         const existing = await api.listBackups();
         for (const b of existing) await api.deleteBackup(b.fileName);
+
+        // The production processor refuses to run a new restore on top of an
+        // unrecovered .pre-restore-* directory. In tests we know the previous
+        // run was controlled, so clear any leftover ones to start clean.
+        purgePreRestoreDirs("uploads");
+        purgePreRestoreDirs("thumbnails");
     });
 
     test("Seed full dataset → backup → mutate → restore → snapshot matches", async ({ page }) => {

--- a/tests/backup-restore-e2e/specs/02-restore-roundtrip.spec.ts
+++ b/tests/backup-restore-e2e/specs/02-restore-roundtrip.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import { BackupApi } from "../helpers/backup-api.js";
+import { SettingsPage } from "../helpers/settings-page.js";
+import {
+    getWebapiLogs,
+    listHostDir,
+    restartWebapi,
+    waitForWebapi,
+} from "../helpers/docker-stack.js";
+import {
+    ASSETS_DIR,
+    seedDataset,
+    takeSnapshot,
+} from "../helpers/seed-and-snapshot.js";
+
+test.describe.serial("Restore round-trip — verify every entity survives intact", () => {
+    const api = new BackupApi();
+
+    test.skip(
+        !fs.existsSync(ASSETS_DIR),
+        `Asset directory missing: ${ASSETS_DIR}`,
+    );
+
+    test.beforeAll(async () => {
+        // AutoRename so duplicate upload names from earlier specs don't 409.
+        await api.setSetting("DuplicateNamePolicy", "AutoRename");
+
+        // Clear any backups from previous runs so this test owns the list.
+        const existing = await api.listBackups();
+        for (const b of existing) await api.deleteBackup(b.fileName);
+    });
+
+    test("Seed full dataset → backup → mutate → restore → snapshot matches", async ({ page }) => {
+        test.setTimeout(360000); // 6 min total budget: seed + backup + restart + verify
+
+        // ── 1. Seed: 5 models (one recycled), one extra version, 2 texture sets,
+        //         2 packs (one populated), 2 projects (one populated).
+        const seed = await seedDataset(api);
+        const before = await takeSnapshot(api);
+
+        // Sanity-check the dataset shape before we trust the round-trip.
+        expect(before.modelIds.length).toBeGreaterThanOrEqual(4); // 1 was recycled
+        expect(before.textureSetIds.length).toBeGreaterThanOrEqual(2);
+        expect(before.packIds.length).toBeGreaterThanOrEqual(2);
+        expect(before.projectIds.length).toBeGreaterThanOrEqual(2);
+        expect(before.versionCountById[seed.versionedModelId]).toBeGreaterThanOrEqual(2);
+        expect(before.recycledEntries.length).toBeGreaterThanOrEqual(1);
+        // The recycled model is referenced in the recycle bin entries.
+        expect(
+            before.recycledEntries.some((r) => r.entityId === seed.recycledModelId),
+        ).toBe(true);
+
+        // ── 2. Create backup via UI.
+        const settings = new SettingsPage(page);
+        await settings.goto();
+        await settings.clickCreateBackup();
+        await settings.setIncludeThumbnails(false);
+        await settings.confirmCreateBackup();
+        const fileName = await settings.waitForFirstBackupRow();
+        await settings.waitForRowReady(fileName);
+
+        // ── 3. Mutate state AFTER the backup. Restore should erase these changes.
+        //         (a) Delete two more models — restore must bring them back.
+        await api.softDeleteModel(seed.modelIds[1]);
+        await api.softDeleteModel(seed.modelIds[2]);
+        //         (b) Create a NEW pack — restore must remove it.
+        const interloperPack = await api.createPack("post-backup-pack", "should be gone after restore");
+        expect([200, 201]).toContain(interloperPack.status);
+        //         (c) Create a NEW project — restore must remove it.
+        const interloperProject = await api.createProject("post-backup-project");
+        expect([200, 201]).toContain(interloperProject.status);
+
+        const mutated = await takeSnapshot(api);
+        expect(mutated.modelIds.length).toBe(before.modelIds.length - 2);
+        expect(mutated.packIds.length).toBe(before.packIds.length + 1);
+        expect(mutated.projectIds.length).toBe(before.projectIds.length + 1);
+
+        // ── 4. Stage the restore via the UI.
+        await settings.clickRestore(fileName);
+        await expect
+            .poll(() => listHostDir("restore"), { timeout: 10000 })
+            .toContain(fileName);
+
+        // ── 5. Restart the webapi container — RestoreOnBootProcessor runs
+        //         before HTTP is up; wait for /health to come back.
+        await restartWebapi();
+        await waitForWebapi(180000);
+
+        // ── 6. The archive should be moved into restore/processed/ and gone
+        //         from the staging directory.
+        const processedFiles = listHostDir("restore/processed");
+        expect(processedFiles.some((f) => f.endsWith(fileName))).toBe(true);
+        expect(listHostDir("restore")).not.toContain(fileName);
+
+        // ── 7. Snapshot the world AFTER restore and compare it to BEFORE.
+        const after = await takeSnapshot(api);
+
+        // Models: every active model from before is back, no interloper persists.
+        expect(after.modelIds).toEqual(before.modelIds);
+        // Versions per model are unchanged.
+        expect(after.versionCountById).toEqual(before.versionCountById);
+        // File hashes on disk match — this proves the upload tree was restored
+        // with byte-identical content.
+        expect(after.modelHashesById).toEqual(before.modelHashesById);
+
+        // Texture sets: same set of IDs, same names, same number of textures each.
+        expect(after.textureSetIds).toEqual(before.textureSetIds);
+        expect(after.textureSetNameById).toEqual(before.textureSetNameById);
+        expect(after.textureCountById).toEqual(before.textureCountById);
+
+        // Packs: identical set, identical names, identical model membership counts.
+        // Restore must have undone the "post-backup-pack" we created in step 3.
+        expect(after.packIds).toEqual(before.packIds);
+        expect(after.packNameById).toEqual(before.packNameById);
+        expect(after.packModelCountById).toEqual(before.packModelCountById);
+
+        // Projects: same — restore must have undone the interloper.
+        expect(after.projectIds).toEqual(before.projectIds);
+        expect(after.projectNameById).toEqual(before.projectNameById);
+        expect(after.projectModelCountById).toEqual(before.projectModelCountById);
+
+        // Recycle bin entries are restored too. We use a structural compare
+        // (entityType + entityId) because timestamps can differ.
+        const beforeRecycledKeys = before.recycledEntries.map(
+            (r) => `${r.entityType}:${r.entityId}`,
+        );
+        const afterRecycledKeys = after.recycledEntries.map(
+            (r) => `${r.entityType}:${r.entityId}`,
+        );
+        expect(afterRecycledKeys).toEqual(beforeRecycledKeys);
+    });
+
+    test.afterAll(async () => {
+        if (test.info().errors.length > 0) {
+            console.log("\n── webapi logs (last 200 lines) ──\n" + (await getWebapiLogs()));
+        }
+    });
+});

--- a/tests/backup-restore-e2e/specs/03-concurrent-conflict.spec.ts
+++ b/tests/backup-restore-e2e/specs/03-concurrent-conflict.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { BackupApi } from "../helpers/backup-api.js";
+
+test.describe("Backup API edge cases", () => {
+    const api = new BackupApi();
+
+    test.beforeAll(async () => {
+        const existing = await api.listBackups();
+        for (const b of existing) await api.deleteBackup(b.fileName);
+    });
+
+    test("Two backups started back-to-back: second returns 409 Conflict", async () => {
+        // Fire both within the same tick. The first acquires the semaphore;
+        // the second must see it locked and return 409.
+        const [first, second] = await Promise.all([
+            api.createBackup(false),
+            (async () => {
+                // Tiny delay so the first call definitely wins the race,
+                // making this test deterministic.
+                await new Promise((r) => setTimeout(r, 10));
+                return api.createBackup(false);
+            })(),
+        ]);
+
+        expect(first.status).toBe(202);
+        expect(second.status).toBe(409);
+
+        // Wait for the first to finish before tearing down.
+        await api.waitForBackupReady(first.data.fileName);
+        await api.deleteBackup(first.data.fileName);
+    });
+
+    test("Delete with an invalid filename is rejected", async () => {
+        // Path-traversal style — must be rejected by the server-side validator.
+        const status = await api.deleteBackup("../etc/passwd");
+        expect(status).toBe(400);
+    });
+
+    test("Download of a non-existent backup returns 404", async () => {
+        const r = await api.downloadBackup("modelibr-9999-99-99-999999.tar");
+        expect(r.status).toBe(404);
+    });
+});

--- a/tests/backup-restore-e2e/specs/04-bad-archive-rejected.spec.ts
+++ b/tests/backup-restore-e2e/specs/04-bad-archive-rejected.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BackupApi } from "../helpers/backup-api.js";
+import {
+    hostPathExists,
+    listHostDir,
+    restartWebapi,
+    waitForWebapi,
+    writeHostFile,
+} from "../helpers/docker-stack.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TEST_ASSET = path.resolve(HERE, "../../e2e/assets/test-cube.glb");
+
+test.describe.serial("Restore rejects bad archives without touching live data", () => {
+    const api = new BackupApi();
+
+    test.skip(
+        !fs.existsSync(TEST_ASSET),
+        `Test asset missing: ${TEST_ASSET}`,
+    );
+
+    test("A garbage .tar in restore/ is moved to failed/ on boot; live data is preserved", async () => {
+        test.setTimeout(180000);
+
+        // Seed: one model, so we have something the test can verify is still there.
+        const m = await api.uploadModel(TEST_ASSET);
+        expect([200, 201]).toContain(m.status);
+        const beforeCount = (await api.listModels()).length;
+        expect(beforeCount).toBeGreaterThan(0);
+
+        // Drop a non-tar payload into restore/ — RestoreOnBootProcessor reads
+        // the manifest first, so an unreadable archive must be rejected before
+        // any data is touched.
+        const badName = "modelibr-bad-0000-00-00-000000.tar";
+        writeHostFile(`restore/${badName}`, Buffer.from("this is not a tar archive"));
+
+        await restartWebapi();
+        await waitForWebapi(120000);
+
+        // The archive must have been moved into failed/ with an .error.txt sibling.
+        const failedFiles = listHostDir("restore/failed");
+        expect(failedFiles).toContain(badName);
+        expect(failedFiles).toContain(`${badName}.error.txt`);
+
+        // And it must NOT remain in the staging directory.
+        expect(hostPathExists(`restore/${badName}`)).toBe(false);
+
+        // Live data is intact — model count unchanged, app responds normally.
+        const afterCount = (await api.listModels()).length;
+        expect(afterCount).toBe(beforeCount);
+    });
+});

--- a/tests/backup-restore-e2e/tsconfig.json
+++ b/tests/backup-restore-e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "test-results", "playwright-report", "data"]
+}

--- a/tests/backup-restore-e2e/wait-for-services.js
+++ b/tests/backup-restore-e2e/wait-for-services.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Waits for the backup-restore-e2e stack to be reachable.
+ * Used by `npm run test:setup` after `docker compose up`.
+ */
+import http from "http";
+
+const services = [
+    { url: "http://localhost:8190/health", label: "WebApi" },
+    { url: "http://localhost:3102", label: "Frontend" },
+];
+
+const TIMEOUT_MS = 180000; // 3 min — first build pulls postgresql-client-16
+const POLL_MS = 2000;
+
+function httpGet(url) {
+    return new Promise((resolve, reject) => {
+        const request = http.get(url, (res) => {
+            res.resume();
+            resolve(res.statusCode || 0);
+        });
+        request.on("error", reject);
+        request.setTimeout(5000, () => {
+            request.destroy(new Error("timeout"));
+        });
+    });
+}
+
+async function waitFor(service) {
+    const start = Date.now();
+    process.stdout.write(
+        `⏳ Waiting for ${service.label} at ${service.url}...`,
+    );
+
+    while (Date.now() - start < TIMEOUT_MS) {
+        try {
+            const status = await httpGet(service.url);
+            if (status >= 200 && status < 400) {
+                process.stdout.write(" ready\n");
+                return;
+            }
+        } catch {
+            // retry
+        }
+        process.stdout.write(".");
+        await new Promise((r) => setTimeout(r, POLL_MS));
+    }
+
+    process.stdout.write("\n");
+    throw new Error(`Timed out waiting for ${service.label}`);
+}
+
+try {
+    for (const svc of services) {
+        await waitFor(svc);
+    }
+    console.log("\nAll backup-restore-e2e services ready\n");
+} catch (err) {
+    console.error(`\n${err.message}`);
+    process.exit(1);
+}

--- a/tests/e2e/demo-tests/demo-mode.spec.ts
+++ b/tests/e2e/demo-tests/demo-mode.spec.ts
@@ -410,7 +410,7 @@ test.describe("demo mode e2e", () => {
         }
     });
 
-    test("locks Blender, SSL, and WebDAV settings sections in demo mode", async ({
+    test("locks Blender, SSL, WebDAV, and Backup & Restore settings sections in demo mode", async ({
         page,
     }) => {
         const settingsPage = new SettingsPage(page);
@@ -419,10 +419,15 @@ test.describe("demo mode e2e", () => {
         await settingsPage.waitForLoaded();
 
         const lockedSections = page.locator(".settings-section-header--locked");
-        await expect(lockedSections).toHaveCount(3);
+        await expect(lockedSections).toHaveCount(4);
 
         // Verify each locked section shows the notice text
-        for (const name of ["Blender Settings", "SSL Certificate", "WebDAV"]) {
+        for (const name of [
+            "Blender Settings",
+            "SSL Certificate",
+            "WebDAV",
+            "Backup & Restore",
+        ]) {
             const header = page.locator(".settings-section-header--locked", {
                 hasText: name,
             });


### PR DESCRIPTION
## Summary

Adds self-hosted backup & restore to the Settings page. Backups capture a Postgres custom-format dump plus the uploads tree (with optional thumbnails) into a single `.tar` archive; restore runs in `Program.Main` before the host is built, so it can safely replace the live state without an active DB connection.

The implementation went through a Sonnet code review focused specifically on data-loss risk. See "Reliability posture" below for what was strengthened and what residual risks remain.

## What's in here

**Backend**
- `IBackupService` + `BackupService` — `pg_dump -Fc`, atomic write through `.tmp/`, SHA-256 of the dump captured in the manifest, fsync before publish, `SemaphoreSlim` guards.
- `RestoreOnBootProcessor` runs in `Program.Main` before `app.Build()`. Strict pre-flight (manifest version, PG major version match, dump SHA-256, entry count). Stages existing trees into `.pre-restore-<ts>/` only after validation passes. `pg_restore --clean --if-exists --exit-on-error`.
- REST surface under `/backups`: list, create (202 + background job), download, delete, storage info, size estimate, stage-for-restore (202).
- `postgresql-client-16` added to the WebApi image so `pg_dump` / `pg_restore` are available at runtime (matched to `postgres:16-alpine`).
- `docker-compose` bind-mounts `./data/{backups,restore,thumbnails}` next to the existing uploads mount.

**Frontend**
- New "Backup & Restore" section in Settings. Create modal with size estimate and thumbnails toggle. Per-row Download / Restore / Delete with in-progress polling. Host path readout for operators who want to `scp` the file off-box.

**Tests** (`tests/backup-restore-e2e/`)
- Isolated Playwright stack — separate compose file, container names (`*-backup-e2e`), ports (8190 / 3102 / 5434), bind-mounted `data/` so specs can drop corrupted archives directly into `restore/`.
- 7 specs across 4 files: UI create/list/download/delete, multi-asset round-trip (models with version history, texture sets with files, packs, projects with model membership, recycled items), concurrent-backup conflict, and bad-archive rejection.

## Reliability posture

The Sonnet review surfaced 13 ways a failed restore could damage live data or trap the container in a crash loop. All of them are fixed:

| # | Risk | Fix |
| --- | --- | --- |
| 3 | `pg_restore` exit 1 (continued-past-warnings) treated as fatal → uploads already swapped, container crash-loops | `--exit-on-error` so exit 1 only happens on a real failure |
| 2 | `StageExistingTree` swallowed `Directory.Move` failures, mixing live + restored files | Throws on any move failure; restore aborts with live data still in place |
| 6 | `.pre-restore-*` dirs auto-deleted on every boot, losing recovery copy after a failed restore | Never auto-deleted; logged as warnings; operator removes manually |
| 11 | No check that the archive actually contains `database.dump` before staging | Pre-flight entry enumeration; missing dump → moved to `failed/` with no live data touched |
| 5 | `ManifestVersion` field ignored | Validated against `BackupManifestConstants.CurrentManifestVersion` |
| 14 | `PostgresMajorVersion` hardcoded to `16` | Queried from live server at backup time and cross-checked at restore time |
| 12 + 13 | No archive integrity check; no extracted-count verification | Dump SHA-256 in manifest, verified after extraction; upload count verified against manifest stats |
| 9 | `MoveToFailedAsync` failure → archive stays in `restore/` → crash-loop | Fallback renames in place with `.invalid` suffix; next boot's `*.tar` glob skips it |
| 7 | `StageRestore` had no lock → concurrent calls staged the wrong backup | Dedicated semaphore + atomic rename through `.staging` |
| 19 | Host display path hardcoded to `./data/backups` | Configurable via `BACKUP_HOST_DISPLAY_PATH` |
| 31 | Manifest type duplicated in two assemblies → would silently diverge | Single canonical type in `Application.Abstractions.Services` |
| 22 | `POST /restore` returned 200 OK (synchronous semantics) | Returns 202 Accepted |
| — | Power-loss between backup completion and OS flush could leave torn archive | `fsync` before atomic publish |

## Test plan

- [ ] `cd tests/backup-restore-e2e && npm run test:setup` builds the stack (first run pulls postgresql-client-16; ~3 min).
- [ ] `npm test` runs the 7-spec suite end to end.
- [ ] All four specs pass — UI flow, round-trip, edge cases, bad-archive rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)