### PR TITLE
fix(grids): drop phantom scrollbar and fix lasso selection offset when scrolled

### DIFF
--- a/src/frontend/src/features/environment-map/components/EnvironmentMapList.css
+++ b/src/frontend/src/features/environment-map/components/EnvironmentMapList.css
@@ -37,7 +37,14 @@
 .environment-map-selection-surface {
   position: relative;
   flex: 1 1 auto;
-  min-height: 100%;
+  /* Fill the leftover space below the toolbar via flex-grow — NOT
+     min-height: 100%. Against the height-bounded .environment-map-list (a
+     bounded flex column), `min-height: 100%` resolves to the *full* container
+     height, so stacked under the toolbar it forced the container to overflow
+     by ~the toolbar height — a phantom scrollbar even with only a few cards
+     that fit. flex:1 already stretches the surface to fill the leftover space
+     (drop / rubber-band area). */
+  min-height: 0;
 }
 
 .environment-map-selection-surface.is-selecting {

--- a/src/frontend/src/features/environment-map/components/EnvironmentMapList.tsx
+++ b/src/frontend/src/features/environment-map/components/EnvironmentMapList.tsx
@@ -393,15 +393,20 @@ export function EnvironmentMapList() {
         return
       }
 
+      // Coordinates are relative to the selection surface's live bounding
+      // rect, which already shifts with the scroll position — so no
+      // scrollTop/scrollLeft offset is added here (doing so double-counts the
+      // scroll and the box would start away from the cursor). The selection
+      // box is absolutely positioned inside the surface, so these surface-
+      // relative coords map directly to its left/top.
       const rect = selectionSurfaceRef.current.getBoundingClientRect()
-      const scrollContainer = listScrollRef.current
 
       setIsAreaSelecting(true)
       setSelectionBox({
-        startX: event.clientX - rect.left + scrollContainer.scrollLeft,
-        startY: event.clientY - rect.top + scrollContainer.scrollTop,
-        currentX: event.clientX - rect.left + scrollContainer.scrollLeft,
-        currentY: event.clientY - rect.top + scrollContainer.scrollTop,
+        startX: event.clientX - rect.left,
+        startY: event.clientY - rect.top,
+        currentX: event.clientX - rect.left,
+        currentY: event.clientY - rect.top,
       })
     },
     []
@@ -419,14 +424,13 @@ export function EnvironmentMapList() {
       }
 
       const rect = selectionSurfaceRef.current.getBoundingClientRect()
-      const scrollContainer = listScrollRef.current
 
       setSelectionBox(previous =>
         previous
           ? {
               ...previous,
-              currentX: event.clientX - rect.left + scrollContainer.scrollLeft,
-              currentY: event.clientY - rect.top + scrollContainer.scrollTop,
+              currentX: event.clientX - rect.left,
+              currentY: event.clientY - rect.top,
             }
           : null
       )
@@ -442,7 +446,6 @@ export function EnvironmentMapList() {
       listScrollRef.current
     ) {
       const rect = selectionSurfaceRef.current.getBoundingClientRect()
-      const scrollContainer = listScrollRef.current
       const selectionLeft = Math.min(selectionBox.startX, selectionBox.currentX)
       const selectionTop = Math.min(selectionBox.startY, selectionBox.currentY)
       const selectionRight = Math.max(
@@ -461,8 +464,8 @@ export function EnvironmentMapList() {
 
       cards.forEach(card => {
         const cardRect = card.getBoundingClientRect()
-        const cardLeft = cardRect.left - rect.left + scrollContainer.scrollLeft
-        const cardTop = cardRect.top - rect.top + scrollContainer.scrollTop
+        const cardLeft = cardRect.left - rect.left
+        const cardTop = cardRect.top - rect.top
         const cardRight = cardLeft + cardRect.width
         const cardBottom = cardTop + cardRect.height
 

--- a/src/frontend/src/features/models/components/ModelGrid/ModelGrid.css
+++ b/src/frontend/src/features/models/components/ModelGrid/ModelGrid.css
@@ -51,7 +51,15 @@
 .model-grid-selection-surface {
   position: relative;
   flex: 1 1 auto;
-  min-height: 100%;
+  /* Fill the remaining space below the toolbar via flex-grow — NOT
+     min-height: 100%. Against a height-bounded .model-grid-container (the
+     standalone Models list is a bounded flex column) `min-height: 100%`
+     resolves to the *full* container height, so stacked under the toolbar it
+     forced the container to overflow by ~the toolbar height — a phantom
+     scrollbar even with only a few cards that fit. flex:1 already stretches
+     the surface to fill the leftover space (drop / rubber-band area), and
+     .model-grid-selection-content keeps min-height:100% to fill it. */
+  min-height: 0;
 }
 
 .model-grid-selection-surface.is-selecting {

--- a/src/frontend/src/features/models/components/ModelGrid/ModelGrid.tsx
+++ b/src/frontend/src/features/models/components/ModelGrid/ModelGrid.tsx
@@ -273,13 +273,19 @@ export function ModelGrid({
         return
       }
 
+      // Coordinates are relative to the selection surface's live bounding
+      // rect, which already shifts with the scroll position — so no
+      // scrollTop/scrollLeft offset is added here (doing so double-counts the
+      // scroll and the box would start away from the cursor). The selection
+      // box is absolutely positioned inside the surface, so these surface-
+      // relative coords map directly to its left/top.
       const rect = selectionSurfaceRef.current.getBoundingClientRect()
       setIsAreaSelecting(true)
       setSelectionBox({
-        startX: event.clientX - rect.left + scrollParent.scrollLeft,
-        startY: event.clientY - rect.top + scrollParent.scrollTop,
-        currentX: event.clientX - rect.left + scrollParent.scrollLeft,
-        currentY: event.clientY - rect.top + scrollParent.scrollTop,
+        startX: event.clientX - rect.left,
+        startY: event.clientY - rect.top,
+        currentX: event.clientX - rect.left,
+        currentY: event.clientY - rect.top,
       })
     },
     [isSelectionEnabled, scrollParent]
@@ -302,8 +308,8 @@ export function ModelGrid({
         previous
           ? {
               ...previous,
-              currentX: event.clientX - rect.left + scrollParent.scrollLeft,
-              currentY: event.clientY - rect.top + scrollParent.scrollTop,
+              currentX: event.clientX - rect.left,
+              currentY: event.clientY - rect.top,
             }
           : null
       )
@@ -338,8 +344,8 @@ export function ModelGrid({
 
       cards.forEach(card => {
         const cardRect = card.getBoundingClientRect()
-        const cardLeft = cardRect.left - rect.left + scrollParent.scrollLeft
-        const cardTop = cardRect.top - rect.top + scrollParent.scrollTop
+        const cardLeft = cardRect.left - rect.left
+        const cardTop = cardRect.top - rect.top
         const cardRight = cardLeft + cardRect.width
         const cardBottom = cardTop + cardRect.height
 

--- a/src/frontend/src/features/sounds/components/SoundList.tsx
+++ b/src/frontend/src/features/sounds/components/SoundList.tsx
@@ -264,6 +264,13 @@ export function SoundList() {
       return
     }
     if (soundGridRef.current) {
+      // NOTE: soundGridRef IS the scroll container (.sound-grid-container has
+      // overflow: auto), so its bounding rect stays fixed while the content
+      // scrolls — the scrollLeft/scrollTop term below is REQUIRED to map the
+      // cursor into the scrolled content. This differs from the model /
+      // texture-set / environment-map grids, where the rect comes from a
+      // non-scrolling selection-surface child and adding scroll would
+      // double-count it. Don't "simplify" this by removing the scroll terms.
       const rect = soundGridRef.current.getBoundingClientRect()
       setIsAreaSelecting(true)
       setSelectionBox({

--- a/src/frontend/src/features/sprite/components/SpriteList.tsx
+++ b/src/frontend/src/features/sprite/components/SpriteList.tsx
@@ -284,6 +284,13 @@ export function SpriteList() {
     const target = e.target as HTMLElement
     if (target.closest('.sprite-card')) return
     if (spriteGridRef.current) {
+      // NOTE: spriteGridRef IS the scroll container (.sprite-grid-container has
+      // overflow: auto), so its bounding rect stays fixed while the content
+      // scrolls — the scrollLeft/scrollTop term below is REQUIRED to map the
+      // cursor into the scrolled content. This differs from the model /
+      // texture-set / environment-map grids, where the rect comes from a
+      // non-scrolling selection-surface child and adding scroll would
+      // double-count it. Don't "simplify" this by removing the scroll terms.
       const rect = spriteGridRef.current.getBoundingClientRect()
       setIsAreaSelecting(true)
       setSelectionBox({

--- a/src/frontend/src/features/texture-set/components/TextureSetGrid.css
+++ b/src/frontend/src/features/texture-set/components/TextureSetGrid.css
@@ -236,7 +236,14 @@
 .texture-set-grid-selection-surface {
   position: relative;
   flex: 1 1 auto;
-  min-height: 100%;
+  /* Fill the leftover space below the toolbar via flex-grow — NOT
+     min-height: 100%. Against the height-bounded .texture-set-grid-container
+     (a bounded flex column), `min-height: 100%` resolves to the *full*
+     container height, so stacked under the toolbar it forced the container to
+     overflow by ~the toolbar height — a phantom scrollbar even with only a few
+     cards that fit. flex:1 already stretches the surface to fill the leftover
+     space (drop / rubber-band area). */
+  min-height: 0;
 }
 
 .texture-set-grid-selection-surface.is-selecting {

--- a/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
@@ -223,13 +223,19 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
       // Only react to primary-button drags.
       if (event.button !== 0) return
 
+      // Coordinates are relative to the selection surface's live bounding
+      // rect, which already shifts with the scroll position — so no
+      // scrollTop/scrollLeft offset is added here (doing so double-counts the
+      // scroll and the box would start away from the cursor). The selection
+      // box is absolutely positioned inside the surface, so these surface-
+      // relative coords map directly to its left/top.
       const rect = selectionSurfaceRef.current.getBoundingClientRect()
       setIsAreaSelecting(true)
       setSelectionBox({
-        startX: event.clientX - rect.left + scrollParent.scrollLeft,
-        startY: event.clientY - rect.top + scrollParent.scrollTop,
-        currentX: event.clientX - rect.left + scrollParent.scrollLeft,
-        currentY: event.clientY - rect.top + scrollParent.scrollTop,
+        startX: event.clientX - rect.left,
+        startY: event.clientY - rect.top,
+        currentX: event.clientX - rect.left,
+        currentY: event.clientY - rect.top,
       })
     },
     [scrollParent]
@@ -250,8 +256,8 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
         prev
           ? {
               ...prev,
-              currentX: event.clientX - rect.left + scrollParent.scrollLeft,
-              currentY: event.clientY - rect.top + scrollParent.scrollTop,
+              currentX: event.clientX - rect.left,
+              currentY: event.clientY - rect.top,
             }
           : null
       )
@@ -278,8 +284,8 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
       const next = new Set<number>()
       cards.forEach(card => {
         const cardRect = card.getBoundingClientRect()
-        const cardLeft = cardRect.left - rect.left + scrollParent.scrollLeft
-        const cardTop = cardRect.top - rect.top + scrollParent.scrollTop
+        const cardLeft = cardRect.left - rect.left
+        const cardTop = cardRect.top - rect.top
         const cardRight = cardLeft + cardRect.width
         const cardBottom = cardTop + cardRect.height
         if (


### PR DESCRIPTION
## Summary

Fixes two related bugs in every card grid that shares the lasso/`*-selection-surface` pattern — **Models**, **Global Materials**, **Multi-Model Textures**, and **Environment Maps**.

### 1. Phantom scrollbar with few items
Each `*-selection-surface` used `min-height: 100%`. The surface lives inside a height-bounded flex-column scroll container, so `100%` resolves to the **full** container height. Stacked under the toolbar, that forced the container to overflow by ~the toolbar height — a scrollbar appeared (and you could scroll ~one toolbar's worth) even when only a few cards were present and everything fit.

**Fix:** `min-height: 0`. `flex: 1 1 auto` already stretches the surface to fill the leftover space below the cards, so the drop / rubber-band area is preserved.

### 2. Lasso selection box offset by the scroll amount
Rubber-band selection coordinates were computed as `event.clientX/Y - rect.left/top + scrollParent.scrollLeft/Top`. But `rect` is the surface's **live** bounding rect, which already shifts with the scroll position — so adding the scroll offset **double-counted** it. Once the list was scrolled, the selection box (and the hit-test) started away from the cursor by exactly the scroll amount.

**Fix:** drop the redundant `scrollParent.scrollLeft/Top` terms in all four spots (mousedown start + current, mousemove current, mouseup card coords). Coordinates are now pure surface-relative space — correct for both the absolutely-positioned box and the hit-test, and a no-op when unscrolled.

## Files
- `ModelGrid.{tsx,css}`
- `TextureSetGrid.{tsx,css}` (Global Materials + Multi-Model Textures)
- `EnvironmentMapList.{tsx,css}`

## Verification
Reproduced and verified each fix by driving the demo app with Playwright:

| Page | Phantom scroll (few cards) | Box vs cursor @150px scroll | Hit-test while scrolled |
|---|---|---|---|
| Models | overflow 0 (was ~toolbar height) | offset 0,0 (was +scroll) | selects covered cards ✓ |
| Global Materials | overflow 0 | offset 0,0 | ✓ |
| Multi-Model Textures | overflow 0 | offset 0,0 | PASS |
| Environment Maps | overflow 0 | offset 0,0 | PASS |

The selection surface still fills the area after the change (so drop / rubber-band selection on empty space keeps working).

## Checks
- Prettier: clean
- ESLint: no new issues (one pre-existing `exhaustive-deps` warning, untouched)
- `tsc --noEmit`: no new errors (the 131 pre-existing repo-wide errors are unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)