### PR TITLE
Prep 0.1.0 release — fix test-tooling CodeQL alerts + align internal versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "1.0.0",
+            "version": "0.1.0",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "1.0.0",
+    "version": "0.1.0",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/scripts/test-catalog/server.mjs
+++ b/scripts/test-catalog/server.mjs
@@ -73,7 +73,8 @@ function ensureCatalog(res) {
             catalogDirty = false;
         } catch (e) {
             if (missing) {
-                send(res, 500, { error: `catalog build failed: ${e.message || e}` });
+                console.error("[test-site] catalog build failed:", e);
+                send(res, 500, { error: "catalog build failed (see server log)" });
                 return false;
             }
         }
@@ -141,7 +142,8 @@ function startRun(spec, res) {
     try {
         rs = buildRunSpec(spec);
     } catch (e) {
-        return send(res, 400, { error: String(e.message || e) });
+        console.error("[test-site] invalid run spec:", e);
+        return send(res, 400, { error: "invalid run request (see server log)" });
     }
 
     fs.mkdirSync(rs.workDir, { recursive: true });
@@ -266,7 +268,7 @@ const server = http.createServer(async (req, res) => {
     if (p === "/api/run/stop" && req.method === "POST") return stopRun(res);
     if (p === "/api/run" && req.method === "POST") return startRun(await readBody(req), res);
     if (p === "/api/github/refresh" && req.method === "POST") {
-        try { buildCatalog({ github: true, refreshGh: true, quiet: true }); } catch (e) { return send(res, 500, { error: String(e.message || e) }); }
+        try { buildCatalog({ github: true, refreshGh: true, quiet: true }); } catch (e) { console.error("[test-site] github refresh failed:", e); return send(res, 500, { error: "github refresh failed (see server log)" }); }
         return send(res, 200, { ok: true });
     }
     if (p.startsWith("/report/") && req.method === "GET") return serveReport(req, res, decodeURIComponent(p.slice("/report/".length)));

--- a/scripts/test-catalog/ui/app.js
+++ b/scripts/test-catalog/ui/app.js
@@ -15,7 +15,15 @@
 const state = { catalog: null, history: null, summary: null, interactive: false, q: "" };
 
 const $ = (sel) => document.querySelector(sel);
-const esc = (s) => String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+// Full HTML entity-escape — covers element AND attribute context (quotes), so
+// esc() is safe to interpolate into "..."/'...' attributes, not just text.
+const esc = (s) =>
+    String(s ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 // Strip all CSI escape sequences (colors AND cursor/erase codes like \x1b[2K).
 const stripAnsi = (s) => s.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "");
 
@@ -84,7 +92,7 @@ function laneOf(feature, sc) {
 }
 function laneBadge(lane) {
     const l = LANES[lane];
-    return `<span class="badge ${l.cls}" title="${esc(l.desc.replace(/<[^>]+>/g, ""))}">${l.label}</span>`;
+    return `<span class="badge ${l.cls}" title="${esc(l.desc)}">${l.label}</span>`;
 }
 function laneCounts() {
     const c = { pr: 0, nightly: 0, local: 0, manual: 0, setup: 0 };

--- a/scripts/test-runner/report.mjs
+++ b/scripts/test-runner/report.mjs
@@ -14,11 +14,15 @@ const STATUS = {
     "not-present": { label: "NOT PRESENT", color: "#57606a", bg: "#eaeef2" },
 };
 
+// Full HTML entity-escape — covers element AND attribute context (quotes), so
+// esc() is safe to interpolate into "..." attributes (href, style), not just text.
 function esc(s) {
     return String(s)
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 }
 
 export function writeReport(results, meta) {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^8.0.11",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Unblocks the **0.1.0** release PR (#519). That PR exposed 18 CodeQL alerts that came in with the Test Studio / test-runner tooling (#518) but were never scanned while `version/0.1` was unprotected.

## CodeQL fixes (18 alerts: 1 high, 17 medium)
- **`js/incomplete-html-attribute-sanitization` ×17** + **`js/incomplete-multi-character-sanitization` ×1**: the `esc()` helpers in `scripts/test-catalog/ui/app.js` and `scripts/test-runner/report.mjs` escaped `<`, `>`, `&` but **not quotes**, so values interpolated into `"..."` attributes could break out. Completed the escaper (added `"` and `'`) and dropped the incomplete tag-stripping regex in `laneBadge`'s title.
- **`js/stack-trace-exposure`**: the local control-panel server (`server.mjs`) returned caught-exception text in HTTP responses. Now logs detail server-side and returns a generic message.

Local-only dev tooling, but real patterns — **fixed, not dismissed**.

## Version alignment
- `src/desktop` + `src/desktop-client` already declare **0.1.0** (these drive the installers and the update feed).
- Bumped the internal, unpublished **root / frontend / asset-processor** `package.json` + lockfiles to `0.1.0` so every version in the repo reads 0.1.0.

After this merges into `version/0.1`, #519's CodeQL re-runs and the 18 alerts clear.