### PR TITLE
fix(textures): include FileName and SourceChannel in texture list DTO

### DIFF
--- a/src/Application/TextureSets/GetAllTextureSetsQuery.cs
+++ b/src/Application/TextureSets/GetAllTextureSetsQuery.cs
@@ -67,7 +67,9 @@ internal class GetAllTextureSetsQueryHandler : IQueryHandler<GetAllTextureSetsQu
             {
                 Id = t.Id,
                 TextureType = t.TextureType,
-                FileId = t.FileId
+                SourceChannel = t.SourceChannel,
+                FileId = t.FileId,
+                FileName = t.File != null ? t.File.OriginalFileName : null
             }).ToList(),
             AssociatedModels = tp.ModelVersionMappings.Select(m => new ModelSummaryListDto
             {
@@ -112,13 +114,19 @@ public record TextureSetListDto
 }
 
 /// <summary>
-/// Minimal texture info for list views - only essential fields for thumbnails and basic operations
+/// Minimal texture info for list views - only essential fields for thumbnails and basic operations.
+/// FileName and SourceChannel are required by the model viewer, which builds its
+/// textured materials from this list DTO: FileName lets it detect formats the
+/// browser cannot decode natively (e.g. TIFF), and SourceChannel drives
+/// single-channel extraction.
 /// </summary>
 public record TextureListDto
 {
     public int Id { get; init; }
     public required TextureType TextureType { get; init; }
+    public TextureChannel SourceChannel { get; init; }
     public int FileId { get; init; }
+    public string? FileName { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Problem

A model with a TIFF-based texture set linked to a material renders **untextured** in the 3D preview (reproduced on model 2 / `test-cylinder` linked to texture set `crate_uncompressed`).

## Root cause

The model viewer builds its textured materials from `versionTextureSets`, which comes from `GET /texture-sets` (the list endpoint). That endpoint's `TextureListDto` exposed only `id`, `textureType` and `fileId` — **no `fileName`**.

Without `fileName`:
- `buildCombinedTextureConfigs` sets `fileName: undefined`
- `useChannelExtractedTextures` calls `isTiffFile(undefined)` → `false`
- the texture is loaded with `THREE.TextureLoader` (a browser `<img>`), which **cannot decode TIFF**
- the load fails and the mesh falls back to an untextured grey material

Any model linked to a TIFF-based texture set is affected — a PNG/JPG texture happens to load fine via `TextureLoader` even without `fileName`, which is why this only surfaced for TIFF.

`SourceChannel` was missing from the same DTO too, so list-sourced textures silently defaulted to RGB instead of extracting the configured channel.

## Fix

Add `FileName` and `SourceChannel` to `TextureListDto` and populate them in `GetAllTextureSetsQuery`. Both come from data that is already eager-loaded (`Textures.ThenInclude(t => t.File)`), so this only surfaces existing fields — no query or schema changes. The frontend `TextureDto` type already declares both.

## Testing

- Backend builds clean (0 errors).
- Confirmed against the live API that `GET /texture-sets` previously returned textures as `{ id, textureType, fileId }` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)