### PR TITLE
fix(webdav): answer HEAD without opening content streams

### DIFF
--- a/src/Infrastructure/WebDav/IVirtualFileMetadata.cs
+++ b/src/Infrastructure/WebDav/IVirtualFileMetadata.cs
@@ -1,0 +1,20 @@
+namespace Infrastructure.WebDav;
+
+/// <summary>
+/// Exposes size and MIME metadata for a virtual WebDAV file so a HEAD request can be
+/// answered without opening (and thereby generating/processing) the content stream.
+///
+/// macOS WebDAV clients (webdavfs) issue a HEAD on every file while listing a folder.
+/// If that HEAD blocks on on-demand content production — e.g. the Blender CLI render
+/// behind <see cref="VirtualGeneratedBlendFile"/>, or the image channel extraction
+/// behind <see cref="VirtualExtractedTextureFile"/> — the client times out and drops
+/// the file from Finder ("shows up for a second and disappears").
+/// </summary>
+public interface IVirtualFileMetadata
+{
+    /// <summary>File size in bytes. May be approximate for files produced on demand.</summary>
+    long SizeBytes { get; }
+
+    /// <summary>MIME content type.</summary>
+    string MimeType { get; }
+}

--- a/src/Infrastructure/WebDav/VirtualAssetFile.cs
+++ b/src/Infrastructure/WebDav/VirtualAssetFile.cs
@@ -10,7 +10,7 @@ namespace Infrastructure.WebDav;
 /// <summary>
 /// Represents a virtual asset file that streams from the hash-based storage.
 /// </summary>
-public sealed class VirtualAssetFile : IStoreItem
+public sealed class VirtualAssetFile : IStoreItem, IVirtualFileMetadata
 {
     private readonly IUploadPathProvider _pathProvider;
 

--- a/src/Infrastructure/WebDav/VirtualExtractedTextureFile.cs
+++ b/src/Infrastructure/WebDav/VirtualExtractedTextureFile.cs
@@ -15,7 +15,7 @@ namespace Infrastructure.WebDav;
 /// <summary>
 /// Represents a virtual asset file that is a specific channel extracted from a source image.
 /// </summary>
-public sealed class VirtualExtractedTextureFile : IStoreItem
+public sealed class VirtualExtractedTextureFile : IStoreItem, IVirtualFileMetadata
 {
     private readonly IUploadPathProvider _pathProvider;
     private readonly TextureChannel _channel;

--- a/src/Infrastructure/WebDav/VirtualGeneratedBlendFile.cs
+++ b/src/Infrastructure/WebDav/VirtualGeneratedBlendFile.cs
@@ -13,7 +13,7 @@ namespace Infrastructure.WebDav;
 /// with material preset textures applied via Blender CLI.
 /// The generated file is cached on disk for subsequent reads.
 /// </summary>
-public sealed class VirtualGeneratedBlendFile : IStoreItem
+public sealed class VirtualGeneratedBlendFile : IStoreItem, IVirtualFileMetadata
 {
     private static readonly VirtualGeneratedBlendPropertyManager s_propertyManager = new();
 

--- a/src/WebApi/Services/CustomWebDavHandler.cs
+++ b/src/WebApi/Services/CustomWebDavHandler.cs
@@ -1,21 +1,24 @@
 using System;
-using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
-using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
+using Infrastructure.WebDav;
 using Microsoft.Extensions.Logging;
 using NWebDav.Server;
-using NWebDav.Server.Handlers;
 using NWebDav.Server.Http;
 using NWebDav.Server.Stores;
 
 namespace WebApi.Services;
 
+/// <summary>
+/// Handles WebDAV OPTIONS, GET and HEAD requests for the virtual asset drive.
+/// PROPFIND is handled separately by <see cref="MacOsPropFindHandler"/> — see
+/// <see cref="RequestHandlerFactory"/> — so it is intentionally not handled here.
+/// </summary>
 public class CustomWebDavHandler : IRequestHandler
 {
-    private static readonly XNamespace DavNs = "DAV:";
     private readonly ILogger<CustomWebDavHandler> _logger;
 
     public CustomWebDavHandler(ILogger<CustomWebDavHandler> logger)
@@ -31,40 +34,37 @@ public class CustomWebDavHandler : IRequestHandler
         switch (request.HttpMethod.ToUpperInvariant())
         {
             case "OPTIONS":
-                return await HandleOptionsAsync(httpContext);
-            case "PROPFIND":
-                return await HandlePropFindAsync(httpContext, store);
+                return HandleOptions(httpContext);
             case "GET":
             case "HEAD":
-                return await HandleGetHeadAsync(httpContext, store);
+                return await HandleGetHeadAsync(httpContext, store).ConfigureAwait(false);
             default:
-                // Let other handlers (if any) generally handle it, or fail.
-                // Since this is the "only" handler in our factory, we probably return false -> 501/404.
+                // Unknown method — let the dispatcher fall through to a 404/501.
                 return false;
         }
     }
 
-    private Task<bool> HandleOptionsAsync(IHttpContext httpContext)
+    private static bool HandleOptions(IHttpContext httpContext)
     {
         var response = httpContext.Response;
-        
-        // Critical WebDAV Compliance Headers
+
+        // Critical WebDAV compliance headers.
         response.SetHeaderValue("Dav", "1, 2");
         response.SetHeaderValue("MS-Author-Via", "DAV");
         response.SetHeaderValue("Allow", "OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, COPY, MOVE, MKCOL, PROPFIND, PROPPATCH, LOCK, UNLOCK");
         response.SetHeaderValue("Public", "OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, COPY, MOVE, MKCOL, PROPFIND, PROPPATCH, LOCK, UNLOCK");
 
         response.Status = 200;
-        return Task.FromResult(true);
+        return true;
     }
 
     private async Task<bool> HandleGetHeadAsync(IHttpContext httpContext, IStore store)
     {
         var request = httpContext.Request;
         var response = httpContext.Response;
-        var isHead = request.HttpMethod == "HEAD";
+        var isHead = request.HttpMethod.Equals("HEAD", StringComparison.OrdinalIgnoreCase);
 
-        try 
+        try
         {
             var item = await store.GetItemAsync(request.Url, httpContext).ConfigureAwait(false);
             if (item == null)
@@ -75,162 +75,99 @@ public class CustomWebDavHandler : IRequestHandler
 
             if (item is IStoreCollection collection)
             {
-                // Generate HTML directory listing
-                var items = await collection.GetItemsAsync(httpContext).ConfigureAwait(false);
-                var htmlBuilder = new System.Text.StringBuilder();
-                htmlBuilder.Append("<html><head><title>WebDAV Listing</title></head><body>");
-                htmlBuilder.Append($"<h1>Contents of {request.Url.AbsolutePath}</h1>");
-                htmlBuilder.Append("<ul>");
-                foreach (var child in items)
-                {
-                    var childName = Uri.EscapeDataString(child.Name);
-                    htmlBuilder.Append($"<li><a href=\"{childName}\">{System.Net.WebUtility.HtmlEncode(child.Name)}</a></li>");
-                }
-                htmlBuilder.Append("</ul></body></html>");
-                
-                var htmlBytes = System.Text.Encoding.UTF8.GetBytes(htmlBuilder.ToString());
-                
-                response.Status = 200;
-                response.SetHeaderValue("Content-Type", "text/html; charset=utf-8");
-                
-                if (!isHead)
-                {
-                    await response.Stream.WriteAsync(htmlBytes, 0, htmlBytes.Length, CancellationToken.None);
-                }
+                await WriteCollectionListingAsync(httpContext, collection, isHead).ConfigureAwait(false);
                 return true;
             }
 
-            if (item is IStoreItem storeItem)
-            {
-                // Serve file
-                // Stream?
-                // IStoreItem stream access?
-                var stream = await storeItem.GetReadableStreamAsync(httpContext).ConfigureAwait(false);
-                if (stream == null)
-                {
-                    response.Status = 404; // Or 500
-                    return true;
-                }
-
-                // Headers
-                // Content-Type? storeItem.PropertyManager?
-                // Let's set generic binary if unknown.
-                response.Status = 200;
-                
-                // Content-Length?
-                // response.SetHeaderValue("Content-Length", stream.Length.ToString()); 
-
-                if (!isHead)
-                {
-                   using (stream)
-                   {
-                       // Async copy to response
-                       await stream.CopyToAsync(response.Stream, 81920, CancellationToken.None);
-                   }
-                }
-            }
-
+            await WriteFileAsync(httpContext, item, isHead).ConfigureAwait(false);
             return true;
-        }
-        catch(Exception ex)
-        {
-            _logger.LogError(ex, "GET request failed");
-            response.Status = 500;
-            return true;
-        }
-    }
-
-    private async Task<bool> HandlePropFindAsync(IHttpContext httpContext, IStore store)
-    {
-        var response = httpContext.Response;
-
-        try
-        {
-            // Buffer the native PropFindHandler output into a MemoryStream for two reasons:
-            //   1. Kestrel blocks synchronous writes; buffering avoids that exception.
-            //   2. We need to post-process the XML to append trailing slashes on collection
-            //      <href> values, which macOS Finder requires to distinguish folders from files.
-            //      Without them Finder treats child folders as the parent and loops infinitely,
-            //      exhausting file descriptors and crashing with malloc/too_many_files_open.
-            using var buffer = new MemoryStream();
-            var macOsResponse = new MacOsHttpResponse(response, buffer);
-            var macOsContext = new MacOsHttpContext(httpContext, macOsResponse);
-
-            var nativeHandler = new PropFindHandler();
-            var handled = await nativeHandler.HandleRequestAsync(macOsContext, store).ConfigureAwait(false);
-
-            // Only patch 207 Multi-Status responses that have XML body content.
-            if (response.Status == 207 && buffer.Length > 0)
-            {
-                buffer.Position = 0;
-                var doc = XDocument.Load(buffer);
-
-                // Ensure every collection <href> ends with '/' so macOS Finder can
-                // distinguish folders from files without re-issuing a PROPFIND on the same URL.
-                foreach (var responseEl in doc.Descendants(DavNs + "response"))
-                {
-                    var isCollection = responseEl
-                        .Descendants(DavNs + "resourcetype")
-                        .Any(rt => rt.Element(DavNs + "collection") != null);
-
-                    if (!isCollection)
-                        continue;
-
-                    var hrefEl = responseEl.Element(DavNs + "href");
-                    if (hrefEl != null && !hrefEl.Value.EndsWith("/"))
-                        hrefEl.Value += "/";
-                }
-
-                using var patched = new MemoryStream();
-                patched.Position = 0;
-                doc.Save(patched);
-
-                response.SetHeaderValue("Content-Length", patched.Length.ToString());
-                patched.Position = 0;
-                await patched.CopyToAsync(response.Stream, 81920, CancellationToken.None).ConfigureAwait(false);
-            }
-            else if (buffer.Length > 0)
-            {
-                // Non-207 response (e.g. 404) — pass through as-is.
-                buffer.Position = 0;
-                await buffer.CopyToAsync(response.Stream, 81920, CancellationToken.None).ConfigureAwait(false);
-            }
-
-            return handled;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "PROPFIND request failed");
+            _logger.LogError(ex, "{Method} request failed for {Url}", request.HttpMethod, request.Url);
             response.Status = 500;
             return true;
         }
     }
 
-    private class MacOsHttpResponse : IHttpResponse
+    /// <summary>Renders a simple HTML directory listing for a collection.</summary>
+    private static async Task WriteCollectionListingAsync(IHttpContext httpContext, IStoreCollection collection, bool isHead)
     {
-        private readonly IHttpResponse _inner;
-        public MacOsHttpResponse(IHttpResponse inner, Stream stream)
+        var response = httpContext.Response;
+        var items = await collection.GetItemsAsync(httpContext).ConfigureAwait(false);
+
+        var html = new StringBuilder();
+        html.Append("<html><head><title>WebDAV Listing</title></head><body>");
+        html.Append($"<h1>Contents of {System.Net.WebUtility.HtmlEncode(httpContext.Request.Url.AbsolutePath)}</h1>");
+        html.Append("<ul>");
+        foreach (var child in items)
         {
-            _inner = inner;
-            Stream = stream;
+            var childName = Uri.EscapeDataString(child.Name);
+            html.Append($"<li><a href=\"{childName}\">{System.Net.WebUtility.HtmlEncode(child.Name)}</a></li>");
         }
-        public int Status { get => _inner.Status; set => _inner.Status = value; }
-        public string StatusDescription { get => _inner.StatusDescription; set => _inner.StatusDescription = value; }
-        public Stream Stream { get; }
-        public void SetHeaderValue(string header, string value) => _inner.SetHeaderValue(header, value);
+        html.Append("</ul></body></html>");
+
+        var bytes = Encoding.UTF8.GetBytes(html.ToString());
+
+        response.Status = 200;
+        response.SetHeaderValue("Content-Type", "text/html; charset=utf-8");
+        response.SetHeaderValue("Content-Length", bytes.Length.ToString(CultureInfo.InvariantCulture));
+
+        if (!isHead)
+            await response.Stream.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None).ConfigureAwait(false);
     }
 
-    private class MacOsHttpContext : IHttpContext
+    /// <summary>
+    /// Writes a file response.
+    ///
+    /// HEAD resolves size/type from <see cref="IVirtualFileMetadata"/> instead of opening
+    /// the content stream. This is essential for virtual files whose stream is produced on
+    /// demand: <see cref="VirtualGeneratedBlendFile"/> runs a Blender CLI render and
+    /// <see cref="VirtualExtractedTextureFile"/> decodes and re-encodes an image. macOS
+    /// issues a HEAD on every file while browsing a folder; opening those streams made the
+    /// HEAD hang until the client gave up and dropped the file from Finder.
+    ///
+    /// Both HEAD and GET always emit Content-Length and Content-Type — macOS webdavfs
+    /// treats a file with missing/invalid length metadata as unavailable.
+    /// </summary>
+    private static async Task WriteFileAsync(IHttpContext httpContext, IStoreItem item, bool isHead)
     {
-        private readonly IHttpContext _inner;
-        public MacOsHttpContext(IHttpContext inner, IHttpResponse response)
+        var response = httpContext.Response;
+
+        // Fast path: HEAD answered purely from metadata, no stream opened.
+        if (isHead && item is IVirtualFileMetadata meta)
         {
-            _inner = inner;
-            Response = response;
+            response.Status = 200;
+            response.SetHeaderValue("Content-Type", SafeContentType(meta.MimeType));
+            response.SetHeaderValue("Content-Length", meta.SizeBytes.ToString(CultureInfo.InvariantCulture));
+            response.SetHeaderValue("Accept-Ranges", "none");
+            return;
         }
-        public IHttpRequest Request => _inner.Request;
-        public IHttpResponse Response { get; }
-        public NWebDav.Server.Http.IHttpSession Session => _inner.Session;
-        public Task CloseAsync() => _inner.CloseAsync();
+
+        var stream = await item.GetReadableStreamAsync(httpContext).ConfigureAwait(false);
+        if (stream == null || ReferenceEquals(stream, Stream.Null))
+        {
+            // The underlying content could not be produced (generation failed, file missing).
+            response.Status = 404;
+            return;
+        }
+
+        await using (stream.ConfigureAwait(false))
+        {
+            response.Status = 200;
+            response.SetHeaderValue("Content-Type", SafeContentType((item as IVirtualFileMetadata)?.MimeType));
+            response.SetHeaderValue("Accept-Ranges", "none");
+
+            // Advertise the real length of what we are about to send so the client can
+            // verify the transfer. Virtual streams are file/memory backed and seekable.
+            if (stream.CanSeek)
+                response.SetHeaderValue("Content-Length", stream.Length.ToString(CultureInfo.InvariantCulture));
+
+            if (!isHead)
+                await stream.CopyToAsync(response.Stream, 81920, CancellationToken.None).ConfigureAwait(false);
+        }
     }
+
+    private static string SafeContentType(string? mimeType)
+        => string.IsNullOrWhiteSpace(mimeType) ? "application/octet-stream" : mimeType;
 }


### PR DESCRIPTION
## Problem

WebDAV `.blend` files in the model directory worked on Windows but on macOS they **showed up for a second and then disappeared** from Finder.

macOS WebDAV clients (`webdavfs`) issue a **HEAD on every file** while listing a folder — Windows' redirector relies on the PROPFIND listing alone, which is why it only broke on Mac.

The GET/HEAD handler called `GetReadableStreamAsync()` for **both** GET and HEAD. For virtual files that meant running expensive on-demand work just to answer a HEAD:

- `generated-*.blend` ran a full **Blender CLI render** synchronously
- extracted channel textures **decoded and re-encoded a PNG**

The HEAD blocked until the client timed out and dropped the file from Finder. HEAD/GET responses also omitted `Content-Length` and `Content-Type` (those lines were commented out), and `webdavfs` treats a file with missing length metadata as unavailable. The HEAD path also leaked the stream (the `using` was inside the `if (!isHead)` block).

## Changes

- Add `IVirtualFileMetadata` (`SizeBytes` + `MimeType`) so HEAD resolves metadata **without opening the content stream**; implemented on `VirtualAssetFile`, `VirtualGeneratedBlendFile`, and `VirtualExtractedTextureFile` (all already had those properties).
- GET and HEAD now always emit `Content-Length` and `Content-Type`, dispose the stream on every path, and return `404` when content is unavailable instead of a bogus empty `200`.
- HTML directory listing now sends `Content-Length`.
- Remove ~95 lines of **dead code**: `CustomWebDavHandler.HandlePropFindAsync` and its wrapper classes were unreachable — `RequestHandlerFactory` routes every PROPFIND to `MacOsPropFindHandler`.

## Testing

- `dotnet build` succeeds.
- Existing WebDAV infrastructure tests pass (7/7).
- Verified on macOS by the reporter: with Blender CLI installed, both `uploaded-*.blend` and `generated-*.blend` now stay visible and open correctly.

## Notes

The **first GET** of a `generated-*.blend` still runs the one-time Blender render (result is cached on disk afterwards); only the listing/HEAD path is now cheap, which is what kept the files from staying visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)