### PR TITLE
feat(textures): single-model texture sets with kind conversion

### DIFF
--- a/src/Application/TextureSets/UpdateTextureSetKindCommand.cs
+++ b/src/Application/TextureSets/UpdateTextureSetKindCommand.cs
@@ -13,17 +13,20 @@ internal class UpdateTextureSetKindCommandHandler : ICommandHandler<UpdateTextur
     private readonly ITextureSetRepository _textureSetRepository;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly IThumbnailQueue _thumbnailQueue;
+    private readonly IBlendFileGenerator _blendFileGenerator;
     private readonly ILogger<UpdateTextureSetKindCommandHandler> _logger;
 
     public UpdateTextureSetKindCommandHandler(
         ITextureSetRepository textureSetRepository,
         IDateTimeProvider dateTimeProvider,
         IThumbnailQueue thumbnailQueue,
+        IBlendFileGenerator blendFileGenerator,
         ILogger<UpdateTextureSetKindCommandHandler> logger)
     {
         _textureSetRepository = textureSetRepository;
         _dateTimeProvider = dateTimeProvider;
         _thumbnailQueue = thumbnailQueue;
+        _blendFileGenerator = blendFileGenerator;
         _logger = logger;
     }
 
@@ -39,6 +42,24 @@ internal class UpdateTextureSetKindCommandHandler : ICommandHandler<UpdateTextur
             }
 
             textureSet.UpdateKind(command.Kind, _dateTimeProvider.UtcNow);
+
+            // Converting to a single-model (ModelOwned) kind ties the texture
+            // set to exactly one model — drop links to every other model.
+            if (command.Kind == TextureSetKind.ModelOwned && command.OwnerModelId.HasValue)
+            {
+                var removed = textureSet.RemoveModelVersionsNotOwnedBy(
+                    command.OwnerModelId.Value, _dateTimeProvider.UtcNow);
+
+                // Invalidate each unlinked model version's cached .blend so it
+                // regenerates without the removed texture set (mirrors the
+                // disassociate-from-model-version flow).
+                foreach (var mapping in removed.DistinctBy(m => m.ModelVersionId))
+                {
+                    _blendFileGenerator.InvalidateCache(
+                        mapping.ModelVersion.Model.Id, mapping.ModelVersionId);
+                }
+            }
+
             var updated = await _textureSetRepository.UpdateAsync(textureSet, cancellationToken);
 
             // Auto-enqueue thumbnail generation when kind changes to Universal
@@ -65,5 +86,5 @@ internal class UpdateTextureSetKindCommandHandler : ICommandHandler<UpdateTextur
     }
 }
 
-public record UpdateTextureSetKindCommand(int Id, TextureSetKind Kind) : ICommand<UpdateTextureSetKindResponse>;
+public record UpdateTextureSetKindCommand(int Id, TextureSetKind Kind, int? OwnerModelId = null) : ICommand<UpdateTextureSetKindResponse>;
 public record UpdateTextureSetKindResponse(int Id, TextureSetKind Kind);

--- a/src/Application/TextureSets/UpdateTextureSetKindCommand.cs
+++ b/src/Application/TextureSets/UpdateTextureSetKindCommand.cs
@@ -34,6 +34,21 @@ internal class UpdateTextureSetKindCommandHandler : ICommandHandler<UpdateTextur
     {
         try
         {
+            if (!Enum.IsDefined(typeof(TextureSetKind), command.Kind))
+            {
+                return Result.Failure<UpdateTextureSetKindResponse>(
+                    new Error("InvalidTextureSetKind", $"'{(int)command.Kind}' is not a valid texture set kind."));
+            }
+
+            // A single-model (ModelOwned) set must be tied to exactly one model,
+            // so the owner must be known — otherwise the set could end up
+            // ModelOwned while still linked to several models.
+            if (command.Kind == TextureSetKind.ModelOwned && !command.OwnerModelId.HasValue)
+            {
+                return Result.Failure<UpdateTextureSetKindResponse>(
+                    new Error("OwnerModelIdRequired", "Converting a texture set to Single Model requires an owner model id."));
+            }
+
             var textureSet = await _textureSetRepository.GetByIdAsync(command.Id, cancellationToken);
             if (textureSet == null)
             {
@@ -45,7 +60,7 @@ internal class UpdateTextureSetKindCommandHandler : ICommandHandler<UpdateTextur
 
             // Converting to a single-model (ModelOwned) kind ties the texture
             // set to exactly one model — drop links to every other model.
-            if (command.Kind == TextureSetKind.ModelOwned && command.OwnerModelId.HasValue)
+            if (command.Kind == TextureSetKind.ModelOwned)
             {
                 var removed = textureSet.RemoveModelVersionsNotOwnedBy(
                     command.OwnerModelId.Value, _dateTimeProvider.UtcNow);

--- a/src/Domain/Models/TextureSet.cs
+++ b/src/Domain/Models/TextureSet.cs
@@ -532,6 +532,29 @@ public class TextureSet : AggregateRoot
     }
 
     /// <summary>
+    /// Removes every model-version mapping that does not belong to the given
+    /// owner model. Used when converting a texture set to the single-model
+    /// (ModelOwned) kind so it stays tied to exactly one model.
+    /// Requires ModelVersion.Model to be loaded on each mapping.
+    /// </summary>
+    /// <param name="ownerModelId">The model that should remain associated</param>
+    /// <param name="updatedAt">When the change occurred</param>
+    /// <returns>The mappings that were removed.</returns>
+    public IReadOnlyList<ModelVersionTextureSet> RemoveModelVersionsNotOwnedBy(int ownerModelId, DateTime updatedAt)
+    {
+        var toRemove = _modelVersionMappings
+            .Where(m => m.ModelVersion.Model.Id != ownerModelId)
+            .ToList();
+        foreach (var mapping in toRemove)
+        {
+            _modelVersionMappings.Remove(mapping);
+        }
+        if (toRemove.Count > 0)
+            UpdatedAt = updatedAt;
+        return toRemove;
+    }
+
+    /// <summary>
     /// Checks if this texture set is associated with a model version with the specified ID.
     /// </summary>
     /// <param name="modelVersionId">The model version ID to check</param>

--- a/src/Domain/ValueObjects/TextureSetKind.cs
+++ b/src/Domain/ValueObjects/TextureSetKind.cs
@@ -18,7 +18,13 @@ public enum TextureSetKind
     /// Suitable for large surfaces (walls, floors, terrain) and modular kits.
     /// Exists independently of any model and supports tiling scale metadata.
     /// </summary>
-    Universal = 1
+    Universal = 1,
+
+    /// <summary>
+    /// Owned by a single model — never surfaced in cross-model browsing or
+    /// linking pickers. Lives inside the owning model's Materials panel.
+    /// </summary>
+    ModelOwned = 2
 }
 
 /// <summary>
@@ -33,8 +39,9 @@ public static class TextureSetKindExtensions
     {
         return kind switch
         {
-            TextureSetKind.ModelSpecific => "Model-Specific (Baked/Unique)",
+            TextureSetKind.ModelSpecific => "Multi-Model (Baked/Unique)",
             TextureSetKind.Universal => "Universal (Tileable/Global)",
+            TextureSetKind.ModelOwned => "Model-Owned (Single-Model)",
             _ => "Unknown"
         };
     }
@@ -46,8 +53,9 @@ public static class TextureSetKindExtensions
     {
         return kind switch
         {
-            TextureSetKind.ModelSpecific => "Model-Specific",
+            TextureSetKind.ModelSpecific => "Multi-Model",
             TextureSetKind.Universal => "Universal",
+            TextureSetKind.ModelOwned => "Model-Owned",
             _ => "Unknown"
         };
     }

--- a/src/WebApi/Endpoints/TextureSetEndpoints.cs
+++ b/src/WebApi/Endpoints/TextureSetEndpoints.cs
@@ -105,7 +105,7 @@ public static class TextureSetEndpoints
         // Kind update
         app.MapPut("/texture-sets/{id}/kind", UpdateTextureSetKind)
             .WithName("Update Texture Set Kind")
-            .WithSummary("Updates the kind of a texture set (ModelSpecific or Universal)")
+            .WithSummary("Updates the kind of a texture set (ModelSpecific, Universal or ModelOwned)")
             .WithOpenApi();
 
         // Tiling scale (Universal texture sets only)
@@ -459,7 +459,7 @@ public static class TextureSetEndpoints
         CancellationToken cancellationToken)
     {
         var result = await commandHandler.Handle(
-            new UpdateTextureSetKindCommand(id, request.Kind),
+            new UpdateTextureSetKindCommand(id, request.Kind, request.OwnerModelId),
             cancellationToken);
 
         if (result.IsFailure)
@@ -595,7 +595,7 @@ public static class TextureSetEndpoints
 // Request DTOs
 public record CreateTextureSetRequest(string Name, TextureSetKind? Kind = null, int? CategoryId = null);
 public record UpdateTextureSetRequest(string Name, int? CategoryId);
-public record UpdateTextureSetKindRequest(TextureSetKind Kind);
+public record UpdateTextureSetKindRequest(TextureSetKind Kind, int? OwnerModelId = null);
 public record UpdateTilingScaleRequest(float TilingScaleX, float TilingScaleY, UvMappingMode? UvMappingMode = null, float? UvScale = null);
 public record AddTextureToTextureSetRequest(int FileId, TextureType TextureType, TextureChannel? SourceChannel = null);
 public record ChangeTextureTypeRequest(TextureType? TextureType);

--- a/src/frontend/src/components/layout/DraggableTab.tsx
+++ b/src/frontend/src/components/layout/DraggableTab.tsx
@@ -66,7 +66,7 @@ const getTabTooltip = (tab: Tab): string => {
     case 'globalMaterials':
       return 'Global Materials'
     case 'modelTextures':
-      return 'Model Textures'
+      return 'Multi-Model Textures'
     case 'textureSetViewer': {
       return `Texture Set: ${tab.label || tab.setId || 'Unknown'}`
     }

--- a/src/frontend/src/components/layout/NewTabPage.tsx
+++ b/src/frontend/src/components/layout/NewTabPage.tsx
@@ -72,10 +72,10 @@ const TILES: Tile[] = [
     key: 'model-textures',
     group: 'assets',
     icon: 'pi-images',
-    label: 'Model Textures',
-    description: 'Textures bound to a specific model and its UVs.',
+    label: 'Multi-Model Textures',
+    description: 'Baked texture sets that can be shared across multiple models.',
     targetType: 'modelTextures',
-    targetLabel: 'Model Textures',
+    targetLabel: 'Multi-Model Textures',
   },
   {
     key: 'environment-maps',

--- a/src/frontend/src/components/layout/NewTabPage.tsx
+++ b/src/frontend/src/components/layout/NewTabPage.tsx
@@ -73,7 +73,8 @@ const TILES: Tile[] = [
     group: 'assets',
     icon: 'pi-images',
     label: 'Multi-Model Textures',
-    description: 'Baked texture sets that can be shared across multiple models.',
+    description:
+      'Baked texture sets that can be shared across multiple models.',
     targetType: 'modelTextures',
     targetLabel: 'Multi-Model Textures',
   },

--- a/src/frontend/src/components/layout/__tests__/NewTabPage.test.tsx
+++ b/src/frontend/src/components/layout/__tests__/NewTabPage.test.tsx
@@ -72,7 +72,7 @@ describe('NewTabPage', () => {
 
     expect(screen.getByText('Models')).toBeInTheDocument()
     expect(screen.getByText('Global Materials')).toBeInTheDocument()
-    expect(screen.getByText('Model Textures')).toBeInTheDocument()
+    expect(screen.getByText('Multi-Model Textures')).toBeInTheDocument()
     expect(screen.getByText('Projects')).toBeInTheDocument()
     expect(screen.getByText('Settings')).toBeInTheDocument()
 
@@ -160,7 +160,7 @@ describe('NewTabPage', () => {
     expect(setActiveTab).toHaveBeenCalledWith(updated[0].id)
   })
 
-  it('opens a dedicated modelTextures tab when Model Textures is picked', () => {
+  it('opens a dedicated modelTextures tab when Multi-Model Textures is picked', () => {
     const setTabs = jest.fn()
     const setActiveTab = jest.fn()
     const ctx = makeContextValue({
@@ -171,12 +171,12 @@ describe('NewTabPage', () => {
     })
     renderWithContext(<NewTabPage tabId="newTab" />, ctx)
 
-    fireEvent.click(screen.getByText('Model Textures'))
+    fireEvent.click(screen.getByText('Multi-Model Textures'))
 
     const [updated] = setTabs.mock.calls[0]
     expect(updated[0]).toMatchObject({
       type: 'modelTextures',
-      label: 'Model Textures',
+      label: 'Multi-Model Textures',
     })
     expect(setActiveTab).toHaveBeenCalledWith(updated[0].id)
   })

--- a/src/frontend/src/features/model-viewer/components/MaterialsPanel.css
+++ b/src/frontend/src/features/model-viewer/components/MaterialsPanel.css
@@ -90,11 +90,32 @@
   background: var(--surface-card, #2a2a2a);
 }
 
+.materials-item-clickable {
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.materials-item-clickable:hover,
+.materials-item-clickable:focus-visible {
+  background: var(--surface-hover, #333);
+  border-color: var(--primary-color, #4a9eff);
+  outline: none;
+}
+
 .materials-item-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.25rem;
   margin-bottom: 0.25rem;
+}
+
+.materials-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
 }
 
 .materials-item-name {
@@ -118,7 +139,6 @@
   align-items: center;
   justify-content: center;
   background: var(--surface-hover, #333);
-  cursor: pointer;
   flex-shrink: 0;
 }
 

--- a/src/frontend/src/features/model-viewer/components/MaterialsPanel.tsx
+++ b/src/frontend/src/features/model-viewer/components/MaterialsPanel.tsx
@@ -1,10 +1,13 @@
 import './MaterialsPanel.css'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { Badge } from 'primereact/badge'
 import { Button } from 'primereact/button'
 import { confirmDialog } from 'primereact/confirmdialog'
+import { ContextMenu } from 'primereact/contextmenu'
 import { Dropdown } from 'primereact/dropdown'
 import { InputText } from 'primereact/inputtext'
+import type { MenuItem } from 'primereact/menuitem'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 
@@ -17,9 +20,17 @@ import { useModelByIdQuery } from '@/features/model-viewer/api/queries'
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
 import { getFilePreviewUrl } from '@/features/models/api/modelApi'
 import { useTextureSetsByModelVersionQuery } from '@/features/texture-set/api/queries'
-import { disassociateTextureSetFromModelVersion } from '@/features/texture-set/api/textureSetApi'
+import {
+  associateTextureSetWithModelVersion,
+  createTextureSet,
+  disassociateTextureSetFromModelVersion,
+  getTextureSetById,
+  updateTextureSetKind,
+} from '@/features/texture-set/api/textureSetApi'
+import { CreateTextureSetDialog } from '@/features/texture-set/dialogs/CreateTextureSetDialog'
 import { TextureType } from '@/features/texture-set/types'
-import { type TextureSetDto } from '@/types'
+import { useTabContext } from '@/hooks/useTabContext'
+import { type TextureSetDto, TextureSetKind } from '@/types'
 
 import { TextureSetAssociationDialog } from './TextureSetAssociationDialog'
 
@@ -67,6 +78,17 @@ export function MaterialsPanel({
   const [newPresetName, setNewPresetName] = useState('')
   const [deletingPreset, setDeletingPreset] = useState(false)
   const newPresetInputRef = useRef<HTMLInputElement>(null)
+  const [createSetDialogVisible, setCreateSetDialogVisible] = useState(false)
+  const [creatingForMaterial, setCreatingForMaterial] = useState<string | null>(
+    null
+  )
+  const [contextTextureSet, setContextTextureSet] =
+    useState<TextureSetDto | null>(null)
+  const [convertingId, setConvertingId] = useState<number | null>(null)
+  const contextMenuRef = useRef<ContextMenu>(null)
+
+  const queryClient = useQueryClient()
+  const { openTextureSetDetailsTab } = useTabContext()
 
   // Sync selectedVariant to mainVariantName when version changes
   useEffect(() => {
@@ -252,6 +274,33 @@ export function MaterialsPanel({
     onModelUpdated()
   }
 
+  const handleOpenCreateSetDialog = (materialName: string) => {
+    setCreatingForMaterial(materialName)
+    setCreateSetDialogVisible(true)
+  }
+
+  const handleCloseCreateSetDialog = () => {
+    setCreateSetDialogVisible(false)
+    setCreatingForMaterial(null)
+  }
+
+  const handleCreateOwnedSet = async (name: string, kind: TextureSetKind) => {
+    if (!modelVersionId || creatingForMaterial === null) return
+    const created = await createTextureSet({ name, kind })
+    const apiMaterialName =
+      creatingForMaterial === 'Default' ? '' : creatingForMaterial
+    await associateTextureSetWithModelVersion(
+      created.id,
+      modelVersionId,
+      apiMaterialName,
+      selectedVariant
+    )
+    await textureSetsQuery.refetch()
+    onModelUpdated()
+    openTextureSetDetailsTab(created.id, created.name)
+    handleCloseCreateSetDialog()
+  }
+
   const handleUnlinkMaterial = async (
     materialName: string,
     textureSetId?: number
@@ -294,6 +343,107 @@ export function MaterialsPanel({
       setUnlinking(null)
     }
   }
+
+  // Apply a kind change and refresh every texture-set-derived query so the
+  // Materials panel, link picker and texture set pages all stay in sync.
+  const applyKindChange = useCallback(
+    async (ts: TextureSetDto, kind: TextureSetKind, ownerModelId?: number) => {
+      try {
+        setConvertingId(ts.id)
+        await updateTextureSetKind(ts.id, kind, ownerModelId)
+        // Converting to Single Model unlinks the set from other models, so
+        // refresh texture-set, model and version queries — any open model
+        // viewer must drop the now-stale mapping from its 3D preview.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['textureSets'] }),
+          queryClient.invalidateQueries({ queryKey: ['modelVersions'] }),
+          queryClient.invalidateQueries({ queryKey: ['models'] }),
+        ])
+        onModelUpdated()
+      } catch (error) {
+        console.error('Failed to change texture set kind:', error)
+      } finally {
+        setConvertingId(null)
+      }
+    },
+    [queryClient, onModelUpdated]
+  )
+
+  // Multi-Model → Single Model. Single-model sets belong to exactly one model,
+  // so warn (and list) when other models would be unlinked by the conversion.
+  const handleConvertToSingleModel = useCallback(
+    async (ts: TextureSetDto) => {
+      const currentModelId = Number(modelId)
+
+      // The cached texture set may be stale — e.g. it was linked to another
+      // model from a different panel since this list was loaded. Re-fetch so
+      // the unlink warning reflects the set's actual associations.
+      let associatedModels = ts.associatedModels
+      try {
+        const fresh = await getTextureSetById(ts.id)
+        associatedModels = fresh.associatedModels
+      } catch (error) {
+        console.error('Failed to refresh texture set associations:', error)
+      }
+
+      const otherModels = Array.from(
+        new Map(
+          associatedModels
+            .filter(m => m.id !== currentModelId)
+            .map(m => [m.id, m.name])
+        ).values()
+      )
+
+      if (otherModels.length > 0) {
+        const label = otherModels.length === 1 ? 'model' : 'models'
+        confirmDialog({
+          header: 'Convert to Single Model Texture Set',
+          message: `"${ts.name}" is also linked to ${otherModels.length} other ${label}: ${otherModels.join(', ')}.\n\nConverting it will unlink the texture set from ${otherModels.length === 1 ? 'that model' : 'those models'}. Continue?`,
+          icon: 'pi pi-exclamation-triangle',
+          acceptLabel: 'Convert & Unlink',
+          rejectLabel: 'Cancel',
+          acceptClassName: 'p-button-danger',
+          accept: () =>
+            applyKindChange(ts, TextureSetKind.ModelOwned, currentModelId),
+        })
+        return
+      }
+
+      applyKindChange(ts, TextureSetKind.ModelOwned, currentModelId)
+    },
+    [modelId, applyKindChange]
+  )
+
+  // Single Model → Multi-Model. No data is lost, so convert without a prompt.
+  const handleConvertToMultiModel = useCallback(
+    (ts: TextureSetDto) => {
+      applyKindChange(ts, TextureSetKind.ModelSpecific)
+    },
+    [applyKindChange]
+  )
+
+  const contextMenuItems = useMemo<MenuItem[]>(() => {
+    if (!contextTextureSet) return []
+    if (contextTextureSet.kind === TextureSetKind.ModelSpecific) {
+      return [
+        {
+          label: 'Convert to Single Model Texture Set',
+          icon: 'pi pi-box',
+          command: () => handleConvertToSingleModel(contextTextureSet),
+        },
+      ]
+    }
+    if (contextTextureSet.kind === TextureSetKind.ModelOwned) {
+      return [
+        {
+          label: 'Convert to Multi-Model Texture Set',
+          icon: 'pi pi-images',
+          command: () => handleConvertToMultiModel(contextTextureSet),
+        },
+      ]
+    }
+    return []
+  }, [contextTextureSet, handleConvertToSingleModel, handleConvertToMultiModel])
 
   // Use persisted variant names from backend (no longer need localPresets)
   // Filter out '' (Default) and '__embedded__' which are shown as fixed options
@@ -410,30 +560,77 @@ export function MaterialsPanel({
                 <div className="materials-item-header">
                   <span className="materials-item-name">{materialName}</span>
                   {!isEmbeddedPreset && (
-                    <Button
-                      icon="pi pi-link"
-                      label="Link Texture Set"
-                      className="p-button-sm p-button-text"
-                      onClick={() => handleLinkTextureSet(materialName)}
-                      size="small"
-                      data-testid={`link-ts-${materialName}`}
-                    />
+                    <div className="materials-item-actions">
+                      <Button
+                        icon="pi pi-link"
+                        className="p-button-sm p-button-text"
+                        onClick={() => handleLinkTextureSet(materialName)}
+                        tooltip="Link Texture Set"
+                        tooltipOptions={{ position: 'top' }}
+                        aria-label="Link Texture Set"
+                        size="small"
+                        data-testid={`link-ts-${materialName}`}
+                      />
+                      <Button
+                        icon="pi pi-plus"
+                        className="p-button-sm p-button-text"
+                        onClick={() => handleOpenCreateSetDialog(materialName)}
+                        tooltip="Add new texture set"
+                        tooltipOptions={{ position: 'top' }}
+                        aria-label="Add new texture set"
+                        size="small"
+                        data-testid={`add-ts-${materialName}`}
+                      />
+                      {linkedSets.length > 0 && (
+                        <Button
+                          icon="pi pi-times"
+                          className="p-button-text p-button-sm p-button-danger"
+                          onClick={() => handleUnlinkMaterial(materialName)}
+                          loading={unlinking === materialName}
+                          tooltip="Unlink"
+                          tooltipOptions={{ position: 'top' }}
+                          aria-label="Unlink"
+                          size="small"
+                          data-testid={`unlink-ts-${materialName}`}
+                        />
+                      )}
+                    </div>
                   )}
                 </div>
                 {linkedSets.map(linkedTs => {
                   const previewUrl = getPreviewUrl(linkedTs)
+                  const openSet = () => {
+                    onTextureSetSelect(linkedTs.id)
+                    openTextureSetDetailsTab(linkedTs.id, linkedTs.name)
+                  }
+                  const canConvert =
+                    linkedTs.kind === TextureSetKind.ModelSpecific ||
+                    linkedTs.kind === TextureSetKind.ModelOwned
                   return (
                     <div
                       key={`${materialName}-${linkedTs.id}`}
-                      className="materials-item"
+                      className="materials-item materials-item-clickable"
                       data-testid={`material-item-${materialName}-${linkedTs.id}`}
                       data-texture-set={linkedTs.name}
+                      role="button"
+                      tabIndex={0}
+                      onClick={openSet}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          openSet()
+                        }
+                      }}
+                      onContextMenu={e => {
+                        if (!canConvert || convertingId !== null) return
+                        e.preventDefault()
+                        setContextTextureSet(linkedTs)
+                        contextMenuRef.current?.show(e)
+                      }}
+                      title={`Open ${linkedTs.name} in a new tab`}
                     >
                       <div className="materials-item-linked">
-                        <div
-                          className="materials-item-preview"
-                          onClick={() => onTextureSetSelect(linkedTs.id)}
-                        >
+                        <div className="materials-item-preview">
                           {previewUrl ? (
                             <img
                               src={previewUrl}
@@ -453,17 +650,6 @@ export function MaterialsPanel({
                             {linkedTs.textureCount !== 1 ? 's' : ''}
                           </span>
                         </div>
-                        <Button
-                          icon="pi pi-times"
-                          className="p-button-text p-button-sm p-button-danger"
-                          onClick={() =>
-                            handleUnlinkMaterial(materialName, linkedTs.id)
-                          }
-                          loading={unlinking === materialName}
-                          tooltip="Unlink"
-                          tooltipOptions={{ position: 'left' }}
-                          size="small"
-                        />
                       </div>
                     </div>
                   )
@@ -504,6 +690,24 @@ export function MaterialsPanel({
           onAssociationsChanged={handleLinkDialogClose}
         />
       )}
+
+      <CreateTextureSetDialog
+        visible={createSetDialogVisible}
+        onHide={handleCloseCreateSetDialog}
+        onSubmit={handleCreateOwnedSet}
+        lockedKind={TextureSetKind.ModelOwned}
+        header={
+          creatingForMaterial
+            ? `New Texture Set — ${creatingForMaterial}`
+            : 'New Texture Set'
+        }
+      />
+
+      <ContextMenu
+        ref={contextMenuRef}
+        model={contextMenuItems}
+        onHide={() => setContextTextureSet(null)}
+      />
     </div>
   )
 }

--- a/src/frontend/src/features/model-viewer/components/MaterialsPanel.tsx
+++ b/src/frontend/src/features/model-viewer/components/MaterialsPanel.tsx
@@ -8,6 +8,7 @@ import { ContextMenu } from 'primereact/contextmenu'
 import { Dropdown } from 'primereact/dropdown'
 import { InputText } from 'primereact/inputtext'
 import type { MenuItem } from 'primereact/menuitem'
+import { Toast } from 'primereact/toast'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 
@@ -86,6 +87,7 @@ export function MaterialsPanel({
     useState<TextureSetDto | null>(null)
   const [convertingId, setConvertingId] = useState<number | null>(null)
   const contextMenuRef = useRef<ContextMenu>(null)
+  const toastRef = useRef<Toast>(null)
 
   const queryClient = useQueryClient()
   const { openTextureSetDetailsTab } = useTabContext()
@@ -286,15 +288,30 @@ export function MaterialsPanel({
 
   const handleCreateOwnedSet = async (name: string, kind: TextureSetKind) => {
     if (!modelVersionId || creatingForMaterial === null) return
-    const created = await createTextureSet({ name, kind })
     const apiMaterialName =
       creatingForMaterial === 'Default' ? '' : creatingForMaterial
-    await associateTextureSetWithModelVersion(
-      created.id,
-      modelVersionId,
-      apiMaterialName,
-      selectedVariant
-    )
+
+    let created: { id: number; name: string }
+    try {
+      created = await createTextureSet({ name, kind })
+      await associateTextureSetWithModelVersion(
+        created.id,
+        modelVersionId,
+        apiMaterialName,
+        selectedVariant
+      )
+    } catch (error) {
+      console.error('Failed to create texture set:', error)
+      toastRef.current?.show({
+        severity: 'error',
+        summary: 'Create failed',
+        detail: 'Could not create the texture set. Please try again.',
+        life: 4000,
+      })
+      // Rethrow so the dialog stays open and the user can retry.
+      throw error
+    }
+
     await textureSetsQuery.refetch()
     onModelUpdated()
     openTextureSetDetailsTab(created.id, created.name)
@@ -308,37 +325,42 @@ export function MaterialsPanel({
     if (!modelVersionId) return
     // Map 'Default' display name to '' for API calls
     const apiMaterialName = materialName === 'Default' ? '' : materialName
-    const mapping = textureSetId
-      ? currentVariantMappings.find(
-          m =>
-            m.textureSetId === textureSetId &&
-            (m.materialName === apiMaterialName ||
-              (materialName === 'Default' && m.materialName === ''))
+    const matchesMaterial = (m: { materialName: string }) =>
+      m.materialName === apiMaterialName ||
+      (materialName === 'Default' && m.materialName === '')
+    // With a texture set id, unlink only that set; without one (the header
+    // button), unlink every set linked to the material in this variant.
+    const mappings = textureSetId
+      ? currentVariantMappings.filter(
+          m => m.textureSetId === textureSetId && matchesMaterial(m)
         )
-      : currentVariantMappings.find(
-          m =>
-            m.materialName === apiMaterialName ||
-            (materialName === 'Default' && m.materialName === '')
-        )
-    if (!mapping) return
+      : currentVariantMappings.filter(matchesMaterial)
+    if (mappings.length === 0) return
 
     try {
       setUnlinking(materialName)
-      await disassociateTextureSetFromModelVersion(
-        mapping.textureSetId,
-        modelVersionId,
-        mapping.materialName,
-        selectedVariant
-      )
-
-      if (selectedTextureSetId === mapping.textureSetId) {
-        onTextureSetSelect(null)
+      for (const mapping of mappings) {
+        await disassociateTextureSetFromModelVersion(
+          mapping.textureSetId,
+          modelVersionId,
+          mapping.materialName,
+          selectedVariant
+        )
+        if (selectedTextureSetId === mapping.textureSetId) {
+          onTextureSetSelect(null)
+        }
       }
 
       await textureSetsQuery.refetch()
       onModelUpdated()
     } catch (error) {
       console.error('Failed to unlink material:', error)
+      toastRef.current?.show({
+        severity: 'error',
+        summary: 'Unlink failed',
+        detail: 'Could not unlink the texture set. Please try again.',
+        life: 4000,
+      })
     } finally {
       setUnlinking(null)
     }
@@ -362,6 +384,12 @@ export function MaterialsPanel({
         onModelUpdated()
       } catch (error) {
         console.error('Failed to change texture set kind:', error)
+        toastRef.current?.show({
+          severity: 'error',
+          summary: 'Conversion failed',
+          detail: 'Could not change the texture set kind. Please try again.',
+          life: 4000,
+        })
       } finally {
         setConvertingId(null)
       }
@@ -708,6 +736,8 @@ export function MaterialsPanel({
         model={contextMenuItems}
         onHide={() => setContextTextureSet(null)}
       />
+
+      <Toast ref={toastRef} />
     </div>
   )
 }

--- a/src/frontend/src/features/model-viewer/components/TextureSetAssociationDialog.tsx
+++ b/src/frontend/src/features/model-viewer/components/TextureSetAssociationDialog.tsx
@@ -17,6 +17,7 @@ import {
 import {
   type PackSummaryDto,
   type TextureSetDto,
+  TextureSetKind,
   TextureType,
 } from '@/features/texture-set/types'
 import type { Model } from '@/utils/fileUtils'
@@ -38,7 +39,7 @@ interface TextureSetAssociationDialogProps {
 
 export function TextureSetAssociationDialog({
   visible,
-  model: _model,
+  model,
   modelVersionId,
   materialName,
   variantName,
@@ -46,6 +47,7 @@ export function TextureSetAssociationDialog({
   onHide,
   onAssociationsChanged,
 }: TextureSetAssociationDialogProps) {
+  const currentModelId = Number(model.id)
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const [originalId, setOriginalId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
@@ -178,9 +180,17 @@ export function TextureSetAssociationDialog({
     onHide()
   }
 
-  // Filter texture sets
+  // Filter + group texture sets. Model-owned sets are private to their
+  // owning model — they're hidden outright when viewing a different model.
   const allTextureSets = allTextureSetsQuery.data ?? []
-  const filteredTextureSets = allTextureSets.filter(ts => {
+  const isLinkedToCurrentModel = (ts: TextureSetDto) =>
+    ts.associatedModels.some(m => m.id === currentModelId)
+
+  const matchedTextureSets = allTextureSets.filter(ts => {
+    if (ts.kind === TextureSetKind.ModelOwned && !isLinkedToCurrentModel(ts)) {
+      return false
+    }
+
     const matchesSearch = ts.name
       .toLowerCase()
       .includes(searchQuery.toLowerCase())
@@ -191,6 +201,21 @@ export function TextureSetAssociationDialog({
 
     return matchesSearch && matchesPack
   })
+
+  // Three exclusive groups; "This Model" wins over kind-based groups so a
+  // texture set already used on this model surfaces in one place only.
+  const thisModelSets = matchedTextureSets.filter(ts =>
+    isLinkedToCurrentModel(ts)
+  )
+  const multiModelSets = matchedTextureSets.filter(
+    ts =>
+      ts.kind === TextureSetKind.ModelSpecific && !isLinkedToCurrentModel(ts)
+  )
+  const globalMaterialSets = matchedTextureSets.filter(
+    ts => ts.kind === TextureSetKind.Universal && !isLinkedToCurrentModel(ts)
+  )
+  const totalMatched =
+    thisModelSets.length + multiModelSets.length + globalMaterialSets.length
 
   const handlePackFilterToggle = (packId: number) => {
     setSelectedPackIds(prev =>
@@ -271,33 +296,74 @@ export function TextureSetAssociationDialog({
             <i className="pi pi-spin pi-spinner" />
             <p>Loading texture sets...</p>
           </div>
-        ) : (
-          <div className="association-section">
-            <h4 className="section-header">
-              <i className="pi pi-image" />
-              Texture Sets ({filteredTextureSets.length})
-            </h4>
-            {filteredTextureSets.length === 0 ? (
-              <div className="no-results">
-                <i className="pi pi-inbox" />
-                <p>No texture sets found</p>
-              </div>
-            ) : (
-              <div className="texture-sets-card-grid">
-                {filteredTextureSets.map(ts => (
-                  <TextureSetCard
-                    key={ts.id}
-                    textureSet={ts}
-                    isSelected={ts.id === selectedId}
-                    onSelect={handleSelect}
-                  />
-                ))}
-              </div>
-            )}
+        ) : totalMatched === 0 ? (
+          <div className="no-results">
+            <i className="pi pi-inbox" />
+            <p>No texture sets found</p>
           </div>
+        ) : (
+          <>
+            <TextureSetGroup
+              icon="pi-box"
+              title="This Model Textures"
+              sets={thisModelSets}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+            />
+            <TextureSetGroup
+              icon="pi-images"
+              title="Multi-Model Textures"
+              sets={multiModelSets}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+            />
+            <TextureSetGroup
+              icon="pi-palette"
+              title="Global Materials"
+              sets={globalMaterialSets}
+              selectedId={selectedId}
+              onSelect={handleSelect}
+            />
+          </>
         )}
       </div>
     </Dialog>
+  )
+}
+
+interface TextureSetGroupProps {
+  icon: string
+  title: string
+  sets: TextureSetDto[]
+  selectedId: number | null
+  onSelect: (textureSetId: number) => void
+}
+
+function TextureSetGroup({
+  icon,
+  title,
+  sets,
+  selectedId,
+  onSelect,
+}: TextureSetGroupProps) {
+  if (sets.length === 0) return null
+  return (
+    <div className="association-section">
+      <h4 className="section-header">
+        <i className={`pi ${icon}`} />
+        {title} ({sets.length})
+      </h4>
+      <div className="texture-sets-card-grid">
+        {sets.map(ts => (
+          <TextureSetCard
+            key={ts.id}
+            textureSet={ts}
+            isSelected={ts.id === selectedId}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/src/frontend/src/features/texture-set/api/textureSetApi.ts
+++ b/src/frontend/src/features/texture-set/api/textureSetApi.ts
@@ -249,7 +249,8 @@ export async function regenerateTextureSetThumbnail(
 
 export async function updateTextureSetKind(
   textureSetId: number,
-  kind: number
+  kind: number,
+  ownerModelId?: number
 ): Promise<void> {
-  await client.put(`/texture-sets/${textureSetId}/kind`, { kind })
+  await client.put(`/texture-sets/${textureSetId}/kind`, { kind, ownerModelId })
 }

--- a/src/frontend/src/features/texture-set/components/TextureSetList.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetList.tsx
@@ -29,7 +29,7 @@ type KindFilter = 'model-specific' | 'universal'
 const kindFilterOptions: { label: string; value: KindFilter; kind: number }[] =
   [
     {
-      label: 'Model-Specific',
+      label: 'Multi-Model',
       value: 'model-specific',
       kind: TextureSetKind.ModelSpecific,
     },
@@ -40,7 +40,7 @@ const kindFilterOptions: { label: string; value: KindFilter; kind: number }[] =
     },
   ]
 
-function kindFilterToApiKind(filter: KindFilter): number {
+function kindFilterToApiKind(filter: KindFilter): TextureSetKind {
   switch (filter) {
     case 'model-specific':
       return TextureSetKind.ModelSpecific
@@ -222,7 +222,7 @@ export function TextureSetList({ kind }: TextureSetListProps = {}) {
           kind === TextureSetKind.Universal
             ? 'Global Materials'
             : kind === TextureSetKind.ModelSpecific
-              ? 'Model Textures'
+              ? 'Multi-Model Textures'
               : undefined
         }
         unitLabel={
@@ -340,6 +340,7 @@ export function TextureSetList({ kind }: TextureSetListProps = {}) {
           visible={showCreateDialog}
           onHide={() => setShowCreateDialog(false)}
           onSubmit={handleCreateTextureSet}
+          lockedKind={kind ?? kindFilterToApiKind(kindFilter)}
         />
       )}
     </div>

--- a/src/frontend/src/features/texture-set/components/TextureSetList.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetList.tsx
@@ -340,7 +340,9 @@ export function TextureSetList({ kind }: TextureSetListProps = {}) {
           visible={showCreateDialog}
           onHide={() => setShowCreateDialog(false)}
           onSubmit={handleCreateTextureSet}
-          lockedKind={kind ?? kindFilterToApiKind(kindFilter)}
+          // Dedicated kind pages (Multi-Model / Global Materials) lock the
+          // dialog to their kind; the generic tab keeps the kind selector.
+          lockedKind={kind}
         />
       )}
     </div>

--- a/src/frontend/src/features/texture-set/dialogs/CreateTextureSetDialog.tsx
+++ b/src/frontend/src/features/texture-set/dialogs/CreateTextureSetDialog.tsx
@@ -18,18 +18,30 @@ interface CreateTextureSetDialogProps {
   visible: boolean
   onHide: () => void
   onSubmit: (name: string, kind: TextureSetKind) => Promise<void>
+  /**
+   * When set, the kind is fixed to this value and the kind selector is hidden.
+   * Used by the Materials panel "Add new texture set" flow which always
+   * creates ModelOwned texture sets.
+   */
+  lockedKind?: TextureSetKind
+  /** Optional header override; defaults to "Create Texture Set". */
+  header?: string
 }
 
 export function CreateTextureSetDialog({
   visible,
   onHide,
   onSubmit,
+  lockedKind,
+  header,
 }: CreateTextureSetDialogProps) {
   const [submitting, setSubmitting] = useState(false)
-  const [kind, setKind] = useState<TextureSetKind>(TextureSetKind.ModelSpecific)
+  const [kind, setKind] = useState<TextureSetKind>(
+    lockedKind ?? TextureSetKind.ModelSpecific
+  )
 
   const kindOptions = [
-    { label: 'Model-Specific', value: TextureSetKind.ModelSpecific },
+    { label: 'Multi-Model', value: TextureSetKind.ModelSpecific },
     { label: 'Universal (Tileable)', value: TextureSetKind.Universal },
   ]
 
@@ -52,9 +64,9 @@ export function CreateTextureSetDialog({
   useEffect(() => {
     if (!visible) {
       reset({ name: '' })
-      setKind(TextureSetKind.ModelSpecific)
+      setKind(lockedKind ?? TextureSetKind.ModelSpecific)
     }
-  }, [visible, reset])
+  }, [visible, reset, lockedKind])
 
   const handleValidSubmit = async (values: TextureSetNameFormValues) => {
     try {
@@ -94,7 +106,7 @@ export function CreateTextureSetDialog({
 
   return (
     <Dialog
-      header="Create Texture Set"
+      header={header ?? 'Create Texture Set'}
       visible={visible}
       onHide={handleCancel}
       footer={dialogFooter}
@@ -128,22 +140,24 @@ export function CreateTextureSetDialog({
         </small>
       </div>
 
-      <div className="p-field" style={{ marginTop: '1rem' }}>
-        <label className="p-text-bold">Type</label>
-        <SelectButton
-          value={kind}
-          options={kindOptions}
-          onChange={e => {
-            if (e.value !== null && e.value !== undefined) setKind(e.value)
-          }}
-          style={{ marginTop: '0.5rem' }}
-        />
-        <small className="p-text-secondary">
-          {kind === TextureSetKind.ModelSpecific
-            ? "Baked textures tied to a specific model's UV layout"
-            : 'Tileable/seamless textures for surfaces (walls, floors, terrain)'}
-        </small>
-      </div>
+      {lockedKind === undefined && (
+        <div className="p-field" style={{ marginTop: '1rem' }}>
+          <label className="p-text-bold">Type</label>
+          <SelectButton
+            value={kind}
+            options={kindOptions}
+            onChange={e => {
+              if (e.value !== null && e.value !== undefined) setKind(e.value)
+            }}
+            style={{ marginTop: '0.5rem' }}
+          />
+          <small className="p-text-secondary">
+            {kind === TextureSetKind.ModelSpecific
+              ? "Baked textures tied to a specific model's UV layout"
+              : 'Tileable/seamless textures for surfaces (walls, floors, terrain)'}
+          </small>
+        </div>
+      )}
     </Dialog>
   )
 }

--- a/src/frontend/src/features/texture-set/types/index.ts
+++ b/src/frontend/src/features/texture-set/types/index.ts
@@ -27,6 +27,7 @@ export enum TextureChannel {
 export enum TextureSetKind {
   ModelSpecific = 0,
   Universal = 1,
+  ModelOwned = 2,
 }
 
 export enum UvMappingMode {

--- a/src/frontend/src/stores/navigationStore.ts
+++ b/src/frontend/src/stores/navigationStore.ts
@@ -154,7 +154,7 @@ export function getTabLabel(
     case 'globalMaterials':
       return 'Global Materials'
     case 'modelTextures':
-      return 'Model Textures'
+      return 'Multi-Model Textures'
     case 'textureSetViewer':
       if (setName) return setName
       return setId ? `Set ${setId}` : 'Texture Set'

--- a/tests/e2e/demo-tests/demo-mode.spec.ts
+++ b/tests/e2e/demo-tests/demo-mode.spec.ts
@@ -158,7 +158,7 @@ test.describe("demo mode e2e", () => {
             expect.arrayContaining(["Global Stone Material"]),
         );
 
-        await textureSetsPage.selectKindTab("Model-Specific");
+        await textureSetsPage.selectKindTab("Multi-Model");
         expect(await textureSetsPage.getTextureSetNames()).toEqual(
             expect.arrayContaining(["Basic Texture Set", "Color Textures"]),
         );
@@ -262,7 +262,7 @@ test.describe("demo mode e2e", () => {
         const textureSetName = `Demo Runtime Texture Set ${Date.now()}`;
 
         await textureSetsPage.goto();
-        await textureSetsPage.selectKindTab("Model-Specific");
+        await textureSetsPage.selectKindTab("Multi-Model");
         await textureSetsPage.createEmptyTextureSet(textureSetName);
         await expect(textureSetsPage.getCardByName(textureSetName)).toBeVisible(
             {
@@ -289,7 +289,7 @@ test.describe("demo mode e2e", () => {
         await recycledFilesPage.restoreTextureSet(0);
 
         await textureSetsPage.goto();
-        await textureSetsPage.selectKindTab("Model-Specific");
+        await textureSetsPage.selectKindTab("Multi-Model");
         await expect(textureSetsPage.getCardByName(textureSetName)).toBeVisible(
             {
                 timeout: 15000,

--- a/tests/e2e/features/00-texture-sets/10-texture-set-kind.feature
+++ b/tests/e2e/features/00-texture-sets/10-texture-set-kind.feature
@@ -1,8 +1,8 @@
 @texture-set-kind
-Feature: Texture Set Kind (Model-Specific vs Global Materials)
+Feature: Texture Set Kind (Multi-Model vs Global Materials)
 
   Tests for the texture set kind feature including:
-  - Kind filter tabs (Model-Specific and Global Materials)
+  - Kind filter tabs (Multi-Model and Global Materials)
   - Default tab is Global Materials
   - Creating texture sets with specific kind
   - Changing kind via API
@@ -18,30 +18,30 @@ Feature: Texture Set Kind (Model-Specific vs Global Materials)
   Scenario: Creating texture sets places them in correct kind tabs
     Given I am on the texture sets page
     When I create a model-specific texture set "kind_test_ms" via API
-    And I switch to the "Model-Specific" kind tab
+    And I switch to the "Multi-Model" kind tab
     Then I should see texture set "kind_test_ms" in the grid
     When I switch to the "Global Materials" kind tab
     Then I should not see texture set "kind_test_ms" in the grid
     When I create a universal texture set "kind_test_uni" via API
     And I switch to the "Global Materials" kind tab
     Then I should see texture set "kind_test_uni" in the grid
-    When I switch to the "Model-Specific" kind tab
+    When I switch to the "Multi-Model" kind tab
     Then I should not see texture set "kind_test_uni" in the grid
 
-  Scenario: Changing kind between Model-Specific and Universal via API
+  Scenario: Changing kind between Multi-Model and Universal via API
     Given I am on the texture sets page
     When I create a model-specific texture set "kind_change_test" via API
-    And I switch to the "Model-Specific" kind tab
+    And I switch to the "Multi-Model" kind tab
     Then I should see texture set "kind_change_test" in the grid
     When I change texture set "kind_change_test" kind to Universal via API
     And I reload the page
     And I switch to the "Global Materials" kind tab
     Then I should see texture set "kind_change_test" in the grid
-    When I switch to the "Model-Specific" kind tab
+    When I switch to the "Multi-Model" kind tab
     Then I should not see texture set "kind_change_test" in the grid
     When I change texture set "kind_change_test" kind to ModelSpecific via API
     And I reload the page
-    And I switch to the "Model-Specific" kind tab
+    And I switch to the "Multi-Model" kind tab
     Then I should see texture set "kind_change_test" in the grid
     When I switch to the "Global Materials" kind tab
     Then I should not see texture set "kind_change_test" in the grid
@@ -50,7 +50,7 @@ Feature: Texture Set Kind (Model-Specific vs Global Materials)
     Given I am on the texture sets page
     When I create a model-specific texture set "drag_to_global" via API
     And I reload the page
-    And I switch to the "Model-Specific" kind tab
+    And I switch to the "Multi-Model" kind tab
     Then I should see texture set "drag_to_global" in the grid
     When I drag texture set "drag_to_global" to the "Global Materials" kind tab
     Then I should not see texture set "drag_to_global" in the grid
@@ -60,9 +60,9 @@ Feature: Texture Set Kind (Model-Specific vs Global Materials)
     And I reload the page
     And I switch to the "Global Materials" kind tab
     Then I should see texture set "drag_to_ms" in the grid
-    When I drag texture set "drag_to_ms" to the "Model-Specific" kind tab
+    When I drag texture set "drag_to_ms" to the "Multi-Model" kind tab
     Then I should not see texture set "drag_to_ms" in the grid
-    When I switch to the "Model-Specific" kind tab
+    When I switch to the "Multi-Model" kind tab
     Then I should see texture set "drag_to_ms" in the grid
 
   @timeout:720000 @slow
@@ -79,7 +79,7 @@ Feature: Texture Set Kind (Model-Specific vs Global Materials)
     And I right-click on texture set "ctx_uni_regen"
     Then I should see "Regenerate Thumbnail" in the context menu
     When I create a model-specific texture set "ctx_ms_no_regen" via API
-    And I switch to the "Model-Specific" kind tab
+    And I switch to the "Multi-Model" kind tab
     And I right-click on texture set "ctx_ms_no_regen"
     Then I should not see "Regenerate Thumbnail" in the context menu
 

--- a/tests/e2e/features/00-texture-sets/18-texture-set-kind-conversion.feature
+++ b/tests/e2e/features/00-texture-sets/18-texture-set-kind-conversion.feature
@@ -1,0 +1,50 @@
+@texture-set-conversion @depends-on:setup
+Feature: Convert Texture Set Kind from the Materials Panel
+
+  A texture set linked to a model can be converted between Multi-Model and
+  Single Model kinds via the right-click context menu on its materials-item.
+  Converting a Multi-Model set that is shared with other models warns the
+  user and unlinks it from those models.
+
+  Background:
+    Given the following models exist in shared state:
+      | name                 |
+      | single-version-model |
+      | multi-version-model  |
+
+  Scenario: Context menu offers Single Model conversion for a Multi-Model set
+    Given a Multi-Model texture set "conv_ctx_ms" linked to "single-version-model"
+    And I am on the model viewer page for "single-version-model"
+    When I right-click the material item for texture set "conv_ctx_ms"
+    Then I should see "Convert to Single Model Texture Set" in the context menu
+
+  Scenario: Context menu offers Multi-Model conversion for a Single Model set
+    Given a Single Model texture set "conv_ctx_owned" linked to "single-version-model"
+    And I am on the model viewer page for "single-version-model"
+    When I right-click the material item for texture set "conv_ctx_owned"
+    Then I should see "Convert to Multi-Model Texture Set" in the context menu
+
+  Scenario: Convert a Multi-Model texture set to Single Model
+    Given a Multi-Model texture set "conv_to_single" linked to "single-version-model"
+    And I am on the model viewer page for "single-version-model"
+    When I right-click the material item for texture set "conv_to_single"
+    And I click "Convert to Single Model Texture Set" in the context menu
+    Then texture set "conv_to_single" should have kind "Single Model" via API
+
+  Scenario: Convert a Single Model texture set back to Multi-Model
+    Given a Single Model texture set "conv_to_multi" linked to "single-version-model"
+    And I am on the model viewer page for "single-version-model"
+    When I right-click the material item for texture set "conv_to_multi"
+    And I click "Convert to Multi-Model Texture Set" in the context menu
+    Then texture set "conv_to_multi" should have kind "Multi-Model" via API
+
+  Scenario: Converting a shared texture set warns and unlinks the other model
+    Given a Multi-Model texture set "conv_shared" linked to "single-version-model"
+    And texture set "conv_shared" is also linked to "multi-version-model"
+    And I am on the model viewer page for "single-version-model"
+    When I right-click the material item for texture set "conv_shared"
+    And I click "Convert to Single Model Texture Set" in the context menu
+    Then a conversion warning dialog should appear mentioning "multi-version-model"
+    When I accept the conversion warning dialog
+    Then texture set "conv_shared" should have kind "Single Model" via API
+    And texture set "conv_shared" should not be linked to "multi-version-model" via API

--- a/tests/e2e/helpers/navigation-helper.ts
+++ b/tests/e2e/helpers/navigation-helper.ts
@@ -21,14 +21,14 @@ import { Page, expect } from "@playwright/test";
  * opening a tab via UI.
  *
  * Tab types not in this map (`textureSets`, `stageList`) have no tile —
- * `textureSets` was split into Global Materials / Model Textures, and
+ * `textureSets` was split into Global Materials / Multi-Model Textures, and
  * `stageList` is disabled while the feature is incomplete. Tests that need
  * them inject the tab via localStorage state — see `injectAndActivateTab`.
  */
 const TILE_LABELS: Record<string, string> = {
     modelList: "Models",
     globalMaterials: "Global Materials",
-    modelTextures: "Model Textures",
+    modelTextures: "Multi-Model Textures",
     sprites: "Sprites",
     environmentMaps: "Environment Maps",
     sounds: "Sounds",

--- a/tests/e2e/pages/ModelViewerPage.ts
+++ b/tests/e2e/pages/ModelViewerPage.ts
@@ -804,19 +804,19 @@ export class ModelViewerPage {
             (await item.count()) > 0 ? item.first() : fallbackItem.first();
         await expect(targetItem).toBeVisible({ timeout: 10000 });
 
-        // Click the preview to select this texture set
-        const preview = targetItem.locator(".materials-item-preview");
-        if (
-            await preview
-                .waitFor({ state: "visible", timeout: 2000 })
-                .then(() => true)
-                .catch(() => false)
-        ) {
-            await preview.scrollIntoViewIfNeeded();
-            await preview.click();
-        } else {
-            await targetItem.scrollIntoViewIfNeeded();
-            await targetItem.click();
+        // Click the material item to select this texture set. The whole row is
+        // clickable: it applies the texture set to the 3D model AND opens the
+        // texture set in its own tab.
+        await targetItem.scrollIntoViewIfNeeded();
+        await targetItem.click();
+
+        // Opening the texture set switches focus to its new tab — return to the
+        // model viewer tab so the inline preview is visible for assertions.
+        const modelViewerTab = this.page
+            .locator(".draggable-tab:has(.pi-box)")
+            .first();
+        if ((await modelViewerTab.count()) > 0) {
+            await modelViewerTab.click();
         }
 
         // Let React commit the selection before the assertion step polls the scene.
@@ -1002,21 +1002,25 @@ export class ModelViewerPage {
 
     /**
      * Unlink a texture set from a specific material in the current preset.
-     * Clicks the pi-times (unlink) button on the material item that has the given texture set.
+     * The unlink button lives in the material group header (a sibling of the
+     * .materials-item that displays the texture set), so we scope to the
+     * enclosing .materials-material-group.
      */
     async unlinkTextureSetFromMaterial(textureSetName: string): Promise<void> {
         await this.openTab("Materials", '[data-testid="materials-panel"]');
 
-        // Find the material item showing this texture set
-        const materialItem = this.page.locator(
-            `.materials-item[data-texture-set="${textureSetName}"]`,
-        );
-        await expect(materialItem.first()).toBeVisible({ timeout: 10000 });
+        // Find the material group that contains this texture set's item
+        const group = this.page.locator(".materials-material-group", {
+            has: this.page.locator(
+                `.materials-item[data-texture-set="${textureSetName}"]`,
+            ),
+        });
+        await expect(group.first()).toBeVisible({ timeout: 10000 });
 
-        // Click the unlink button (pi-times icon) inside it
-        const unlinkBtn = materialItem
+        // Click the unlink button in that group's header
+        const unlinkBtn = group
             .first()
-            .locator("button.p-button-danger");
+            .locator('[data-testid^="unlink-ts-"]');
         await unlinkBtn.click();
 
         // Wait for the UI to update

--- a/tests/e2e/pages/TextureSetsPage.ts
+++ b/tests/e2e/pages/TextureSetsPage.ts
@@ -121,7 +121,7 @@ export class TextureSetsPage {
      * @param label - Visible tab label
      */
     async selectKindTab(
-        label: "Model-Specific" | "Global Materials",
+        label: "Multi-Model" | "Global Materials",
     ): Promise<void> {
         await this.page.getByRole("button", { name: label }).click();
         await this.waitForLoad();

--- a/tests/e2e/steps/merge-channel-mapping.steps.ts
+++ b/tests/e2e/steps/merge-channel-mapping.steps.ts
@@ -237,11 +237,11 @@ When(
         // Refresh the page to see newly created texture sets
         await page.reload({ waitUntil: "domcontentloaded" });
 
-        // Wait for the texture set page to render, then switch to Model-Specific tab
+        // Wait for the texture set page to render, then switch to Multi-Model tab
         await page.waitForSelector(".kind-filter-select", { timeout: 10000 });
         const msTab = page
             .locator(".kind-filter-select .p-button")
-            .filter({ hasText: "Model-Specific" });
+            .filter({ hasText: "Multi-Model" });
         await msTab.waitFor({ state: "visible", timeout: 5000 });
         const isActive = await msTab.evaluate((el: Element) =>
             el.classList.contains("p-highlight"),

--- a/tests/e2e/steps/recycled-files-common.steps.ts
+++ b/tests/e2e/steps/recycled-files-common.steps.ts
@@ -325,11 +325,11 @@ GivenBdd(
         await openTabViaMenu(page, "textureSets", "left");
         await page.waitForLoadState("domcontentloaded");
 
-        // The texture sets created in test setup are Model-Specific (backend default).
-        // The default tab is Global Materials, so we must switch to Model-Specific first.
+        // The texture sets created in test setup are Multi-Model (backend default).
+        // The default tab is Global Materials, so we must switch to Multi-Model first.
         const modelSpecificBtn = page
             .locator(".kind-filter-select button")
-            .filter({ hasText: "Model-Specific" });
+            .filter({ hasText: "Multi-Model" });
         await expect(modelSpecificBtn).toBeVisible({ timeout: 10000 });
         const isActive = await modelSpecificBtn.evaluate((el: Element) =>
             el.classList.contains("p-highlight"),

--- a/tests/e2e/steps/recycled-files-textures.steps.ts
+++ b/tests/e2e/steps/recycled-files-textures.steps.ts
@@ -257,10 +257,10 @@ ThenBdd(
                 );
             });
 
-        // Switch to Model-Specific tab (default tab is now Global Materials)
+        // Switch to Multi-Model tab (default tab is now Global Materials)
         const msTab = page
             .locator(".kind-filter-select .p-button")
-            .filter({ hasText: "Model-Specific" });
+            .filter({ hasText: "Multi-Model" });
         await msTab.waitFor({ state: "visible", timeout: 10000 });
         const isActive = await msTab.evaluate((el: Element) =>
             el.classList.contains("p-highlight"),

--- a/tests/e2e/steps/texture-set-conversion.steps.ts
+++ b/tests/e2e/steps/texture-set-conversion.steps.ts
@@ -1,0 +1,209 @@
+import { createBdd } from "playwright-bdd";
+import { expect, type Page } from "@playwright/test";
+import { ApiHelper } from "../helpers/api-helper";
+import { UniqueFileGenerator } from "../fixtures/unique-file-generator";
+import { ModelViewerPage } from "../pages/ModelViewerPage";
+import { getScenarioState } from "../fixtures/shared-state";
+
+const { Given, When, Then } = createBdd();
+
+const apiHelper = new ApiHelper();
+
+// Run-unique suffix so texture set names never collide across runs.
+const runId = Date.now().toString(36).slice(-4);
+
+// Texture set kind numbers as understood by the API.
+const KIND = { multiModel: 0, universal: 1, singleModel: 2 } as const;
+const KIND_BY_NAME: Record<string, number> = {
+    "Multi-Model": KIND.multiModel,
+    Universal: KIND.universal,
+    "Single Model": KIND.singleModel,
+};
+
+// Texture sets created within this scenario, keyed by feature-file alias.
+const createdSets: Record<string, { id: number; name: string }> = {};
+
+function uniqueName(alias: string): string {
+    return `${alias}_${runId}`;
+}
+
+function trackedSet(alias: string): { id: number; name: string } {
+    const set = createdSets[alias];
+    if (!set) {
+        throw new Error(
+            `Texture set "${alias}" was not created in this scenario.`,
+        );
+    }
+    return set;
+}
+
+function resolveModel(page: Page, modelAlias: string): { id: number } {
+    const model = getScenarioState(page).getModel(modelAlias);
+    if (!model) {
+        throw new Error(`Model "${modelAlias}" is not in shared state.`);
+    }
+    return model;
+}
+
+async function firstVersionId(modelId: number): Promise<number> {
+    const versions = await apiHelper.getModelVersions(modelId);
+    const versionId = versions[0]?.id;
+    if (!versionId) {
+        throw new Error(`Model ${modelId} has no versions to link against.`);
+    }
+    return versionId;
+}
+
+async function createAndLink(
+    page: Page,
+    alias: string,
+    kind: number,
+    modelAlias: string,
+): Promise<void> {
+    const name = uniqueName(alias);
+    const file = await UniqueFileGenerator.generate("blue_color.png");
+    const result = await apiHelper.createTextureSetWithFileAndKind(
+        name,
+        file,
+        1, // Albedo
+        kind,
+    );
+    createdSets[alias] = { id: result.textureSetId, name };
+
+    const model = resolveModel(page, modelAlias);
+    const versionId = await firstVersionId(model.id);
+    await apiHelper.linkTextureSetToModel(
+        result.textureSetId,
+        model.id,
+        versionId,
+    );
+    console.log(
+        `[API] Created texture set "${name}" (kind ${kind}) and linked to "${modelAlias}"`,
+    );
+}
+
+// ── Data provisioning ─────────────────────────────────────────────────
+
+Given(
+    "a Multi-Model texture set {string} linked to {string}",
+    async ({ page }, alias: string, modelAlias: string) => {
+        await createAndLink(page, alias, KIND.multiModel, modelAlias);
+    },
+);
+
+Given(
+    "a Single Model texture set {string} linked to {string}",
+    async ({ page }, alias: string, modelAlias: string) => {
+        await createAndLink(page, alias, KIND.singleModel, modelAlias);
+    },
+);
+
+Given(
+    "texture set {string} is also linked to {string}",
+    async ({ page }, alias: string, modelAlias: string) => {
+        const set = trackedSet(alias);
+        const model = resolveModel(page, modelAlias);
+        const versionId = await firstVersionId(model.id);
+        await apiHelper.linkTextureSetToModel(set.id, model.id, versionId);
+        console.log(
+            `[API] Texture set "${set.name}" also linked to "${modelAlias}"`,
+        );
+    },
+);
+
+// ── Materials panel interactions ──────────────────────────────────────
+
+When(
+    "I right-click the material item for texture set {string}",
+    async ({ page }, alias: string) => {
+        const set = trackedSet(alias);
+
+        const viewer = new ModelViewerPage(page);
+        await viewer.openTab("Materials", '[data-testid="materials-panel"]');
+
+        const item = page
+            .locator(`.materials-item[data-texture-set="${set.name}"]`)
+            .first();
+        await expect(item).toBeVisible({ timeout: 15000 });
+        await item.scrollIntoViewIfNeeded();
+        await item.click({ button: "right" });
+
+        await page.waitForSelector(".p-contextmenu", { timeout: 5000 });
+        console.log(`[Action] Right-clicked material item "${set.name}"`);
+    },
+);
+
+// ── Conversion warning dialog ─────────────────────────────────────────
+
+Then(
+    "a conversion warning dialog should appear mentioning {string}",
+    async ({ page }, modelAlias: string) => {
+        const model = resolveModel(page, modelAlias);
+        const realName = (await apiHelper.getModel(model.id)).name;
+
+        const dialog = page.locator(".p-confirm-dialog");
+        await expect(dialog).toBeVisible({ timeout: 10000 });
+        await expect(dialog).toContainText(realName, { timeout: 5000 });
+        console.log(
+            `[Assert] Conversion warning dialog lists model "${realName}"`,
+        );
+    },
+);
+
+When("I accept the conversion warning dialog", async ({ page }) => {
+    const dialog = page.locator(".p-confirm-dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole("button", { name: "Convert & Unlink" }).click();
+    await expect(dialog).toBeHidden({ timeout: 10000 });
+    console.log(`[Action] Accepted conversion warning dialog`);
+});
+
+// ── API verification ──────────────────────────────────────────────────
+
+Then(
+    "texture set {string} should have kind {string} via API",
+    async ({}, alias: string, kindName: string) => {
+        const set = trackedSet(alias);
+        const expectedKind = KIND_BY_NAME[kindName];
+        if (expectedKind === undefined) {
+            throw new Error(`Unknown texture set kind "${kindName}".`);
+        }
+
+        // The conversion is async (kind update + query invalidation), so poll.
+        let actualKind = -1;
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const dto = await apiHelper.getTextureSetById(set.id);
+            actualKind = dto.kind;
+            if (actualKind === expectedKind) break;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        expect(actualKind).toBe(expectedKind);
+        console.log(
+            `[API] Texture set "${set.name}" has kind ${kindName} (${expectedKind})`,
+        );
+    },
+);
+
+Then(
+    "texture set {string} should not be linked to {string} via API",
+    async ({ page }, alias: string, modelAlias: string) => {
+        const set = trackedSet(alias);
+        const model = resolveModel(page, modelAlias);
+
+        let stillLinked = true;
+        for (let attempt = 0; attempt < 20; attempt++) {
+            const dto = await apiHelper.getTextureSetById(set.id);
+            const associated: Array<{ id: number }> =
+                dto.associatedModels ?? [];
+            stillLinked = associated.some((m) => m.id === model.id);
+            if (!stillLinked) break;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        expect(stillLinked).toBe(false);
+        console.log(
+            `[API] Texture set "${set.name}" is no longer linked to "${modelAlias}"`,
+        );
+    },
+);

--- a/tests/e2e/steps/texture-set-conversion.steps.ts
+++ b/tests/e2e/steps/texture-set-conversion.steps.ts
@@ -5,7 +5,7 @@ import { UniqueFileGenerator } from "../fixtures/unique-file-generator";
 import { ModelViewerPage } from "../pages/ModelViewerPage";
 import { getScenarioState } from "../fixtures/shared-state";
 
-const { Given, When, Then } = createBdd();
+const { Given, When, Then, Before } = createBdd();
 
 const apiHelper = new ApiHelper();
 
@@ -20,8 +20,16 @@ const KIND_BY_NAME: Record<string, number> = {
     "Single Model": KIND.singleModel,
 };
 
-// Texture sets created within this scenario, keyed by feature-file alias.
+// Texture sets created within the current scenario, keyed by feature-file
+// alias. Reset before each scenario so aliases never leak between scenarios
+// that share a worker process.
 const createdSets: Record<string, { id: number; name: string }> = {};
+
+Before(() => {
+    for (const key of Object.keys(createdSets)) {
+        delete createdSets[key];
+    }
+});
 
 function uniqueName(alias: string): string {
     return `${alias}_${runId}`;

--- a/tests/e2e/steps/texture-types.steps.ts
+++ b/tests/e2e/steps/texture-types.steps.ts
@@ -83,10 +83,10 @@ Given("I have a texture set with uploaded textures", async ({ page }) => {
     await page.waitForLoadState("domcontentloaded");
     await textureSetsPage.goto();
 
-    // Switch to Model-Specific tab (default tab is now Global Materials)
+    // Switch to Multi-Model tab (default tab is now Global Materials)
     const msTab = page
         .locator(".kind-filter-select .p-button")
-        .filter({ hasText: "Model-Specific" });
+        .filter({ hasText: "Multi-Model" });
     await msTab.waitFor({ state: "visible", timeout: 10000 });
     const msTabActive = await msTab.evaluate((el: Element) =>
         el.classList.contains("p-highlight"),
@@ -145,10 +145,10 @@ Given("I have a texture set with ORM packed texture", async ({ page }) => {
     await page.waitForLoadState("domcontentloaded");
     await textureSetsPage.goto();
 
-    // Switch to Model-Specific tab (default tab is now Global Materials)
+    // Switch to Multi-Model tab (default tab is now Global Materials)
     const msTabOrm = page
         .locator(".kind-filter-select .p-button")
-        .filter({ hasText: "Model-Specific" });
+        .filter({ hasText: "Multi-Model" });
     await msTabOrm.waitFor({ state: "visible", timeout: 10000 });
     const msTabOrmActive = await msTabOrm.evaluate((el: Element) =>
         el.classList.contains("p-highlight"),
@@ -196,10 +196,10 @@ Given("I have a texture set with a height texture", async ({ page }) => {
     await page.waitForLoadState("domcontentloaded");
     await textureSetsPage.goto();
 
-    // Switch to Model-Specific tab (default tab is now Global Materials)
+    // Switch to Multi-Model tab (default tab is now Global Materials)
     const msTabHeight = page
         .locator(".kind-filter-select .p-button")
-        .filter({ hasText: "Model-Specific" });
+        .filter({ hasText: "Multi-Model" });
     await msTabHeight.waitFor({ state: "visible", timeout: 10000 });
     const msTabHeightActive = await msTabHeight.evaluate((el: Element) =>
         el.classList.contains("p-highlight"),

--- a/tests/e2e/steps/thumbnail-previews.steps.ts
+++ b/tests/e2e/steps/thumbnail-previews.steps.ts
@@ -125,12 +125,12 @@ Given("I have a sprite with an uploaded image", async () => {
 
 // ============= UI navigation steps =============
 
-/** After navigating to texture sets page, switch to Model-Specific tab
- *  (the default is Global Materials, but our API creates Model-Specific sets)
+/** After navigating to texture sets page, switch to Multi-Model tab
+ *  (the default is Global Materials, but our API creates Multi-Model sets)
  *  Optionally searches for a specific card name to handle pagination (>50 sets). */
 async function switchToModelSpecificKind(page: any, searchText?: string) {
     const modelSpecificBtn = page.locator(".kind-filter-select button").filter({
-        hasText: "Model-Specific",
+        hasText: "Multi-Model",
     });
     await expect(modelSpecificBtn).toBeVisible({ timeout: 5000 });
     const isActive = await modelSpecificBtn.evaluate((el: Element) =>


### PR DESCRIPTION
## Summary

Adds a third texture set kind — **ModelOwned ("Single Model")** — that lives inside a single model's Materials panel and is excluded from cross-model browsing and linking. Also adds in-panel kind conversion and renames the old "Model Textures" to "Multi-Model Textures".

## Materials panel

- **Add new texture set** action creates a ModelOwned set and opens it in a new tab.
- The whole `materials-item` row is clickable and opens the texture set in a new tab (keyboard accessible).
- **Right-click context menu** converts a set between Multi-Model and Single Model.
- Converting a *shared* Multi-Model set to Single Model shows a warning listing the other models it will be unlinked from, then unlinks them on confirm.
- Link / Add / Unlink are icon-only buttons with tooltips and `aria-label`s; the unlink button moved into the material group header.

## Link Texture Set dialog

Sets are grouped into **This Model Textures**, **Multi-Model Textures** and **Global Materials**. ModelOwned sets owned by other models are excluded.

## Backend

- `UpdateTextureSetKind` accepts an optional owner model id; converting to ModelOwned drops mappings to every other model and invalidates their cached `.blend` files (mirrors the disassociate flow).
- New domain method `TextureSet.RemoveModelVersionsNotOwnedBy`.

## Other

- Rename "Model Textures" → "Multi-Model Textures" across tabs, tiles and tooltips.
- The **Create Set** dialog is locked to the active page's kind (no wrong-kind creation on the dedicated pages).
- Frontend invalidates texture-set, model and version queries on conversion so open model viewers refresh.

## Tests

- New e2e feature `18-texture-set-kind-conversion.feature` (5 scenarios) covering context-menu conversion and the unlink warning.
- Fixed existing texture-set e2e tests broken by the renames and Materials panel restructure.
- Backend builds clean; frontend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)