### PR TITLE
ci(upgrade): manually-runnable cross-OS upgrade-integrity test

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,0 +1,205 @@
+name: Upgrade Test
+
+# Proves a real version-to-version upgrade keeps user data. On Windows/macOS/Linux
+# it installs the FROM release, seeds one of every asset type through the host
+# API, installs the TO release *over* it (the data folder lives in the user
+# profile, so it persists), then verifies every asset survived byte-for-byte and
+# the upgraded app still works.
+#
+# Both installers come straight from GitHub Releases — no build step — so this is
+# fast and can be run on demand. Defaults to "v0.1.0 → latest published release".
+on:
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: "Release tag to upgrade FROM"
+        required: false
+        default: "v0.1.0"
+        type: string
+      to_tag:
+        description: "Release tag to upgrade TO (blank = latest published release)"
+        required: false
+        type: string
+  # Nightly safety net so a data-losing upgrade is caught within a day of release.
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upgrade-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade-test:
+    name: Upgrade ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+          - name: macOS
+            os: macos-14
+          - name: Linux
+            os: ubuntu-latest
+    env:
+      # Both seed/verify scripts default to this; the installed host serves its
+      # edge-proxied public API on plain http here.
+      MODELIBR_API_BASE: http://127.0.0.1:3010/api
+    steps:
+      - name: Checkout repo (seed/verify scripts)
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Resolve FROM / TO release tags
+        id: tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_FROM: ${{ inputs.from_tag }}
+          INPUT_TO: ${{ inputs.to_tag }}
+        run: |
+          set -euo pipefail
+          from="${INPUT_FROM:-v0.1.0}"
+          to="${INPUT_TO:-}"
+          if [ -z "$to" ]; then
+            # Newest published, non-draft, non-prerelease release.
+            to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName // empty')
+          fi
+          [ -n "$to" ] || { echo "Could not resolve a TO release tag"; exit 1; }
+          if [ "$from" = "$to" ]; then
+            echo "FROM ($from) equals TO ($to) — nothing to upgrade."
+            exit 1
+          fi
+          echo "Upgrading: $from  ->  $to"
+          echo "from=$from" >> "$GITHUB_OUTPUT"
+          echo "to=$to" >> "$GITHUB_OUTPUT"
+
+      - name: Download FROM and TO installers
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${{ runner.os }}" in
+            Linux)   pat='*linux-amd64.deb' ;;
+            macOS)   pat='*macos-arm64.dmg' ;;
+            Windows) pat='*windows-x64.exe' ;;
+          esac
+          mkdir -p old-installer new-installer
+          # Each release carries both host and Client assets matching the pattern;
+          # the per-OS scenario below picks the host one (filters out *Client*).
+          gh release download "${{ steps.tags.outputs.from }}" --dir old-installer --pattern "$pat"
+          gh release download "${{ steps.tags.outputs.to }}"   --dir new-installer --pattern "$pat"
+          echo "── FROM ──"; ls -la old-installer
+          echo "── TO ──";   ls -la new-installer
+
+      - name: Upgrade scenario (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y xvfb >/dev/null
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+
+          install_deb() { sudo dpkg -i "$1" || sudo apt-get install -f -y; }
+          start_app() {
+            local bin
+            bin=$(find /opt -type f -executable \( -name 'modelibr*' -o -name 'Modelibr*' \) 2>/dev/null | head -n1)
+            [ -n "$bin" ] || { echo "binary not found under /opt"; ls -la /opt || true; exit 1; }
+            nohup "$bin" --no-sandbox >/tmp/modelibr.log 2>&1 & disown || true
+          }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { pkill -f -i modelibr || true; sleep 5; }
+
+          OLD=$(ls old-installer/*.deb | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.deb | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_deb "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_deb "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Upgrade scenario (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dmg() {
+            hdiutil attach "$1" -mountpoint /Volumes/ModelibrUp -nobrowse -quiet
+            rm -rf /Applications/Modelibr.app
+            cp -R "/Volumes/ModelibrUp/Modelibr.app" /Applications/
+            hdiutil detach /Volumes/ModelibrUp -quiet
+            sudo xattr -dr com.apple.quarantine /Applications/Modelibr.app 2>/dev/null || true
+          }
+          start_app() { nohup "/Applications/Modelibr.app/Contents/MacOS/Modelibr" >/tmp/modelibr.log 2>&1 & disown || true; }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { osascript -e 'quit app "Modelibr"' || true; sleep 3; pkill -f Modelibr || true; sleep 3; }
+
+          OLD=$(ls old-installer/*.dmg | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.dmg | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_dmg "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_dmg "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Upgrade scenario (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $old = Get-ChildItem old-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          $new = Get-ChildItem new-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          if (-not $old) { throw "FROM installer not found" }
+          if (-not $new) { throw "TO installer not found" }
+          Write-Host "OLD=$($old.FullName)  NEW=$($new.FullName)"
+
+          function Install-App($installer) { Start-Process -Wait -FilePath $installer.FullName -ArgumentList '/S' }
+          function Start-App {
+            $exe = @("$env:LOCALAPPDATA\Programs\Modelibr\Modelibr.exe", "$env:PROGRAMFILES\Modelibr\Modelibr.exe") |
+              Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (-not $exe) { throw "Modelibr.exe not found" }
+            Start-Process -FilePath $exe
+          }
+          function Wait-Ready {
+            for ($i = 0; $i -lt 60; $i++) {
+              try { Invoke-WebRequest -UseBasicParsing http://127.0.0.1:3010 -TimeoutSec 5 | Out-Null; return } catch { Start-Sleep 3 }
+            }
+            throw "app not ready"
+          }
+          function Stop-App { Stop-Process -Name Modelibr -Force -ErrorAction SilentlyContinue; Start-Sleep 5 }
+
+          Install-App $old; Start-App; Wait-Ready
+          node tests/upgrade/seed-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "seed failed" }; Stop-App
+          Install-App $new; Start-App; Wait-Ready
+          node tests/upgrade/verify-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "verify failed" }; Stop-App
+
+      - name: Upload upgrade manifest + logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-test-${{ matrix.name }}
+          path: |
+            upgrade-manifest.json
+            /tmp/modelibr.log
+          if-no-files-found: ignore

--- a/tests/upgrade/lib.mjs
+++ b/tests/upgrade/lib.mjs
@@ -1,0 +1,175 @@
+// Shared helpers for the upgrade-integrity scripts (seed + verify). Zero external
+// deps — only Node built-ins — so the scripts run on a bare CI runner against the
+// installed app, exactly like src/desktop/scripts/integration/data-folder-migration.mjs.
+
+import crypto from 'crypto'
+import http from 'http'
+import https from 'https'
+
+// Default to the edge-proxied public API of an installed host. Override with
+// MODELIBR_API_BASE (e.g. the self-signed docker stack at https://127.0.0.1:3010/api).
+export const API_BASE = process.env.MODELIBR_API_BASE || 'http://127.0.0.1:3010/api'
+
+export function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex')
+}
+
+export function request(method, url, { headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url)
+    const transport = u.protocol === 'https:' ? https : http
+    const req = transport.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method,
+        headers,
+        // The local docker stack serves a self-signed cert on :3010; the installed
+        // app is plain http. Accept self-signed so the same script covers both.
+        rejectUnauthorized: false,
+      },
+      res => {
+        const chunks = []
+        res.on('data', c => chunks.push(c))
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode,
+            buffer: Buffer.concat(chunks),
+            json() {
+              return JSON.parse(Buffer.concat(chunks).toString())
+            },
+          })
+        )
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(60000, () => req.destroy(new Error('request timed out')))
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+// Build a multipart/form-data body. `fields` is an array of either
+// { name, value } (text) or { name, filename, content } (file).
+export function multipart(fields) {
+  const boundary = '----modelibr-upgrade' + crypto.randomBytes(8).toString('hex')
+  const parts = []
+  for (const field of fields) {
+    if (field.filename != null) {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"; filename="${field.filename}"\r\n` +
+            `Content-Type: application/octet-stream\r\n\r\n`
+        ),
+        field.content,
+        Buffer.from('\r\n')
+      )
+    } else {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"\r\n\r\n` +
+            `${field.value}\r\n`
+        )
+      )
+    }
+  }
+  parts.push(Buffer.from(`--${boundary}--\r\n`))
+  return { body: Buffer.concat(parts), contentType: `multipart/form-data; boundary=${boundary}` }
+}
+
+// ───── Tiny inline fixtures (no committed binaries) ─────
+
+const OBJ = Buffer.from('# modelibr upgrade cube\no cube\nv 0 0 0\nv 1 0 0\nv 1 1 0\nf 1 2 3\n')
+
+// 1×1 opaque-red PNG.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+// A valid 16-bit PCM mono WAV with a few samples (≈ a click of audio).
+function makeWav() {
+  const sampleRate = 8000
+  const samples = 16
+  const dataLen = samples * 2
+  const buf = Buffer.alloc(44 + dataLen)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(36 + dataLen, 4)
+  buf.write('WAVE', 8)
+  buf.write('fmt ', 12)
+  buf.writeUInt32LE(16, 16) // PCM chunk size
+  buf.writeUInt16LE(1, 20) // PCM
+  buf.writeUInt16LE(1, 22) // mono
+  buf.writeUInt32LE(sampleRate, 24)
+  buf.writeUInt32LE(sampleRate * 2, 28) // byte rate
+  buf.writeUInt16LE(2, 32) // block align
+  buf.writeUInt16LE(16, 34) // bits per sample
+  buf.write('data', 36)
+  buf.writeUInt32LE(dataLen, 40)
+  for (let i = 0; i < samples; i++) buf.writeInt16LE((i % 2 ? 8000 : -8000), 44 + i * 2)
+  return buf
+}
+
+const WAV = makeWav()
+
+// The asset types a v0.1.0 host supports. Each is seeded once, then looked up by
+// its unique name after the upgrade. `listKey` is the array property in the list
+// response (null = the response IS the array, as for /models). `fileCheck` pulls
+// the bytes back and compares the sha256 (only /models exposes /{id}/file).
+export function assetTypes(tag) {
+  return [
+    {
+      type: 'model',
+      uploadPath: '/models',
+      listPath: '/models',
+      listKey: null,
+      name: `upgrade-model-${tag}`,
+      filename: `upgrade-model-${tag}.obj`,
+      content: OBJ,
+      fileUrlFor: id => `/models/${id}/file`,
+    },
+    {
+      type: 'texture-set',
+      uploadPath: '/texture-sets/with-file',
+      listPath: '/texture-sets',
+      listKey: 'textureSets',
+      name: `upgrade-texset-${tag}`,
+      filename: `upgrade-texset-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sprite',
+      uploadPath: '/sprites/with-file',
+      listPath: '/sprites',
+      listKey: 'sprites',
+      name: `upgrade-sprite-${tag}`,
+      filename: `upgrade-sprite-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sound',
+      uploadPath: '/sounds/with-file',
+      listPath: '/sounds',
+      listKey: 'sounds',
+      name: `upgrade-sound-${tag}`,
+      filename: `upgrade-sound-${tag}.wav`,
+      content: WAV,
+    },
+    {
+      type: 'environment-map',
+      uploadPath: '/environment-maps/with-file',
+      listPath: '/environment-maps',
+      listKey: 'environmentMaps',
+      name: `upgrade-envmap-${tag}`,
+      filename: `upgrade-envmap-${tag}.png`,
+      content: PNG,
+    },
+  ]
+}
+
+export function listArray(payload, listKey) {
+  return listKey ? (payload?.[listKey] ?? []) : payload
+}

--- a/tests/upgrade/seed-assets.mjs
+++ b/tests/upgrade/seed-assets.mjs
@@ -1,0 +1,60 @@
+// Upgrade-integrity test — STEP 1 (seed). Uploads one of every asset type the
+// previous (old) Modelibr version supports through the host's public API, then
+// writes a manifest (name + uploaded-bytes sha256 per asset) for verify-assets.mjs
+// to check after the app has been upgraded in place.
+//
+// Usage: node tests/upgrade/seed-assets.mjs [manifestPath]
+//   MODELIBR_API_BASE  API base (default http://127.0.0.1:3010/api)
+
+import fs from 'fs/promises'
+
+import { API_BASE, assetTypes, multipart, request, sha256 } from './lib.mjs'
+
+const manifestPath = process.argv[2] || 'upgrade-manifest.json'
+
+async function seedOne(spec) {
+  const fields = [
+    { name: 'file', filename: spec.filename, content: spec.content },
+    { name: 'name', value: spec.name },
+  ]
+  const { body, contentType } = multipart(fields)
+  const res = await request('POST', `${API_BASE}${spec.uploadPath}`, {
+    headers: { 'content-type': contentType, 'content-length': body.length },
+    body,
+  })
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(
+      `seed ${spec.type} failed: POST ${spec.uploadPath} -> ${res.status} ${res.buffer
+        .toString()
+        .slice(0, 300)}`
+    )
+  }
+  console.log(`[seed] ${spec.type.padEnd(16)} "${spec.name}" (${res.status})`)
+  return {
+    type: spec.type,
+    name: spec.name,
+    listPath: spec.listPath,
+    listKey: spec.listKey,
+    sha256: sha256(spec.content),
+    hasFileUrl: typeof spec.fileUrlFor === 'function',
+  }
+}
+
+async function main() {
+  const tag = process.env.MODELIBR_SEED_TAG || `${Date.now()}`
+  console.log(`[seed] API ${API_BASE} — tag ${tag}`)
+
+  const records = []
+  for (const spec of assetTypes(tag)) {
+    records.push(await seedOne(spec))
+  }
+
+  const manifest = { tag, apiBase: API_BASE, seededAt: new Date().toISOString(), records }
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
+  console.log(`[seed] ✅ seeded ${records.length} assets — manifest written to ${manifestPath}`)
+}
+
+main().catch(error => {
+  console.error('[seed] ❌ FAIL:', error.message || error)
+  process.exit(1)
+})

--- a/tests/upgrade/verify-assets.mjs
+++ b/tests/upgrade/verify-assets.mjs
@@ -1,0 +1,91 @@
+// Upgrade-integrity test — STEP 2 (verify). Reads the manifest written by
+// seed-assets.mjs (before the upgrade) and confirms, against the UPGRADED host,
+// that every seeded asset is still there (by name), the model's bytes are
+// byte-identical (sha256), and a brand-new 0.2.0-only asset type (Script) can be
+// created — i.e. the upgrade preserved data AND the app still works.
+//
+// Usage: node tests/upgrade/verify-assets.mjs [manifestPath]
+//   MODELIBR_API_BASE  API base (default http://127.0.0.1:3010/api)
+
+import fs from 'fs/promises'
+
+import { API_BASE, listArray, multipart, request, sha256 } from './lib.mjs'
+
+const manifestPath = process.argv[2] || 'upgrade-manifest.json'
+
+const failures = []
+function check(ok, message) {
+  if (ok) {
+    console.log(`[verify] ✓ ${message}`)
+  } else {
+    console.error(`[verify] ✗ ${message}`)
+    failures.push(message)
+  }
+}
+
+async function findByName(record) {
+  const res = await request('GET', `${API_BASE}${record.listPath}`)
+  if (res.status !== 200) {
+    return { ok: false, detail: `GET ${record.listPath} -> ${res.status}` }
+  }
+  const entry = listArray(res.json(), record.listKey).find(a => a?.name === record.name)
+  return { ok: !!entry, entry }
+}
+
+async function verifyModelBytes(record, entry) {
+  const id = entry.id ?? entry.Id
+  const res = await request('GET', `${API_BASE}/models/${id}/file`)
+  check(res.status === 200, `model #${id} file is downloadable`)
+  check(sha256(res.buffer) === record.sha256, `model #${id} bytes are byte-identical after upgrade`)
+}
+
+async function verifyNewFeatureWorks() {
+  // Scripts did not exist in v0.1.0 — creating one proves the schema migrated and
+  // the upgraded app accepts writes for a type the old DB never had.
+  const name = `upgrade-postcheck-script-${Date.now()}`
+  const { body, contentType } = multipart([
+    { name: 'file', filename: `${name}.cs`, content: Buffer.from('// post-upgrade smoke\n') },
+    { name: 'name', value: name },
+  ])
+  const res = await request('POST', `${API_BASE}/scripts/with-file`, {
+    headers: { 'content-type': contentType, 'content-length': body.length },
+    body,
+  })
+  check(res.status >= 200 && res.status < 300, `can create a Script (0.2.0 feature) post-upgrade (${res.status})`)
+  if (res.status < 200 || res.status >= 300) {
+    return
+  }
+
+  // Read the new script back by the id the create returned — deterministic, so it
+  // doesn't depend on /scripts list ordering or pagination.
+  const created = res.json()
+  const id = created.scriptId ?? created.id ?? created.Id
+  const readBack = await request('GET', `${API_BASE}/scripts/${id}`)
+  check(readBack.status === 200, `the new Script (#${id}) is readable from the upgraded app`)
+}
+
+async function main() {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+  console.log(`[verify] API ${API_BASE} — manifest tag ${manifest.tag} (${manifest.records.length} assets)`)
+
+  for (const record of manifest.records) {
+    const { ok, entry, detail } = await findByName(record)
+    check(ok, `${record.type} "${record.name}" survived the upgrade${detail ? ` (${detail})` : ''}`)
+    if (ok && record.hasFileUrl && record.type === 'model') {
+      await verifyModelBytes(record, entry)
+    }
+  }
+
+  await verifyNewFeatureWorks()
+
+  if (failures.length) {
+    console.error(`[verify] ❌ FAIL — ${failures.length} check(s) failed`)
+    process.exit(1)
+  }
+  console.log('[verify] ✅ PASS — all assets survived the upgrade and the app works')
+}
+
+main().catch(error => {
+  console.error('[verify] ❌ FAIL:', error.message || error)
+  process.exit(1)
+})


### PR DESCRIPTION
Lands the **Upgrade Test** workflow + scripts directly on `main` so it's
**manually runnable from the Actions tab**. GitHub only exposes
`workflow_dispatch` for workflows that live on the default branch, and CI tooling
is not part of the released app — so this correctly sits on `main` rather than
waiting for the release cadence.

### What it does
On Windows/macOS/Linux, on demand (or nightly):
1. installs the **FROM** release (default `v0.1.0`),
2. seeds one of every asset type via the host API,
3. installs the **TO** release (default: latest published, e.g. `v0.2.0`) **over** it,
4. verifies every asset survived **byte-for-byte** (sha256) and the upgraded app
   still works (creates a Script, a 0.2.0-only type).

Both installers come straight from GitHub Releases — no build step — so a run
finishes in minutes. Inputs: `from_tag` (default `v0.1.0`) and `to_tag` (blank =
latest published).

`tests/upgrade/{lib,seed-assets,verify-assets}.mjs` are zero-dep Node scripts
(built-ins only), mirroring the existing `data-folder-migration.mjs` integration
test; validated locally against a running host (all 5 types seed, model bytes
match after re-read, new-feature check passes, failure path exits non-zero).

> The opt-in **update behavior** change (host/client) is separate — it ships
> through the normal version-branch flow in #527.