### PR TITLE
chore(release): align internal package versions to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Prep PR for the 0.2.0 release (mirrors the 0.1.0 prep, #520).

Bumps every shipped package's own version `0.1.0` → `0.2.0`:

- root `package.json` (+ lockfile)
- `src/frontend` (+ lockfile)
- `src/asset-processor` (+ lockfile)
- `src/desktop` (+ lockfile) — drives the host installer + electron-updater feed
- `src/desktop-client` — drives the client installer + its `client` update feed

Only each package's own `version` field changed; no dependency versions were
touched (verified against the lockfiles). Without this, the native installers
would rebuild as `0.1.0` and auto-update would never fire.

Next: merge `version/0.2` → `main`, tag `v0.2.0`, publish the release.