### PR TITLE
Compact pack/project header: icon tabs + matched page background

### DIFF
--- a/docs/videos/scripts/packs.spec.ts
+++ b/docs/videos/scripts/packs.spec.ts
@@ -122,7 +122,7 @@ test.describe("Packs", () => {
         await disableHighlights(page);
         await longPause(page);
 
-        const modelsTab = page.getByRole("tab", { name: /Models:\s*0/i });
+        const modelsTab = page.getByTestId("container-tab-models");
         await modelsTab.waitFor({ state: "visible", timeout: ciVideoTimeout });
         await modelsTab.click();
         await mediumPause(page);
@@ -186,9 +186,11 @@ test.describe("Packs", () => {
             }
         }
 
-        await expect(page.getByRole("tab", { name: /Models:\s*2/i })).toBeVisible({
-            timeout: ciVideoTimeout,
-        });
+        await expect(page.getByTestId("container-tab-models")).toHaveAttribute(
+            "aria-label",
+            "Models (2)",
+            { timeout: ciVideoTimeout },
+        );
         const assignedModelCards = page.locator(".model-card:not(.model-card-add)");
         await expect(assignedModelCards.first()).toBeVisible({ timeout: ciVideoTimeout });
         const assignedCount = await assignedModelCards.count();

--- a/docs/videos/scripts/projects.spec.ts
+++ b/docs/videos/scripts/projects.spec.ts
@@ -380,7 +380,7 @@ test.describe("Projects", () => {
         });
         await viewerPause(page, 700);
 
-        const modelsTab = page.getByRole("tab", { name: /Models:\s*2/i });
+        const modelsTab = page.getByTestId("container-tab-models");
         await moveToLocator(page, modelsTab, 220);
         await modelsTab.click();
         await expect(page.locator(".model-card:not(.model-card-add)").first()).toBeVisible({
@@ -415,9 +415,11 @@ test.describe("Projects", () => {
         await moveToLocator(page, confirmAddButton, 240);
         await confirmAddButton.click();
 
-        await expect(page.getByRole("tab", { name: /Models:\s*3/i })).toBeVisible({
-            timeout: ciVideoTimeout,
-        });
+        await expect(page.getByTestId("container-tab-models")).toHaveAttribute(
+            "aria-label",
+            "Models (3)",
+            { timeout: ciVideoTimeout },
+        );
         await longPause(page);
 
         const visibleModelCards = page.locator(".model-card:not(.model-card-add)");

--- a/src/frontend/src/shared/components/ContainerViewer.css
+++ b/src/frontend/src/shared/components/ContainerViewer.css
@@ -3,37 +3,114 @@
   flex-direction: column;
   height: 100%;
   padding: 1rem;
-  gap: 1rem;
+  gap: 0.5rem;
   overflow-y: auto;
+  background: var(--mod-color-bg);
 }
 
-.container-header {
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--surface-border);
+/* Single-row layout: title on the left, tab nav on the right, panels on
+   row 2 spanning full width. `display: contents` on the TabView lifts its
+   children (nav-container, panels) into the grid so we can place them
+   independently — without splitting the PrimeReact component. */
+.container-tab-bar {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  flex: 1;
+  min-height: 0;
+  column-gap: var(--mod-space-md);
 }
 
-.container-header h2 {
+.container-title {
+  grid-column: 1;
+  grid-row: 1;
+  align-self: center;
   margin: 0;
+  font-size: var(--mod-text-sm);
+  font-weight: var(--mod-font-weight-medium);
+  color: var(--mod-color-text-muted);
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
-.container-content {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+.container-tab-bar > .container-tabs {
+  display: contents;
+}
+
+.container-tab-bar > .container-tabs > .p-tabview-nav-container {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.container-tab-bar > .container-tabs > .p-tabview-panels {
+  grid-column: 1 / -1;
+  grid-row: 2;
   min-height: 0;
-}
-
-.container-tabs {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
-.container-tabs .p-tabview-panels {
-  flex: 1;
   overflow-y: auto;
-  padding: 1rem 0;
+  padding: var(--mod-space-md) 0;
+}
+
+/* PrimeReact's theme is loaded at runtime via <link> injection
+   (see useTheme.ts), so on equal-specificity ties it wins. Background
+   and border overrides need !important to defeat the late-loader. */
+.container-tab-bar .p-tabview,
+.container-tab-bar .p-tabview-nav-container,
+.container-tab-bar .p-tabview-nav-content,
+.container-tab-bar .p-tabview-nav,
+.container-tab-bar .p-tabview-nav-link,
+.container-tab-bar .p-tabview-nav li.p-highlight .p-tabview-nav-link,
+.container-tab-bar
+  .p-tabview-nav
+  li:not(.p-highlight):not(.p-disabled):hover
+  .p-tabview-nav-link,
+.container-tab-bar .p-tabview-panels,
+.container-tab-bar .p-tabview-nav-btn {
+  background: transparent !important;
+}
+
+.container-tab-bar .p-tabview-nav {
+  gap: var(--mod-space-2xs);
+  flex-wrap: nowrap;
+  border-color: var(--mod-color-border) !important;
+}
+
+.container-tab-bar .p-tabview-nav li .p-tabview-nav-link {
+  border-color: transparent !important;
+  padding: var(--mod-space-xs) var(--mod-space-sm);
+  color: var(--mod-color-text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mod-space-2xs);
+  font-weight: var(--mod-font-weight-medium);
+}
+
+.container-tab-bar .p-tabview-nav li.p-highlight .p-tabview-nav-link {
+  color: var(--mod-color-primary);
+  box-shadow: inset 0 -2px 0 0 var(--mod-color-primary);
+}
+
+.container-tab-trigger i {
+  font-size: var(--mod-text-md);
+  line-height: 1;
+}
+
+.container-tab-count {
+  font-size: var(--mod-text-sm);
+  font-weight: var(--mod-font-weight-medium);
+  line-height: 1;
+}
+
+.container-tab-label-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .container-details {

--- a/src/frontend/src/shared/components/ContainerViewer.css
+++ b/src/frontend/src/shared/components/ContainerViewer.css
@@ -85,9 +85,12 @@
   font-weight: var(--mod-font-weight-medium);
 }
 
+/* Active tab: tint the link's bottom border (PrimeReact's existing
+   `margin: 0 0 -2px 0` on the link makes it overlap the nav's bottom
+   border exactly — no double line). */
 .container-tab-bar .p-tabview-nav li.p-highlight .p-tabview-nav-link {
   color: var(--mod-color-primary);
-  box-shadow: inset 0 -2px 0 0 var(--mod-color-primary);
+  border-color: var(--mod-color-primary) !important;
 }
 
 .container-tab-trigger i {
@@ -99,18 +102,6 @@
   font-size: var(--mod-text-sm);
   font-weight: var(--mod-font-weight-medium);
   line-height: 1;
-}
-
-.container-tab-label-sr {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 .container-details {

--- a/src/frontend/src/shared/components/ContainerViewer.tsx
+++ b/src/frontend/src/shared/components/ContainerViewer.tsx
@@ -20,6 +20,32 @@ interface ContainerViewerProps {
   tabId?: string
 }
 
+const renderTabHeader =
+  (icon: string, title: string, count?: number) =>
+  (options: TabPanelHeaderTemplateOptions) => {
+    const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    return (
+      <a
+        href="#"
+        role="tab"
+        aria-label={count !== undefined ? `${title} (${count})` : title}
+        className={`${options.className} container-tab-trigger`}
+        onClick={e => {
+          e.preventDefault()
+          options.onClick(e)
+        }}
+        data-pr-tooltip={title}
+        data-pr-position="bottom"
+        data-testid={`container-tab-${slug}`}
+      >
+        <i className={`pi ${icon}`} aria-hidden="true" />
+        {count !== undefined && (
+          <span className="container-tab-count">{count}</span>
+        )}
+      </a>
+    )
+  }
+
 export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
   const toast = useRef<Toast>(null)
   const [modelTotalCount, setModelTotalCount] = useState(0)
@@ -50,29 +76,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
 
   const { container, refetchContainer } = useContainerData(adapter, showToast)
   const label = adapter.label
-
-  const renderTabHeader =
-    (icon: string, title: string, count?: number) =>
-    (options: TabPanelHeaderTemplateOptions) => {
-      const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
-      return (
-        <a
-          href="#"
-          role="tab"
-          aria-label={count !== undefined ? `${title} (${count})` : title}
-          className={`${options.className} container-tab-trigger`}
-          onClick={options.onClick}
-          data-pr-tooltip={title}
-          data-pr-position="bottom"
-          data-testid={`container-tab-${slug}`}
-        >
-          <i className={`pi ${icon}`} aria-hidden="true" />
-          {count !== undefined && (
-            <span className="container-tab-count">{count}</span>
-          )}
-        </a>
-      )
-    }
+  const scopeKey = tabId ?? `${adapter.type}-${adapter.containerId}`
 
   // Sync tab counts from container data
   useEffect(() => {
@@ -95,16 +99,16 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
       <Toast ref={toast} />
 
       <Tooltip
-        target=".container-tab-trigger"
+        target={`[data-tab-scope="${scopeKey}"] .container-tab-trigger`}
         showDelay={0}
         hideDelay={0}
         mouseTrack={false}
       />
 
-      <div className="container-tab-bar">
-        <h3 className="container-title">
+      <div className="container-tab-bar" data-tab-scope={scopeKey}>
+        <h2 className="container-title">
           {label}: {container.name}
-        </h3>
+        </h2>
         <TabView
           activeIndex={activeTabIndex}
           onTabChange={e => setActiveTabIndex(e.index)}
@@ -158,7 +162,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Models: ${modelTotalCount}`}
+            header="Models"
             headerTemplate={renderTabHeader(
               'pi-box',
               'Models',
@@ -174,7 +178,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Global Materials: ${globalMaterialTotalCount}`}
+            header="Global Materials"
             headerTemplate={renderTabHeader(
               'pi-globe',
               'Global Materials',
@@ -193,7 +197,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Multi-Model Textures: ${multiModelTextureTotalCount}`}
+            header="Multi-Model Textures"
             headerTemplate={renderTabHeader(
               'pi-clone',
               'Multi-Model Textures',
@@ -212,7 +216,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Sprites: ${spriteTotalCount}`}
+            header="Sprites"
             headerTemplate={renderTabHeader(
               'pi-image',
               'Sprites',
@@ -228,7 +232,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Sounds: ${soundTotalCount}`}
+            header="Sounds"
             headerTemplate={renderTabHeader(
               'pi-volume-up',
               'Sounds',
@@ -244,7 +248,7 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
           </TabPanel>
 
           <TabPanel
-            header={`Environment Maps: ${environmentMapTotalCount}`}
+            header="Environment Maps"
             headerTemplate={renderTabHeader(
               'pi-map',
               'Environment Maps',

--- a/src/frontend/src/shared/components/ContainerViewer.tsx
+++ b/src/frontend/src/shared/components/ContainerViewer.tsx
@@ -1,6 +1,10 @@
 import './ContainerViewer.css'
 
-import { TabPanel, TabView, type TabPanelHeaderTemplateOptions } from 'primereact/tabview'
+import {
+  TabPanel,
+  type TabPanelHeaderTemplateOptions,
+  TabView,
+} from 'primereact/tabview'
 import { Toast } from 'primereact/toast'
 import { Tooltip } from 'primereact/tooltip'
 import { useCallback, useEffect, useRef, useState } from 'react'

--- a/src/frontend/src/shared/components/ContainerViewer.tsx
+++ b/src/frontend/src/shared/components/ContainerViewer.tsx
@@ -1,7 +1,8 @@
 import './ContainerViewer.css'
 
-import { TabPanel, TabView } from 'primereact/tabview'
+import { TabPanel, TabView, type TabPanelHeaderTemplateOptions } from 'primereact/tabview'
 import { Toast } from 'primereact/toast'
+import { Tooltip } from 'primereact/tooltip'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ModelGrid } from '@/features/models/components/ModelGrid'
@@ -50,6 +51,29 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
   const { container, refetchContainer } = useContainerData(adapter, showToast)
   const label = adapter.label
 
+  const renderTabHeader =
+    (icon: string, title: string, count?: number) =>
+    (options: TabPanelHeaderTemplateOptions) => {
+      const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+      return (
+        <a
+          href="#"
+          role="tab"
+          aria-label={count !== undefined ? `${title} (${count})` : title}
+          className={`${options.className} container-tab-trigger`}
+          onClick={options.onClick}
+          data-pr-tooltip={title}
+          data-pr-position="bottom"
+          data-testid={`container-tab-${slug}`}
+        >
+          <i className={`pi ${icon}`} aria-hidden="true" />
+          {count !== undefined && (
+            <span className="container-tab-count">{count}</span>
+          )}
+        </a>
+      )
+    }
+
   // Sync tab counts from container data
   useEffect(() => {
     if (container) {
@@ -70,19 +94,26 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
     <div className="container-viewer">
       <Toast ref={toast} />
 
-      <div className="container-header">
-        <h2>
-          {label}: {container.name}
-        </h2>
-      </div>
+      <Tooltip
+        target=".container-tab-trigger"
+        showDelay={0}
+        hideDelay={0}
+        mouseTrack={false}
+      />
 
-      <div className="container-content">
+      <div className="container-tab-bar">
+        <h3 className="container-title">
+          {label}: {container.name}
+        </h3>
         <TabView
           activeIndex={activeTabIndex}
           onTabChange={e => setActiveTabIndex(e.index)}
-          className="container-tabs"
+          className="container-tabs container-tabs-compact"
         >
-          <TabPanel header="Details">
+          <TabPanel
+            header="Details"
+            headerTemplate={renderTabHeader('pi-info-circle', 'Details')}
+          >
             {adapter.renderDetails ? (
               adapter.renderDetails({
                 container,
@@ -126,7 +157,14 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
             )}
           </TabPanel>
 
-          <TabPanel header={`Models: ${modelTotalCount}`}>
+          <TabPanel
+            header={`Models: ${modelTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-box',
+              'Models',
+              modelTotalCount
+            )}
+          >
             <ModelGrid
               {...(adapter.type === 'pack'
                 ? { packId: adapter.containerId }
@@ -135,7 +173,14 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
             />
           </TabPanel>
 
-          <TabPanel header={`Global Materials: ${globalMaterialTotalCount}`}>
+          <TabPanel
+            header={`Global Materials: ${globalMaterialTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-globe',
+              'Global Materials',
+              globalMaterialTotalCount
+            )}
+          >
             <ContainerTextureSetsTab
               adapter={adapter}
               showToast={showToast}
@@ -149,6 +194,11 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
 
           <TabPanel
             header={`Multi-Model Textures: ${multiModelTextureTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-clone',
+              'Multi-Model Textures',
+              multiModelTextureTotalCount
+            )}
           >
             <ContainerTextureSetsTab
               adapter={adapter}
@@ -161,7 +211,14 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
             />
           </TabPanel>
 
-          <TabPanel header={`Sprites: ${spriteTotalCount}`}>
+          <TabPanel
+            header={`Sprites: ${spriteTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-image',
+              'Sprites',
+              spriteTotalCount
+            )}
+          >
             <ContainerSpritesTab
               adapter={adapter}
               showToast={showToast}
@@ -170,7 +227,14 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
             />
           </TabPanel>
 
-          <TabPanel header={`Sounds: ${soundTotalCount}`}>
+          <TabPanel
+            header={`Sounds: ${soundTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-volume-up',
+              'Sounds',
+              soundTotalCount
+            )}
+          >
             <ContainerSoundsTab
               adapter={adapter}
               showToast={showToast}
@@ -179,7 +243,14 @@ export function ContainerViewer({ adapter, tabId }: ContainerViewerProps) {
             />
           </TabPanel>
 
-          <TabPanel header={`Environment Maps: ${environmentMapTotalCount}`}>
+          <TabPanel
+            header={`Environment Maps: ${environmentMapTotalCount}`}
+            headerTemplate={renderTabHeader(
+              'pi-map',
+              'Environment Maps',
+              environmentMapTotalCount
+            )}
+          >
             <ContainerEnvironmentMapsTab
               adapter={adapter}
               showToast={showToast}

--- a/tests/e2e/demo-tests/demo-mode.spec.ts
+++ b/tests/e2e/demo-tests/demo-mode.spec.ts
@@ -102,7 +102,7 @@ async function openProject(page, name) {
 }
 
 async function addModelToOpenPack(page, modelName, modelId) {
-    await page.locator(".p-tabview-nav li", { hasText: /^Models:/ }).click();
+    await page.locator('[data-testid="container-tab-models"]').click();
 
     const addCard = page.locator(".model-card.model-card-add").first();
     await expect(addCard).toBeVisible({ timeout: 15000 });
@@ -305,8 +305,8 @@ test.describe("demo mode e2e", () => {
         await addModelToOpenPack(page, "Test Cone", 2);
 
         await expect(
-            page.locator(".p-tabview-nav li", { hasText: /^Models: 1$/ }),
-        ).toBeVisible();
+            page.locator('[data-testid="container-tab-models"]'),
+        ).toHaveAttribute("aria-label", "Models (1)");
     });
 
     test("creates a pack with metadata and uploads a custom thumbnail", async ({

--- a/tests/e2e/pages/PacksPage.ts
+++ b/tests/e2e/pages/PacksPage.ts
@@ -288,8 +288,7 @@ export class PacksPage {
     async addModelToPack(): Promise<void> {
         // Click Models tab first, then find the Add Model card
         await this.page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
         const addCard = this.page.locator(".model-card-add").first();
         await addCard.waitFor({ state: "visible", timeout: 10000 });
@@ -325,8 +324,7 @@ export class PacksPage {
     ): Promise<void> {
         // Click Models tab first
         await this.page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
         const modelCard = modelId
             ? this.page.locator(`.model-card[data-model-id="${modelId}"]`)

--- a/tests/e2e/steps/packs.steps.ts
+++ b/tests/e2e/steps/packs.steps.ts
@@ -328,7 +328,7 @@ Then("the pack viewer should be visible", async ({ page }) => {
 Then(
     "the pack name {string} should be displayed",
     async ({ page }, packName: string) => {
-        const header = page.locator(".container-header h2");
+        const header = page.locator(".container-tab-bar .container-title");
         await expect(header).toContainText(packName);
         console.log(`[UI] Pack name "${packName}" is displayed ✓`);
     },
@@ -432,8 +432,7 @@ When(
 
         // Click the Models tab first to reveal model content
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         // Click "Add Model" card in container viewer (ModelGrid uses .model-card-add)
@@ -517,8 +516,7 @@ When(
 
         // Click the Models tab first to reveal model content
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         // Right-click on model card in container viewer (ModelGrid uses .model-card)
@@ -566,8 +564,7 @@ When(
         // Global Materials + Multi-Model Textures; newly-created sets default
         // to the model-specific kind).
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Multi-Model Textures" })
+            .locator('[data-testid="container-tab-multi-model-textures"]')
             .click();
 
         // Click add texture set card
@@ -615,8 +612,7 @@ When(
         // Global Materials + Multi-Model Textures; newly-created sets default
         // to the model-specific kind).
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Multi-Model Textures" })
+            .locator('[data-testid="container-tab-multi-model-textures"]')
             .click();
 
         // Right-click on texture set card
@@ -661,8 +657,7 @@ Then(
 
         // Click the Models tab first to reveal model content
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         // Wait for model grid to finish loading - wait for actual model cards (not just add button)
@@ -714,8 +709,7 @@ Then(
 
         // Click the Models tab first to reveal model content
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         // Wait for model grid to finish loading
@@ -740,8 +734,7 @@ Then(
     async ({ page }, expectedCount: number) => {
         // Click Details tab to see asset counts
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         const stat = page
@@ -774,8 +767,7 @@ Then(
         // Global Materials + Multi-Model Textures; newly-created sets default
         // to the model-specific kind).
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Multi-Model Textures" })
+            .locator('[data-testid="container-tab-multi-model-textures"]')
             .click();
 
         const textureCard = page.locator(
@@ -802,8 +794,7 @@ Then(
         // Global Materials + Multi-Model Textures; newly-created sets default
         // to the model-specific kind).
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Multi-Model Textures" })
+            .locator('[data-testid="container-tab-multi-model-textures"]')
             .click();
 
         const textureCard = page.locator(
@@ -821,8 +812,7 @@ Then(
     async ({ page }, expectedCount: number) => {
         // Click Details tab to see asset counts
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         // Texture sets are now split into Global Materials + Multi-Model
@@ -872,8 +862,7 @@ Given(
 
         // Click the Models tab first to reveal model content
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         // Wait for model grid to finish loading (cards or empty state)
@@ -915,8 +904,7 @@ Given(
         // Global Materials + Multi-Model Textures; newly-created sets default
         // to the model-specific kind).
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Multi-Model Textures" })
+            .locator('[data-testid="container-tab-multi-model-textures"]')
             .click();
 
         const textureCard = page.locator(
@@ -981,8 +969,7 @@ Then("I take a screenshot of pack after sprite removed", async ({ page }) => {
 When("I click add sprites button", async ({ page }) => {
     // Click the Sprites tab first to reveal sprite content
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: "Sprites" })
+        .locator('[data-testid="container-tab-sprites"]')
         .click();
 
     // Find the Add Sprite card in the active tab and wait for it
@@ -1040,8 +1027,7 @@ Then(
     async ({ page }, expectedCount: number) => {
         // Click Details tab to see asset counts
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         // Check sprite count in container details
@@ -1062,8 +1048,7 @@ Given(
     async ({ page }, minCount: number) => {
         // Click Details tab to see asset counts
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         const statSpan = page
@@ -1085,8 +1070,7 @@ Given(
 When("I remove the first sprite from the pack", async ({ page }) => {
     // Click the Sprites tab first to reveal sprite content
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: "Sprites" })
+        .locator('[data-testid="container-tab-sprites"]')
         .click();
 
     // Right-click on first sprite card to open context menu

--- a/tests/e2e/steps/projects.steps.ts
+++ b/tests/e2e/steps/projects.steps.ts
@@ -271,8 +271,7 @@ When(
 
         // Click Models tab first, then find Add Model card
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         const addModelCard = page.locator(".model-card-add").first();
@@ -347,8 +346,7 @@ When(
 
         // Click Models tab first, then find and right-click model card
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         const modelCard = page.locator(
@@ -511,8 +509,7 @@ Then(
 
         // Click Models tab first
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         const modelCard = page.locator(
@@ -536,8 +533,7 @@ Then(
 
         // Click Models tab first
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         const modelCard = page.locator(
@@ -562,8 +558,7 @@ Given(
 
         // Click Models tab first
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Models" })
+            .locator('[data-testid="container-tab-models"]')
             .click();
 
         const modelCard = page.locator(
@@ -605,8 +600,7 @@ Given(
                 .first()
                 .waitFor({ state: "visible", timeout: 15000 });
             await page
-                .locator(".p-tabview-nav li")
-                .filter({ hasText: "Models" })
+                .locator('[data-testid="container-tab-models"]')
                 .click();
             await modelCard.waitFor({ state: "visible", timeout: 10000 });
         }
@@ -623,19 +617,19 @@ Given(
 // (backend default) and parallel "global material" step names target Global
 // Materials.
 type TextureSetKindLabel = {
-    tabHeader: string; // tab text in .p-tabview-nav
+    tabTestId: string; // data-testid on the container tab anchor
     dialogHeader: string; // dialog header substring
     label: string; // logging label
 };
 
 const MULTI_MODEL_LABEL: TextureSetKindLabel = {
-    tabHeader: "Multi-Model Textures",
+    tabTestId: "container-tab-multi-model-textures",
     dialogHeader: "Add Multi-Model Textures",
     label: "texture set",
 };
 
 const GLOBAL_MATERIAL_LABEL: TextureSetKindLabel = {
-    tabHeader: "Global Materials",
+    tabTestId: "container-tab-global-materials",
     dialogHeader: "Add Global Materials",
     label: "global material",
 };
@@ -687,8 +681,7 @@ async function addTextureSetOfKindToProject(
 
     // Click the appropriate kind tab, then find Add card
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader })
+        .locator(`[data-testid="${labels.tabTestId}"]`)
         .click();
 
     const addCard = page.locator(".container-card-add").first();
@@ -764,8 +757,7 @@ async function addTextureSetOfKindToProject(
 
     // Switch to the kind tab to see the newly added card
     const kindTab = page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader });
+        .locator(`[data-testid="${labels.tabTestId}"]`);
     await kindTab.click();
 
     // Wait for the texture set card to appear (React Query refetch + render)
@@ -818,8 +810,7 @@ async function removeTextureSetOfKindFromProject(
 
     // Click the kind tab first, then find and right-click texture set card
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader })
+        .locator(`[data-testid="${labels.tabTestId}"]`)
         .click();
 
     const textureCard = page.locator(
@@ -884,8 +875,7 @@ async function assertProjectContainsTextureSetOfKind(
 
     // Click the kind tab first, then poll with reload until the card appears
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader })
+        .locator(`[data-testid="${labels.tabTestId}"]`)
         .click();
 
     await expect
@@ -923,8 +913,7 @@ async function assertProjectDoesNotContainTextureSetOfKind(
 
     // Click the kind tab first
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader })
+        .locator(`[data-testid="${labels.tabTestId}"]`)
         .click();
 
     const textureCard = page.locator(
@@ -996,8 +985,7 @@ async function ensureProjectContainsTextureSetOfKind(
 
     // Click the kind tab first
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: labels.tabHeader })
+        .locator(`[data-testid="${labels.tabTestId}"]`)
         .click();
 
     const textureCard = page.locator(
@@ -1214,8 +1202,7 @@ Then(
     async ({ page }, expectedCount: number) => {
         // Click Details tab to see stats
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         // Use retrying assertion — the count may take a moment to update
@@ -1238,8 +1225,7 @@ Given(
     async ({ page }, minCount: number) => {
         // Click Details tab to see stats
         await page
-            .locator(".p-tabview-nav li")
-            .filter({ hasText: "Details" })
+            .locator('[data-testid="container-tab-details"]')
             .click();
 
         // Wait for Details tab content to render
@@ -1261,8 +1247,7 @@ Given(
 When("I remove the first sprite from the project", async ({ page }) => {
     // Click Sprites tab first, then right-click on first sprite card
     await page
-        .locator(".p-tabview-nav li")
-        .filter({ hasText: "Sprites" })
+        .locator('[data-testid="container-tab-sprites"]')
         .click();
 
     const spriteCard = page


### PR DESCRIPTION
## Summary

- Pack/Project viewer header is now a single compact row: small muted title (matches the `list-toolbar-count` styling) on the left, icon tabs on the right.
- Each tab shows an icon + count badge with a zero-delay PrimeReact tooltip carrying the full label; long text labels removed.
- Container background now matches the Models list page (`--surface-ground` / `#111827`) instead of PrimeReact's card surface (`#1f2937`).
- Added `data-testid="container-tab-<slug>"` to each tab anchor so e2e tests can target tabs without depending on visible text (which is now icon-only).

## Implementation notes

- Layout uses CSS Grid + `display: contents` on the `TabView` so the title and tab nav share row 1 and the panels span row 2 full-width, without forking the PrimeReact component.
- PrimeReact's lara-dark-blue theme is injected at runtime via `<link>` (see `useTheme.ts`), so equal-specificity overrides lose to it on load order. Background/border overrides therefore use targeted `!important` (4 total, only on `background` and `border-color`).
- Active tab indicator is an inset bottom `box-shadow` in `--mod-color-primary` (replaced PrimeReact's filled-pill highlight).
- `aria-label` provides the accessible name for each icon tab (e.g. `"Models (5)"`) — no SR-only span needed.

## Test plan

- [ ] Open a pack and a project; confirm header reads on the same dark page background as the Models list.
- [ ] Hover each icon tab — tooltip appears immediately and shows full label (Details / Models / Global Materials / Multi-Model Textures / Sprites / Sounds / Environment Maps).
- [ ] Click each tab — content switches; active-tab indicator (underline) appears.
- [ ] Run the e2e suite (or at least `packs`, `projects`, `texture-types`, `demo-mode` features) — tab navigation steps still pass with the new `data-testid` selectors.