### PR TITLE
feat(texture-sets): add projects filter to Global Materials and Multi-Model lists

### DIFF
--- a/src/Application/Abstractions/Repositories/ITextureSetRepository.cs
+++ b/src/Application/Abstractions/Repositories/ITextureSetRepository.cs
@@ -17,7 +17,7 @@ public interface ITextureSetRepository
     Task<(IEnumerable<TextureSet> Items, int TotalCount)> GetPagedAsync(
         int page, int pageSize,
         IReadOnlyCollection<int>? packIds = null,
-        int? projectId = null,
+        IReadOnlyCollection<int>? projectIds = null,
         IReadOnlyCollection<int>? categoryIds = null,
         IReadOnlyCollection<TextureType>? textureTypes = null,
         TextureSetKind? kind = null,

--- a/src/Application/TextureSets/GetAllTextureSetsQuery.cs
+++ b/src/Application/TextureSets/GetAllTextureSetsQuery.cs
@@ -26,7 +26,7 @@ internal class GetAllTextureSetsQueryHandler : IQueryHandler<GetAllTextureSetsQu
         {
             var result = await _textureSetRepository.GetPagedAsync(
                 query.Page.Value, query.PageSize.Value,
-                query.PackIds, query.ProjectId,
+                query.PackIds, query.ProjectIds,
                 query.CategoryIds,
                 query.TextureTypes,
                 query.Kind,
@@ -41,8 +41,8 @@ internal class GetAllTextureSetsQueryHandler : IQueryHandler<GetAllTextureSetsQu
 
             if (query.PackIds is { Count: > 0 })
                 textureSets = textureSets.Where(ts => ts.Packs.Any(p => query.PackIds.Contains(p.Id)));
-            if (query.ProjectId.HasValue)
-                textureSets = textureSets.Where(ts => ts.Projects.Any(p => p.Id == query.ProjectId.Value));
+            if (query.ProjectIds is { Count: > 0 })
+                textureSets = textureSets.Where(ts => ts.Projects.Any(p => query.ProjectIds.Contains(p.Id)));
             if (query.CategoryIds is { Count: > 0 })
                 textureSets = textureSets.Where(ts =>
                     ts.TextureSetCategoryId.HasValue &&
@@ -104,7 +104,7 @@ internal class GetAllTextureSetsQueryHandler : IQueryHandler<GetAllTextureSetsQu
 
 public record GetAllTextureSetsQuery(
     IReadOnlyCollection<int>? PackIds = null,
-    int? ProjectId = null,
+    IReadOnlyCollection<int>? ProjectIds = null,
     IReadOnlyCollection<int>? CategoryIds = null,
     IReadOnlyCollection<TextureType>? TextureTypes = null,
     int? Page = null,

--- a/src/Infrastructure/Repositories/TextureSetRepository.cs
+++ b/src/Infrastructure/Repositories/TextureSetRepository.cs
@@ -45,7 +45,7 @@ internal sealed class TextureSetRepository : ITextureSetRepository
     public async Task<(IEnumerable<TextureSet> Items, int TotalCount)> GetPagedAsync(
         int page, int pageSize,
         IReadOnlyCollection<int>? packIds = null,
-        int? projectId = null,
+        IReadOnlyCollection<int>? projectIds = null,
         IReadOnlyCollection<int>? categoryIds = null,
         IReadOnlyCollection<TextureType>? textureTypes = null,
         TextureSetKind? kind = null,
@@ -57,8 +57,8 @@ internal sealed class TextureSetRepository : ITextureSetRepository
         if (packIds is { Count: > 0 })
             query = query.Where(ts => ts.Packs.Any(p => packIds.Contains(p.Id)));
 
-        if (projectId.HasValue)
-            query = query.Where(ts => ts.Projects.Any(p => p.Id == projectId.Value));
+        if (projectIds is { Count: > 0 })
+            query = query.Where(ts => ts.Projects.Any(p => projectIds.Contains(p.Id)));
 
         if (categoryIds is { Count: > 0 })
             query = query.Where(ts =>

--- a/src/WebApi/Endpoints/TextureSetEndpoints.cs
+++ b/src/WebApi/Endpoints/TextureSetEndpoints.cs
@@ -142,7 +142,7 @@ public static class TextureSetEndpoints
 
     private static async Task<IResult> GetAllTextureSets(
         [FromQuery(Name = "packIds")] int[]? packIds,
-        int? projectId,
+        [FromQuery(Name = "projectIds")] int[]? projectIds,
         [FromQuery(Name = "categoryIds")] int[]? categoryIds,
         [FromQuery(Name = "textureTypes")] int[]? textureTypes,
         int? page,
@@ -159,7 +159,7 @@ public static class TextureSetEndpoints
         var result = await queryHandler.Handle(
             new GetAllTextureSetsQuery(
                 PackIds: packIds is { Length: > 0 } ? packIds : null,
-                ProjectId: projectId,
+                ProjectIds: projectIds is { Length: > 0 } ? projectIds : null,
                 CategoryIds: categoryIds is { Length: > 0 } ? categoryIds : null,
                 TextureTypes: textureTypeFilter,
                 Page: page,

--- a/src/frontend/src/features/project/api/projectApi.ts
+++ b/src/frontend/src/features/project/api/projectApi.ts
@@ -145,12 +145,8 @@ export async function getModelsByProject(projectId: number): Promise<Model[]> {
 export async function getTextureSetsByProject(
   projectId: number
 ): Promise<TextureSetDto[]> {
-  // TextureSet endpoint deliberately kept singular `projectId` — see
-  // `ITextureSetRepository.GetPagedAsync`. The TextureSet API was not
-  // migrated to array `projectIds[]` because the UI does not currently
-  // expose a multi-project filter for texture sets.
   const response = await client.get<GetAllTextureSetsResponse>(
-    `/texture-sets?projectId=${projectId}`
+    `/texture-sets?projectIds=${projectId}`
   )
   return response.data.textureSets
 }

--- a/src/frontend/src/features/texture-set/api/textureSetApi.ts
+++ b/src/frontend/src/features/texture-set/api/textureSetApi.ts
@@ -30,7 +30,7 @@ export async function getTextureSetsPaginated(options: {
   page: number
   pageSize: number
   packIds?: number[]
-  projectId?: number
+  projectIds?: number[]
   categoryIds?: number[]
   textureTypes?: number[]
   kind?: number
@@ -46,8 +46,7 @@ export async function getTextureSetsPaginated(options: {
   params.append('page', options.page.toString())
   params.append('pageSize', options.pageSize.toString())
   options.packIds?.forEach(id => params.append('packIds', id.toString()))
-  if (options.projectId)
-    params.append('projectId', options.projectId.toString())
+  options.projectIds?.forEach(id => params.append('projectIds', id.toString()))
   options.categoryIds?.forEach(id =>
     params.append('categoryIds', id.toString())
   )

--- a/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
@@ -141,6 +141,7 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
     isFetchingNextPage,
     fetchNextPage,
     packs,
+    projects,
     categories,
     searchQuery,
     setSearchQuery,
@@ -150,6 +151,8 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
     setIsFiltersOpen,
     selectedPackIds,
     setSelectedPackIds,
+    selectedProjectIds,
+    setSelectedProjectIds,
     selectedCategoryKeys,
     setSelectedCategoryKeys,
     selectedTextureTypes,
@@ -762,11 +765,14 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         packs={packs}
+        projects={projects}
         categories={categories}
         selectedPackIds={selectedPackIds}
+        selectedProjectIds={selectedProjectIds}
         selectedCategoryKeys={selectedCategoryKeys}
         selectedTextureTypes={selectedTextureTypes}
         onPackFilterChange={setSelectedPackIds}
+        onProjectFilterChange={setSelectedProjectIds}
         onCategoryChange={setSelectedCategoryKeys}
         onTextureTypesChange={setSelectedTextureTypes}
         cardWidth={cardWidth}
@@ -816,6 +822,7 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
         //      something").
         searchQuery.trim().length > 0 ||
         selectedPackIds.length > 0 ||
+        selectedProjectIds.length > 0 ||
         selectedTextureTypes.length > 0 ||
         Object.values(selectedCategoryKeys).some(s => s?.checked) ? (
           <div className="no-results">

--- a/src/frontend/src/features/texture-set/components/TexturesFilters.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturesFilters.tsx
@@ -19,7 +19,12 @@ import {
   OptionsButton,
 } from '@/shared/components/list-toolbar'
 import { type CategorySelectionKeys } from '@/shared/types/categories'
-import { type PackDto, type TextureSetCategoryDto, TextureType } from '@/types'
+import {
+  type PackDto,
+  type ProjectDto,
+  type TextureSetCategoryDto,
+  TextureType,
+} from '@/types'
 
 // Texture types exposed in the filter. SplitChannel is an implementation
 // detail (a single source file fanned out across channels) — hiding it
@@ -47,11 +52,14 @@ interface TexturesFiltersProps {
   searchQuery: string
   onSearchChange: (query: string) => void
   packs: PackDto[]
+  projects: ProjectDto[]
   categories: TextureSetCategoryDto[]
   selectedPackIds: number[]
+  selectedProjectIds: number[]
   selectedCategoryKeys: CategorySelectionKeys
   selectedTextureTypes: number[]
   onPackFilterChange: (packIds: number[]) => void
+  onProjectFilterChange: (projectIds: number[]) => void
   onCategoryChange: (keys: CategorySelectionKeys) => void
   onTextureTypesChange: (types: number[]) => void
   cardWidth: number
@@ -76,11 +84,14 @@ export function TexturesFilters({
   searchQuery,
   onSearchChange,
   packs,
+  projects,
   categories,
   selectedPackIds,
+  selectedProjectIds,
   selectedCategoryKeys,
   selectedTextureTypes,
   onPackFilterChange,
+  onProjectFilterChange,
   onCategoryChange,
   onTextureTypesChange,
   cardWidth,
@@ -100,6 +111,10 @@ export function TexturesFilters({
     label: pack.name,
     value: pack.id,
   }))
+  const projectOptions = projects.map(project => ({
+    label: project.name,
+    value: project.id,
+  }))
 
   const hasActiveSearch = searchQuery.trim().length > 0
   const selectedCategoryCount = Object.values(selectedCategoryKeys).filter(
@@ -107,11 +122,13 @@ export function TexturesFilters({
   ).length
   const hasActiveFilters =
     selectedPackIds.length > 0 ||
+    selectedProjectIds.length > 0 ||
     selectedCategoryCount > 0 ||
     selectedTextureTypes.length > 0
 
   const activeFilterCount = [
     selectedPackIds.length > 0,
+    selectedProjectIds.length > 0,
     selectedCategoryCount > 0,
     selectedTextureTypes.length > 0,
   ].filter(Boolean).length
@@ -233,6 +250,20 @@ export function TexturesFilters({
               filterPlaceholder="Search packs..."
             />
           )}
+          {projects.length > 0 && (
+            <MultiSelect
+              value={selectedProjectIds}
+              options={projectOptions}
+              onChange={e => onProjectFilterChange(e.value || [])}
+              placeholder="Projects"
+              data-testid="texture-set-project-filter"
+              className="list-filters-control"
+              display="chip"
+              showClear
+              filter
+              filterPlaceholder="Search projects..."
+            />
+          )}
           {categories.length > 0 && (
             <CategoryFilterPicker
               categories={categories}
@@ -261,6 +292,7 @@ export function TexturesFilters({
               tooltipOptions={{ position: 'bottom' }}
               onClick={() => {
                 onPackFilterChange([])
+                onProjectFilterChange([])
                 onCategoryChange({})
                 onTextureTypesChange([])
               }}
@@ -268,10 +300,12 @@ export function TexturesFilters({
           ) : null}
         </div>
 
-        {packs.length === 0 && categories.length === 0 ? (
+        {packs.length === 0 &&
+        projects.length === 0 &&
+        categories.length === 0 ? (
           <span className="list-filters-empty">
-            No pack or category filters yet — texture-type filter is always
-            available.
+            No pack, project, or category filters yet — texture-type filter is
+            always available.
           </span>
         ) : null}
       </ListToolbarPanel>

--- a/src/frontend/src/features/texture-set/components/useTextureSetGrid.ts
+++ b/src/frontend/src/features/texture-set/components/useTextureSetGrid.ts
@@ -8,6 +8,7 @@ import { type Toast } from 'primereact/toast'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { usePacksQuery } from '@/features/pack/api/queries'
+import { useProjectsQuery } from '@/features/project/api/queries'
 import {
   createTextureSet,
   createTextureSetWithFile,
@@ -85,6 +86,7 @@ export function useTextureSetGrid({
   // --- Filter facet data ---
 
   const { data: packs = [] } = usePacksQuery()
+  const { data: projects = [] } = useProjectsQuery()
   const { data: categories = [] } = useQuery({
     queryKey: ['textureSetCategories'],
     queryFn: getAllTextureSetCategories,
@@ -108,6 +110,10 @@ export function useTextureSetGrid({
   const sortedPackIds = useMemo(
     () => [...viewState.selectedPackIds].sort((a, b) => a - b),
     [viewState.selectedPackIds]
+  )
+  const sortedProjectIds = useMemo(
+    () => [...viewState.selectedProjectIds].sort((a, b) => a - b),
+    [viewState.selectedProjectIds]
   )
   const sortedTextureTypes = useMemo(
     () => [...viewState.selectedTextureTypes].sort((a, b) => a - b),
@@ -140,6 +146,7 @@ export function useTextureSetGrid({
       {
         kind,
         packIds: sortedPackIds,
+        projectIds: sortedProjectIds,
         categoryIds: sortedCategoryIds,
         textureTypes: sortedTextureTypes,
         searchName: debouncedSearchName || undefined,
@@ -151,6 +158,7 @@ export function useTextureSetGrid({
         pageSize: PAGE_SIZE,
         kind,
         packIds: sortedPackIds.length > 0 ? sortedPackIds : undefined,
+        projectIds: sortedProjectIds.length > 0 ? sortedProjectIds : undefined,
         categoryIds:
           sortedCategoryIds.length > 0 ? sortedCategoryIds : undefined,
         textureTypes:
@@ -195,6 +203,10 @@ export function useTextureSetGrid({
   )
   const setSelectedPackIds = useCallback(
     (ids: number[]) => setView({ selectedPackIds: ids }),
+    [setView]
+  )
+  const setSelectedProjectIds = useCallback(
+    (ids: number[]) => setView({ selectedProjectIds: ids }),
     [setView]
   )
   const setSelectedCategoryKeys = useCallback(
@@ -366,6 +378,7 @@ export function useTextureSetGrid({
     isFetchingNextPage,
     fetchNextPage,
     packs,
+    projects,
     categories,
 
     // Filter / search state
@@ -377,6 +390,8 @@ export function useTextureSetGrid({
     setIsFiltersOpen,
     selectedPackIds: viewState.selectedPackIds,
     setSelectedPackIds,
+    selectedProjectIds: viewState.selectedProjectIds,
+    setSelectedProjectIds,
     selectedCategoryKeys: viewState.selectedCategoryKeys,
     setSelectedCategoryKeys,
     selectedCategoryIds,

--- a/src/frontend/src/shared/hooks/useContainerTextureSets.ts
+++ b/src/frontend/src/shared/hooks/useContainerTextureSets.ts
@@ -59,12 +59,12 @@ export function useContainerTextureSets(
         page: number
         pageSize: number
         packIds?: number[]
-        projectId?: number
+        projectIds?: number[]
         kind?: number
       } = { page: pageParam, pageSize: PAGE_SIZE }
       if (adapter.type === 'pack') filterOptions.packIds = [adapter.containerId]
       if (adapter.type === 'project')
-        filterOptions.projectId = adapter.containerId
+        filterOptions.projectIds = [adapter.containerId]
       if (kind !== undefined) filterOptions.kind = kind
       return getTextureSetsPaginated(filterOptions)
     },

--- a/src/frontend/src/stores/textureSetListViewStore.ts
+++ b/src/frontend/src/stores/textureSetListViewStore.ts
@@ -13,6 +13,7 @@ export interface TextureSetListViewState {
   isFiltersOpen: boolean
   searchQuery: string
   selectedPackIds: number[]
+  selectedProjectIds: number[]
   selectedCategoryKeys: PersistedModelCategorySelectionKeys
   /** Subset of `TextureType` enum values (numeric). */
   selectedTextureTypes: number[]
@@ -34,6 +35,7 @@ export const DEFAULT_TEXTURE_SET_LIST_VIEW_STATE: TextureSetListViewState = {
   isFiltersOpen: false,
   searchQuery: '',
   selectedPackIds: [],
+  selectedProjectIds: [],
   selectedCategoryKeys: {},
   selectedTextureTypes: [],
   selectedTextureSetIds: [],
@@ -65,6 +67,20 @@ export const useTextureSetListViewStore = create<TextureSetListViewStore>()(
       name: 'texture-set-list-view-state',
       storage: createJSONStorage(() => localStorage),
       partialize: state => ({ views: state.views }),
+      // Backfill fields added after a view was first persisted (e.g.
+      // selectedProjectIds) so consumers can read them without guards.
+      merge: (persisted, current) => {
+        const persistedViews =
+          (persisted as { views?: Record<string, TextureSetListViewState> })
+            ?.views ?? {}
+        const views = Object.fromEntries(
+          Object.entries(persistedViews).map(([scope, view]) => [
+            scope,
+            { ...DEFAULT_TEXTURE_SET_LIST_VIEW_STATE, ...view },
+          ])
+        )
+        return { ...current, views }
+      },
     }
   )
 )


### PR DESCRIPTION
## Summary
Adds a multi-select **Projects** filter to the Global Materials and Multi-Model Textures lists, mirroring the existing Models list pattern.

- **Backend**: `GetPagedAsync` / `GetAllTextureSetsQuery` / endpoint migrated from single `projectId` to multi-select `projectIds` (now consistent with models/sprites/sounds/environment-maps).
- **Frontend**: `textureSetApi` sends `projectIds`; `useTextureSetGrid` fetches projects and wires query params; `TexturesFilters` gains a Projects `MultiSelect` (active-filter count + clear-all); `TextureSetGrid` passes props through.
- **View store**: backfills `selectedProjectIds` on hydration so older persisted tabs don't crash.
- **Migration**: updated the remaining singular-`projectId` callers (`getTextureSetsByProject`, `useContainerTextureSets`) to the plural param so project-container texture-set tabs keep filtering correctly.

## Test plan
- [ ] Global Materials list: filter by one and multiple projects; clear-all resets.
- [ ] Multi-Model Textures list: same.
- [ ] Project detail page → Texture Sets tab still scopes to that project.
- [ ] Reload with pre-existing persisted tab state (no crash).