### PR TITLE
ci(asset-processor): gate Prettier formatting on every PR

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -293,6 +293,12 @@ jobs:
                   path: test-results/asset-processor-results.json
                   retention-days: 30
 
+            # Gate formatting here (this job is required and runs on every PR), so
+            # Prettier drift is caught at PR time instead of surfacing on the
+            # release merge. Code Quality stays non-required (it's path-filtered).
+            - name: Check Prettier formatting
+              run: npm run format:check
+
     build-storybook:
         name: Build Storybook
         runs-on: ubuntu-latest

--- a/src/asset-processor/tests/metadataExtraction.test.js
+++ b/src/asset-processor/tests/metadataExtraction.test.js
@@ -11,7 +11,12 @@ vi.mock('../logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }))
 
-const jobLogger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+const jobLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+}
 
 describe('extractTextureDimensions', () => {
   let tmpDir


### PR DESCRIPTION
Follow-up to the 0.2.1 Code Quality failure.

1. **Formats `metadataExtraction.test.js`** on `version/0.2` (it was fixed directly on `main`; this brings the version line in sync so the file isn't red on version/0.2's own Code Quality).
2. **Adds a blocking `format:check` step** to the required *Asset Processor Tests* job. That job runs on every PR with no path filter, so Prettier drift now fails at PR time — without the deadlock that keeps *Code Quality Status* non-required (it's path-filtered and wouldn't report on unrelated PRs).

Verified locally: `npm run format:check` passes for the whole asset-processor after the format fix.