### PR TITLE
fix(e2e): harden virtualized-grid card waits (env maps + texture set viewer)

### DIFF
--- a/tests/e2e/pages/EnvironmentMapsPage.ts
+++ b/tests/e2e/pages/EnvironmentMapsPage.ts
@@ -478,7 +478,10 @@ export class EnvironmentMapsPage {
     }
 
     async waitForCardThumbnailLoaded(name: string, timeout = 30000): Promise<void> {
+        await this.waitForEnvironmentMapByName(name, timeout);
+
         const image = this.getEnvironmentMapCardThumbnailByName(name);
+        await image.scrollIntoViewIfNeeded().catch(() => {});
         await expect(image).toBeVisible({ timeout });
 
         await expect

--- a/tests/e2e/steps/exr-preview.steps.ts
+++ b/tests/e2e/steps/exr-preview.steps.ts
@@ -130,16 +130,28 @@ When(
 
         // Narrow the virtualized grid to the target set so the card is
         // rendered in DOM even if it'd otherwise scroll off-screen.
-        // `narrowVirtualisedList` opens the search panel (throws if it
-        // can't), fills the name, and waits for the count chip to
-        // stabilise.
         const textureSetsPage = new TextureSetsPage(page);
-        await narrowVirtualisedList(page, set.name);
-
-        // Find the card by the unique name
         const card = textureSetsPage.getCardByName(set.name).first();
 
-        await expect(card).toBeVisible({ timeout: 10000 });
+        // `narrowVirtualisedList` waits on the count chip, which can briefly
+        // read "stable" at its pre-filter value before the search debounce
+        // fires — leaving the target card rendered off-screen in the
+        // VirtuosoGrid, where a plain visibility wait can't recover because
+        // nothing scrolls it back into the DOM. Re-narrow + scroll into view
+        // until the card actually materialises, so a single stale count read
+        // can't fail the step (intermittent in CI).
+        await expect
+            .poll(
+                async () => {
+                    await narrowVirtualisedList(page, set.name);
+                    if ((await card.count()) === 0) return false;
+                    await card.scrollIntoViewIfNeeded().catch(() => {});
+                    return card.isVisible().catch(() => false);
+                },
+                { timeout: 30000, intervals: [500, 1000, 2000, 3000] },
+            )
+            .toBe(true);
+
         await card.dblclick();
 
         // Wait for viewer to open


### PR DESCRIPTION
## Summary

Two related e2e flake fixes for asset lists rendered as virtualised `VirtuosoGrid`s, where a target card can sit off-screen / unmounted and a plain `toBeVisible()` wait can't recover (nothing scrolls it back into the DOM).

1. **Env-map thumbnail wait** — `waitForCardThumbnailLoaded` now first materialises the card via `waitForEnvironmentMapByName` (which progressively scrolls + reloads past stale React Query cache) and scrolls the image into view before asserting. Reuses the existing pattern from `openEnvironmentMapByName`.

2. **Texture-set viewer open** — the shared `I open the texture set viewer for {string}` step relied on `narrowVirtualisedList`, whose count-chip wait can return on a *pre-filter* "stable" read before the search debounce fires, leaving the card virtualised off-screen. It now re-narrows + scrolls the card into view in a poll until it materialises. This is what was intermittently failing CI on `00-texture-sets/17-tiff-preview.feature` with "element(s) not found".

## Context

These are the e2e-hardening remnants of #494; the duplicate-name policy that #494 originally carried has since landed on `main` via #488, so #494 can be closed as superseded.

## Test plan

- [ ] CI green on the e2e suite (env-map thumbnail + TIFF/EXR preview scenarios)