### PR TITLE
chore: forward-integrate 0.2.1 into version/0.3

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -27,7 +27,7 @@ jobs:
             frontend: ${{ steps.filter.outputs.frontend }}
             worker: ${{ steps.filter.outputs.worker }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: dorny/paths-filter@v3
               id: filter
               with:
@@ -56,10 +56,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup .NET 9
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: "9.0.x"
 
@@ -126,7 +126,7 @@ jobs:
                   fi
 
             - name: Upload backend test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: backend-test-results-${{ github.run_number }}
@@ -142,10 +142,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -211,7 +211,7 @@ jobs:
                   fi
 
             - name: Upload frontend test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: frontend-test-results-${{ github.run_number }}
@@ -227,10 +227,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -286,7 +286,7 @@ jobs:
                   fi
 
             - name: Upload asset processor test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: asset-processor-test-results-${{ github.run_number }}
@@ -302,10 +302,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -318,7 +318,7 @@ jobs:
               run: npx storybook build
 
             - name: Upload Storybook artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: storybook-static-${{ github.run_number }}
                   path: src/frontend/storybook-static/
@@ -336,7 +336,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Build and start services
               run: |
@@ -365,7 +365,7 @@ jobs:
                   echo "Thumbnail worker is ready!"
 
             - name: Setup Node.js for E2E
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -393,7 +393,7 @@ jobs:
                   PW_WORKERS: "3"
 
             - name: Upload Playwright report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: playwright-report-${{ github.run_number }}
@@ -402,7 +402,7 @@ jobs:
                   if-no-files-found: ignore
 
             - name: Upload test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: test-results-${{ github.run_number }}
@@ -462,7 +462,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Build and start E2E services
               timeout-minutes: 15
@@ -481,7 +481,7 @@ jobs:
                   echo "Thumbnail worker is ready!"
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
 
@@ -509,7 +509,7 @@ jobs:
                   API_BASE_URL: http://localhost:8090
 
             - name: Upload feature videos
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: feature-videos-${{ github.run_number }}
                   path: docs/static/videos/
@@ -538,12 +538,12 @@ jobs:
 
         steps:
             - name: Checkout current branch for scripts
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   path: current-branch
 
             - name: Checkout main branch for docs
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: main
                   path: main-branch
@@ -558,14 +558,14 @@ jobs:
                   cp -r main-branch/docs ./docs
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: 20
                   cache: npm
                   cache-dependency-path: docs/package-lock.json
 
             - name: Download current run artifacts
-              uses: actions/download-artifact@v4.1.3
+              uses: actions/download-artifact@v5
               continue-on-error: true
               with:
                   path: current-run-artifacts
@@ -641,7 +641,7 @@ jobs:
                   exit 1
 
             - name: Download feature videos
-              uses: actions/download-artifact@v4.1.3
+              uses: actions/download-artifact@v5
               with:
                   name: feature-videos-${{ github.run_number }}
                   path: docs/static/videos/
@@ -667,7 +667,7 @@ jobs:
                   done
 
             - name: Download Storybook build
-              uses: actions/download-artifact@v4.1.3
+              uses: actions/download-artifact@v5
               continue-on-error: true
               with:
                   name: storybook-static-${{ github.run_number }}
@@ -691,7 +691,7 @@ jobs:
                   cp -r current-branch/src/frontend/dist/* docs/build/demo/
 
             - name: Upload docs with reports (for preview)
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: docs-with-reports
                   path: docs/build/
@@ -712,4 +712,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,10 +28,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -61,10 +61,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -91,10 +91,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: ${{ github.event.workflow_run.head_sha }}
 

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -70,15 +70,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up .NET 9
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.0.x
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -195,7 +195,7 @@ jobs:
         run: npm run test:integration
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: native-installers-${{ matrix.name }}
           path: ${{ matrix.artifactGlob }}
@@ -227,7 +227,7 @@ jobs:
 
     steps:
       - name: Download installer artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: native-installers-${{ matrix.name }}
           path: installer
@@ -358,11 +358,11 @@ jobs:
       # run) — release / nightly schedule / manual dispatch run the full suite.
       - name: Checkout repo (for E2E suite)
         if: github.event_name != 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js for E2E
         if: github.event_name != 'push'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -417,7 +417,7 @@ jobs:
 
       - name: Upload native E2E report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: native-e2e-report-${{ matrix.name }}
           path: tests/e2e/playwright-report/
@@ -521,7 +521,7 @@ jobs:
       # ───── Capture logs on failure ─────
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-diagnostics-${{ matrix.name }}
           path: |
@@ -566,10 +566,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -598,7 +598,7 @@ jobs:
           ls -1 client*.yml || true
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: client-installers-${{ matrix.name }}
           path: ${{ matrix.artifactGlob }}
@@ -627,7 +627,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
           pattern: "*-installers-*"

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -26,7 +26,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   ref: ${{ github.event.inputs.branch || github.ref }}
 
@@ -44,7 +44,7 @@ jobs:
                   echo "Thumbnail worker is ready!"
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v5
               with:
                   node-version: "20"
                   cache: "npm"
@@ -80,7 +80,7 @@ jobs:
                   PW_WORKERS: "1"
 
             - name: Upload Playwright report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: nightly-playwright-report-${{ github.run_number }}
@@ -89,7 +89,7 @@ jobs:
                   if-no-files-found: ignore
 
             - name: Upload test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: nightly-test-results-${{ github.run_number }}

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,0 +1,368 @@
+name: Upgrade Test
+
+# Proves a real version-to-version upgrade keeps user data. Two complementary jobs:
+#
+#   reinstall   — installs the FROM release, seeds one of every asset type, then
+#                 installs the TO release *over* it (data folder lives in the user
+#                 profile, so it persists) and verifies everything survived. Covers
+#                 all 3 OS and is the only coverage for the Linux .deb and the
+#                 macOS data path.
+#
+#   self-update — exercises the real in-app electron-updater: installs FROM, seeds,
+#                 then drives the app's own "download + install" over CDP and
+#                 confirms the relaunched build is the new version with data intact.
+#                 Windows + Linux only — macOS can't self-update while the app is
+#                 unsigned (Squirrel.Mac requires code signing; planned for 1.0).
+#
+# Installers come straight from GitHub Releases — no build step. Defaults to
+# "v0.1.0 → latest published release".
+on:
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        # NOTE: move this to v0.2.1 after a few releases so the self-update job
+        # exercises the opt-in updater rather than v0.1.0's old forced one.
+        description: "Release tag to upgrade FROM"
+        required: false
+        default: "v0.1.0"
+        type: string
+      to_tag:
+        description: "Release tag to upgrade TO (blank = latest published release)"
+        required: false
+        type: string
+  # Nightly safety net so a data-losing upgrade is caught within a day of release.
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upgrade-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reinstall:
+    name: Reinstall ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+          - name: macOS
+            os: macos-14
+          - name: Linux
+            os: ubuntu-latest
+    env:
+      MODELIBR_API_BASE: http://127.0.0.1:3010/api
+    steps:
+      - name: Checkout repo (seed/verify scripts)
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Resolve FROM / TO release tags
+        id: tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_FROM: ${{ inputs.from_tag }}
+          INPUT_TO: ${{ inputs.to_tag }}
+        run: |
+          set -euo pipefail
+          from="${INPUT_FROM:-v0.1.0}"
+          to="${INPUT_TO:-}"
+          if [ -z "$to" ]; then
+            to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName // empty')
+          fi
+          [ -n "$to" ] || { echo "Could not resolve a TO release tag"; exit 1; }
+          if [ "$from" = "$to" ]; then
+            echo "FROM ($from) equals TO ($to) — nothing to upgrade."; exit 1
+          fi
+          echo "Upgrading: $from  ->  $to"
+          echo "from=$from" >> "$GITHUB_OUTPUT"
+          echo "to=$to" >> "$GITHUB_OUTPUT"
+
+      - name: Download FROM and TO installers
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${{ runner.os }}" in
+            Linux)   pat='*linux-amd64.deb' ;;
+            macOS)   pat='*macos-arm64.dmg' ;;
+            Windows) pat='*windows-x64.exe' ;;
+          esac
+          mkdir -p old-installer new-installer
+          gh release download "${{ steps.tags.outputs.from }}" --dir old-installer --pattern "$pat"
+          gh release download "${{ steps.tags.outputs.to }}"   --dir new-installer --pattern "$pat"
+          echo "── FROM ──"; ls -la old-installer
+          echo "── TO ──";   ls -la new-installer
+
+      - name: Reinstall scenario (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y xvfb >/dev/null
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+
+          install_deb() { sudo dpkg -i "$1" || sudo apt-get install -f -y; }
+          start_app() {
+            local bin
+            bin=$(find /opt -type f -executable \( -name 'modelibr*' -o -name 'Modelibr*' \) 2>/dev/null | head -n1)
+            [ -n "$bin" ] || { echo "binary not found under /opt"; ls -la /opt || true; exit 1; }
+            nohup "$bin" --no-sandbox >/tmp/modelibr.log 2>&1 & disown || true
+          }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { pkill -f -i modelibr || true; sleep 5; }
+
+          OLD=$(ls old-installer/*.deb | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.deb | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_deb "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_deb "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Reinstall scenario (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dmg() {
+            hdiutil attach "$1" -mountpoint /Volumes/ModelibrUp -nobrowse -quiet
+            rm -rf /Applications/Modelibr.app
+            cp -R "/Volumes/ModelibrUp/Modelibr.app" /Applications/
+            hdiutil detach /Volumes/ModelibrUp -quiet
+            sudo xattr -dr com.apple.quarantine /Applications/Modelibr.app 2>/dev/null || true
+          }
+          start_app() { nohup "/Applications/Modelibr.app/Contents/MacOS/Modelibr" >/tmp/modelibr.log 2>&1 & disown || true; }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { osascript -e 'quit app "Modelibr"' || true; sleep 3; pkill -f Modelibr || true; sleep 3; }
+
+          OLD=$(ls old-installer/*.dmg | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.dmg | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_dmg "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_dmg "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Reinstall scenario (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $old = Get-ChildItem old-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          $new = Get-ChildItem new-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          if (-not $old) { throw "FROM installer not found" }
+          if (-not $new) { throw "TO installer not found" }
+          Write-Host "OLD=$($old.FullName)  NEW=$($new.FullName)"
+
+          function Install-App($installer) { Start-Process -Wait -FilePath $installer.FullName -ArgumentList '/S' }
+          function Start-App {
+            $exe = @("$env:LOCALAPPDATA\Programs\Modelibr\Modelibr.exe", "$env:PROGRAMFILES\Modelibr\Modelibr.exe") |
+              Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (-not $exe) { throw "Modelibr.exe not found" }
+            Start-Process -FilePath $exe
+          }
+          function Wait-Ready {
+            for ($i = 0; $i -lt 60; $i++) {
+              try { Invoke-WebRequest -UseBasicParsing http://127.0.0.1:3010 -TimeoutSec 5 | Out-Null; return } catch { Start-Sleep 3 }
+            }
+            throw "app not ready"
+          }
+          function Stop-App { Stop-Process -Name Modelibr -Force -ErrorAction SilentlyContinue; Start-Sleep 5 }
+
+          Install-App $old; Start-App; Wait-Ready
+          node tests/upgrade/seed-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "seed failed" }; Stop-App
+          Install-App $new; Start-App; Wait-Ready
+          node tests/upgrade/verify-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "verify failed" }; Stop-App
+
+      - name: Upload manifest + logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: reinstall-${{ matrix.name }}
+          path: |
+            upgrade-manifest.json
+            /tmp/modelibr.log
+          if-no-files-found: ignore
+
+  self-update:
+    name: Self-update ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+          - name: Linux
+            os: ubuntu-latest
+    env:
+      MODELIBR_API_BASE: http://127.0.0.1:3010/api
+    steps:
+      - name: Checkout repo (seed/verify/driver scripts)
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install CDP driver dependency
+        run: npm install --no-save playwright-core
+
+      - name: Resolve FROM tag (and confirm a newer release exists)
+        id: tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_FROM: ${{ inputs.from_tag }}
+          INPUT_TO: ${{ inputs.to_tag }}
+        run: |
+          set -euo pipefail
+          from="${INPUT_FROM:-v0.1.0}"
+          to="${INPUT_TO:-}"
+          if [ -z "$to" ]; then
+            to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName // empty')
+          fi
+          [ -n "$to" ] || { echo "Could not resolve a newer release"; exit 1; }
+          if [ "$from" = "$to" ]; then
+            echo "FROM ($from) equals latest ($to) — nothing to self-update to."; exit 1
+          fi
+          echo "Self-update: $from  ->  $to (updater picks latest from the feed)"
+          echo "from=$from" >> "$GITHUB_OUTPUT"
+
+      - name: Download FROM installer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Linux self-update needs the AppImage (the .deb is dpkg-managed and
+          # cannot self-update); Windows uses the NSIS .exe.
+          case "${{ runner.os }}" in
+            Linux)   pat='*linux-x86_64.AppImage' ;;
+            Windows) pat='*windows-x64.exe' ;;
+          esac
+          mkdir -p old-installer
+          gh release download "${{ steps.tags.outputs.from }}" --dir old-installer --pattern "$pat"
+          ls -la old-installer
+
+      - name: Self-update scenario (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # libfuse2 lets the AppImage run normally so it sets $APPIMAGE — which
+          # electron-updater needs to know which file to replace on self-update.
+          sudo apt-get install -y xvfb libfuse2 >/dev/null
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+
+          APP=$(readlink -f "$(ls old-installer/*.AppImage | grep -iv client | head -n1)")
+          chmod +x "$APP"
+          echo "FROM AppImage: $APP"
+
+          start_app() { nohup "$APP" --no-sandbox --remote-debugging-port=9222 >>/tmp/modelibr.log 2>&1 & disown || true; }
+          http_code() { curl -s -o /dev/null -w "%{http_code}" "$1"; }
+          wait_ready() {
+            for i in $(seq 1 80); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            return 1
+          }
+
+          echo "::group::Launch FROM + seed"
+          start_app
+          wait_ready || { echo "FROM app not ready"; tail -n 80 /tmp/modelibr.log || true; exit 1; }
+          echo "/api/scripts on FROM (expect 404): $(http_code http://127.0.0.1:3010/api/scripts)"
+          node tests/upgrade/seed-assets.mjs
+          echo "::endgroup::"
+
+          echo "::group::Drive the in-app updater (download → install → relaunch)"
+          node tests/upgrade/drive-update.mjs
+          echo "::endgroup::"
+
+          echo "::group::Verify the relaunched build is the NEW version, data intact"
+          sleep 15  # quitAndInstall relaunches; give it a moment
+          if ! wait_ready; then
+            echo "did not auto-relaunch — launching the (updated) AppImage"
+            start_app; wait_ready || { echo "not ready after update"; tail -n 80 /tmp/modelibr.log || true; exit 1; }
+          fi
+          code=$(http_code http://127.0.0.1:3010/api/scripts)
+          echo "/api/scripts after self-update (expect 200): $code"
+          test "$code" = "200" || { echo "self-update did NOT apply (scripts=$code)"; tail -n 80 /tmp/modelibr.log || true; exit 1; }
+          node tests/upgrade/verify-assets.mjs
+          pkill -f -i modelibr || true
+          echo "::endgroup::"
+
+      - name: Self-update scenario (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $old = Get-ChildItem old-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          if (-not $old) { throw "FROM installer not found" }
+          Start-Process -Wait -FilePath $old.FullName -ArgumentList '/S'
+
+          function Exe { @("$env:LOCALAPPDATA\Programs\Modelibr\Modelibr.exe", "$env:PROGRAMFILES\Modelibr\Modelibr.exe") | Where-Object { Test-Path $_ } | Select-Object -First 1 }
+          function Start-App { $e = Exe; if (-not $e) { throw "Modelibr.exe not found" }; Start-Process -FilePath $e -ArgumentList '--remote-debugging-port=9222' }
+          function Wait-Ready {
+            for ($i = 0; $i -lt 90; $i++) { try { Invoke-WebRequest -UseBasicParsing http://127.0.0.1:3010 -TimeoutSec 5 | Out-Null; return $true } catch { Start-Sleep 3 } }
+            return $false
+          }
+          function HttpCode($u) { try { [int](Invoke-WebRequest -UseBasicParsing $u -TimeoutSec 5).StatusCode } catch { if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 } } }
+
+          Start-App
+          if (-not (Wait-Ready)) { throw "FROM app not ready" }
+          Write-Host "/api/scripts on FROM (expect 404): $(HttpCode 'http://127.0.0.1:3010/api/scripts')"
+          node tests/upgrade/seed-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "seed failed" }
+
+          node tests/upgrade/drive-update.mjs; if ($LASTEXITCODE -ne 0) { throw "drive-update failed" }
+
+          # quitAndInstall runs the NSIS update silently and relaunches the new version.
+          Start-Sleep 25
+          if (-not (Wait-Ready)) {
+            Write-Host "did not auto-relaunch — starting the (updated) app"
+            Start-App
+            if (-not (Wait-Ready)) { throw "app not ready after update" }
+          }
+          $code = HttpCode 'http://127.0.0.1:3010/api/scripts'
+          Write-Host "/api/scripts after self-update (expect 200): $code"
+          if ($code -ne 200) { throw "self-update did NOT apply (scripts=$code)" }
+          node tests/upgrade/verify-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "verify failed" }
+          Stop-Process -Name Modelibr -Force -ErrorAction SilentlyContinue
+
+      - name: Upload manifest + logs
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: self-update-${{ matrix.name }}
+          path: |
+            upgrade-manifest.json
+            /tmp/modelibr.log
+          if-no-files-found: ignore

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -1,0 +1,205 @@
+name: Upgrade Test
+
+# Proves a real version-to-version upgrade keeps user data. On Windows/macOS/Linux
+# it installs the FROM release, seeds one of every asset type through the host
+# API, installs the TO release *over* it (the data folder lives in the user
+# profile, so it persists), then verifies every asset survived byte-for-byte and
+# the upgraded app still works.
+#
+# Both installers come straight from GitHub Releases — no build step — so this is
+# fast and can be run on demand. Defaults to "v0.1.0 → latest published release".
+on:
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: "Release tag to upgrade FROM"
+        required: false
+        default: "v0.1.0"
+        type: string
+      to_tag:
+        description: "Release tag to upgrade TO (blank = latest published release)"
+        required: false
+        type: string
+  # Nightly safety net so a data-losing upgrade is caught within a day of release.
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upgrade-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade-test:
+    name: Upgrade ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+          - name: macOS
+            os: macos-14
+          - name: Linux
+            os: ubuntu-latest
+    env:
+      # Both seed/verify scripts default to this; the installed host serves its
+      # edge-proxied public API on plain http here.
+      MODELIBR_API_BASE: http://127.0.0.1:3010/api
+    steps:
+      - name: Checkout repo (seed/verify scripts)
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Resolve FROM / TO release tags
+        id: tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_FROM: ${{ inputs.from_tag }}
+          INPUT_TO: ${{ inputs.to_tag }}
+        run: |
+          set -euo pipefail
+          from="${INPUT_FROM:-v0.1.0}"
+          to="${INPUT_TO:-}"
+          if [ -z "$to" ]; then
+            # Newest published, non-draft, non-prerelease release.
+            to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+              --json tagName --jq '.[0].tagName // empty')
+          fi
+          [ -n "$to" ] || { echo "Could not resolve a TO release tag"; exit 1; }
+          if [ "$from" = "$to" ]; then
+            echo "FROM ($from) equals TO ($to) — nothing to upgrade."
+            exit 1
+          fi
+          echo "Upgrading: $from  ->  $to"
+          echo "from=$from" >> "$GITHUB_OUTPUT"
+          echo "to=$to" >> "$GITHUB_OUTPUT"
+
+      - name: Download FROM and TO installers
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${{ runner.os }}" in
+            Linux)   pat='*linux-amd64.deb' ;;
+            macOS)   pat='*macos-arm64.dmg' ;;
+            Windows) pat='*windows-x64.exe' ;;
+          esac
+          mkdir -p old-installer new-installer
+          # Each release carries both host and Client assets matching the pattern;
+          # the per-OS scenario below picks the host one (filters out *Client*).
+          gh release download "${{ steps.tags.outputs.from }}" --dir old-installer --pattern "$pat"
+          gh release download "${{ steps.tags.outputs.to }}"   --dir new-installer --pattern "$pat"
+          echo "── FROM ──"; ls -la old-installer
+          echo "── TO ──";   ls -la new-installer
+
+      - name: Upgrade scenario (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update && sudo apt-get install -y xvfb >/dev/null
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          Xvfb :99 -screen 0 1280x1024x24 >/tmp/xvfb.log 2>&1 &
+          export DISPLAY=:99
+
+          install_deb() { sudo dpkg -i "$1" || sudo apt-get install -f -y; }
+          start_app() {
+            local bin
+            bin=$(find /opt -type f -executable \( -name 'modelibr*' -o -name 'Modelibr*' \) 2>/dev/null | head -n1)
+            [ -n "$bin" ] || { echo "binary not found under /opt"; ls -la /opt || true; exit 1; }
+            nohup "$bin" --no-sandbox >/tmp/modelibr.log 2>&1 & disown || true
+          }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { pkill -f -i modelibr || true; sleep 5; }
+
+          OLD=$(ls old-installer/*.deb | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.deb | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_deb "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_deb "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Upgrade scenario (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dmg() {
+            hdiutil attach "$1" -mountpoint /Volumes/ModelibrUp -nobrowse -quiet
+            rm -rf /Applications/Modelibr.app
+            cp -R "/Volumes/ModelibrUp/Modelibr.app" /Applications/
+            hdiutil detach /Volumes/ModelibrUp -quiet
+            sudo xattr -dr com.apple.quarantine /Applications/Modelibr.app 2>/dev/null || true
+          }
+          start_app() { nohup "/Applications/Modelibr.app/Contents/MacOS/Modelibr" >/tmp/modelibr.log 2>&1 & disown || true; }
+          wait_ready() {
+            for i in $(seq 1 60); do curl -sf http://127.0.0.1:3010 -o /dev/null && return 0; sleep 3; done
+            echo "app not ready"; tail -n 60 /tmp/modelibr.log || true; exit 1
+          }
+          stop_app() { osascript -e 'quit app "Modelibr"' || true; sleep 3; pkill -f Modelibr || true; sleep 3; }
+
+          OLD=$(ls old-installer/*.dmg | grep -iv client | head -n1)
+          NEW=$(ls new-installer/*.dmg | grep -iv client | head -n1)
+          echo "OLD=$OLD  NEW=$NEW"
+
+          echo "::group::Install FROM + seed"; install_dmg "$OLD"; start_app; wait_ready
+          node tests/upgrade/seed-assets.mjs; stop_app; echo "::endgroup::"
+          echo "::group::Install TO (upgrade) + verify"; install_dmg "$NEW"; start_app; wait_ready
+          node tests/upgrade/verify-assets.mjs; stop_app; echo "::endgroup::"
+
+      - name: Upgrade scenario (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $old = Get-ChildItem old-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          $new = Get-ChildItem new-installer/*.exe | Where-Object { $_.Name -notlike '*Client*' } | Select-Object -First 1
+          if (-not $old) { throw "FROM installer not found" }
+          if (-not $new) { throw "TO installer not found" }
+          Write-Host "OLD=$($old.FullName)  NEW=$($new.FullName)"
+
+          function Install-App($installer) { Start-Process -Wait -FilePath $installer.FullName -ArgumentList '/S' }
+          function Start-App {
+            $exe = @("$env:LOCALAPPDATA\Programs\Modelibr\Modelibr.exe", "$env:PROGRAMFILES\Modelibr\Modelibr.exe") |
+              Where-Object { Test-Path $_ } | Select-Object -First 1
+            if (-not $exe) { throw "Modelibr.exe not found" }
+            Start-Process -FilePath $exe
+          }
+          function Wait-Ready {
+            for ($i = 0; $i -lt 60; $i++) {
+              try { Invoke-WebRequest -UseBasicParsing http://127.0.0.1:3010 -TimeoutSec 5 | Out-Null; return } catch { Start-Sleep 3 }
+            }
+            throw "app not ready"
+          }
+          function Stop-App { Stop-Process -Name Modelibr -Force -ErrorAction SilentlyContinue; Start-Sleep 5 }
+
+          Install-App $old; Start-App; Wait-Ready
+          node tests/upgrade/seed-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "seed failed" }; Stop-App
+          Install-App $new; Start-App; Wait-Ready
+          node tests/upgrade/verify-assets.mjs; if ($LASTEXITCODE -ne 0) { throw "verify failed" }; Stop-App
+
+      - name: Upload upgrade manifest + logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-test-${{ matrix.name }}
+          path: |
+            upgrade-manifest.json
+            /tmp/modelibr.log
+          if-no-files-found: ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/asset-processor/tests/metadataExtraction.test.js
+++ b/src/asset-processor/tests/metadataExtraction.test.js
@@ -11,7 +11,12 @@ vi.mock('../logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }))
 
-const jobLogger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+const jobLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+}
 
 describe('extractTextureDimensions', () => {
   let tmpDir

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop-client/src/main.js
+++ b/src/desktop-client/src/main.js
@@ -8,9 +8,76 @@ import { loadClientConfig, saveClientConfig } from './clientConfig.js'
 const { autoUpdater } = electronUpdater
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// Background auto-update: check on launch, download in the background, and
-// install on quit. Safe no-op in dev (unpackaged). macOS auto-install needs a
-// signed build; the error is caught so it never blocks the client.
+let updateHandlersWired = false
+
+// Opt-in auto-update: we check on launch, but a new build is only downloaded and
+// installed when the user agrees — first "Download", then "Restart & Install". A
+// user may have reasons to stay on a stable build, so nothing happens behind
+// their back. Handlers are wired once; checkForUpdates() can be called repeatedly
+// (launch + the "Check for Updates…" menu item).
+function wireUpdateHandlers() {
+  if (updateHandlersWired) {
+    return
+  }
+  updateHandlersWired = true
+
+  // The host and client ship in the same GitHub repo/release. electron-updater's
+  // default feed file is latest.yml for both, which would collide. Put the
+  // client on its own channel so it fetches client*.yml (the release workflow
+  // renames the client's feed to match); the host keeps the default latest*.yml.
+  autoUpdater.channel = 'client'
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = false
+
+  autoUpdater.on('update-available', info => {
+    const version = info?.version ? ` (v${info.version})` : ''
+    void dialog
+      .showMessageBox({
+        type: 'info',
+        buttons: ['Download', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+        message: `A new version of Modelibr Client${version} is available.`,
+        detail: 'Download it now? Nothing installs until you choose to restart.',
+      })
+      .then(({ response }) => {
+        if (response === 0) {
+          autoUpdater.downloadUpdate().catch(error => {
+            console.error('[ModelibrClient][update]', error)
+            void dialog.showMessageBox({
+              type: 'error',
+              message: 'Update download failed',
+              detail: error instanceof Error ? error.message : String(error),
+            })
+          })
+        }
+      })
+  })
+
+  autoUpdater.on('update-downloaded', info => {
+    const version = info?.version ? ` (v${info.version})` : ''
+    void dialog
+      .showMessageBox({
+        type: 'info',
+        buttons: ['Restart & Install', 'Later'],
+        defaultId: 0,
+        cancelId: 1,
+        message: `Modelibr Client${version} is ready to install.`,
+        detail: 'The app will restart to finish updating.',
+      })
+      .then(({ response }) => {
+        if (response === 0) {
+          autoUpdater.quitAndInstall()
+        }
+      })
+  })
+
+  autoUpdater.on('error', error => {
+    console.error('[ModelibrClient][update]', error)
+  })
+}
+
+// Safe no-op in dev (unpackaged). Errors never block the client.
 function checkForUpdates({ notifyNoUpdate = false } = {}) {
   if (!app.isPackaged) {
     if (notifyNoUpdate) {
@@ -22,13 +89,7 @@ function checkForUpdates({ notifyNoUpdate = false } = {}) {
     return
   }
 
-  // The host and client ship in the same GitHub repo/release. electron-updater's
-  // default feed file is latest.yml for both, which would collide. Put the
-  // client on its own channel so it fetches client*.yml (the release workflow
-  // renames the client's feed to match); the host keeps the default latest*.yml.
-  autoUpdater.channel = 'client'
-  autoUpdater.autoDownload = true
-  autoUpdater.autoInstallOnAppQuit = true
+  wireUpdateHandlers()
 
   if (notifyNoUpdate) {
     autoUpdater.once('update-not-available', () =>
@@ -36,7 +97,7 @@ function checkForUpdates({ notifyNoUpdate = false } = {}) {
     )
   }
 
-  autoUpdater.checkForUpdatesAndNotify().catch(error => {
+  autoUpdater.checkForUpdates().catch(error => {
     console.error('[ModelibrClient][update]', error)
     if (notifyNoUpdate) {
       void dialog.showMessageBox({

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/src/main.js
+++ b/src/desktop/src/main.js
@@ -10,6 +10,7 @@ import {
   screen,
   shell,
 } from 'electron'
+import electronUpdater from 'electron-updater'
 import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
@@ -23,6 +24,7 @@ import { detectInstalledClient } from './clientDetection.js'
 import { readLeftoverFolder, clearLeftoverFolder } from './dataMigration.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const { autoUpdater } = electronUpdater
 
 // The desktop client ships as its own installer in the same GitHub release.
 const DESKTOP_CLIENT_URL = CLIENT_RELEASES_URL
@@ -122,6 +124,12 @@ function buildTrayMenu() {
     updateItem = {
       label: `Downloading update… ${update.percent ?? 0}%`,
       enabled: false,
+    }
+  } else if (update?.status === 'available') {
+    // A newer build exists but we don't pull it down until the user asks.
+    updateItem = {
+      label: `Download update v${update.latestVersion}`,
+      click: () => void updateManager?.download(),
     }
   } else {
     updateItem = {
@@ -390,6 +398,11 @@ function registerIpc() {
     return updateManager?.state ?? null
   })
 
+  ipcMain.handle('modelibr:download-update', async () => {
+    await updateManager?.download()
+    return updateManager?.state ?? null
+  })
+
   ipcMain.handle('modelibr:open-update', () => {
     updateManager?.install()
   })
@@ -541,6 +554,10 @@ async function bootstrap() {
   runtimeConfigPath = configPath
 
   updateManager = new UpdateManager({
+    autoUpdater,
+    currentVersion: app.getVersion(),
+    isPackaged: app.isPackaged,
+    openExternal: url => void shell.openExternal(url),
     log: runtimeLog,
     onChange: () => refreshTray(),
   })

--- a/src/desktop/src/preload.cjs
+++ b/src/desktop/src/preload.cjs
@@ -24,6 +24,7 @@ contextBridge.exposeInMainWorld('modelibr', {
   dismissPreviousDataFolder: () => ipcRenderer.invoke('modelibr:dismiss-previous-data-folder'),
   getUpdate: () => ipcRenderer.invoke('modelibr:get-update'),
   checkUpdate: () => ipcRenderer.invoke('modelibr:check-update'),
+  downloadUpdate: () => ipcRenderer.invoke('modelibr:download-update'),
   openUpdate: () => ipcRenderer.invoke('modelibr:open-update'),
   restart: () => ipcRenderer.invoke('modelibr:restart'),
   quit: () => ipcRenderer.invoke('modelibr:quit'),

--- a/src/desktop/src/updateManager.js
+++ b/src/desktop/src/updateManager.js
@@ -1,27 +1,38 @@
-import { app, shell } from 'electron'
-import electronUpdater from 'electron-updater'
-
-const { autoUpdater } = electronUpdater
-
 const REPO = 'Papyszoo/Modelibr'
 const RELEASES_PAGE_URL = `https://github.com/${REPO}/releases`
 
-// Wraps electron-updater so the host can check GitHub Releases, download a newer
-// version in the background, and install it on quit. The "update action" becomes
-// a real one-click "Restart & Install" once a build is downloaded.
+// Wraps electron-updater so the host can check GitHub Releases for a newer build
+// and surface it in the tray. Updates are *opt-in*: we keep checking on launch,
+// but nothing downloads or installs until the user clicks — first "Download
+// update", then "Restart & Install". A user may have good reasons to stay on a
+// stable build, so we never download in the background or install on quit.
 //
 // Note: macOS auto-install requires the app to be code-signed (Squirrel.Mac
 // verifies the signature). On unsigned macOS builds the download/install step
 // errors; we catch it and fall back to opening the releases page so the user can
 // update manually. Windows (NSIS) and Linux (AppImage) update without signing.
+//
+// electron is injected (autoUpdater / currentVersion / isPackaged / openExternal)
+// so this module stays free of the `electron` import and is unit-testable under
+// `node --test`, like the other desktop modules.
 export class UpdateManager {
-  constructor({ log = console.log, onChange } = {}) {
+  constructor({
+    autoUpdater,
+    currentVersion = '0.0.0',
+    isPackaged = true,
+    openExternal = () => {},
+    log = console.log,
+    onChange,
+  } = {}) {
+    this.autoUpdater = autoUpdater
+    this.isPackaged = isPackaged
+    this.openExternal = openExternal
     this.log = log
     this.onChange = onChange
     this.state = {
-      // idle | checking | downloading | downloaded | up-to-date | error
+      // idle | checking | available | downloading | downloaded | up-to-date | error
       status: 'idle',
-      currentVersion: app.getVersion(),
+      currentVersion,
       latestVersion: null,
       percent: 0,
       releaseUrl: RELEASES_PAGE_URL,
@@ -45,34 +56,36 @@ export class UpdateManager {
     }
     this._wired = true
 
-    autoUpdater.autoDownload = true
-    autoUpdater.autoInstallOnAppQuit = true
-    autoUpdater.logger = {
+    // Opt-in: don't pull a build down or slip it in on quit behind the user.
+    this.autoUpdater.autoDownload = false
+    this.autoUpdater.autoInstallOnAppQuit = false
+    this.autoUpdater.logger = {
       info: msg => this.log('[ModelibrDesktop][update]', msg),
       warn: msg => this.log('[ModelibrDesktop][update][warn]', msg),
       error: msg => this.log('[ModelibrDesktop][update][error]', msg),
       debug: () => {},
     }
 
-    autoUpdater.on('checking-for-update', () =>
+    this.autoUpdater.on('checking-for-update', () =>
       this.setState({ status: 'checking', error: null })
     )
-    autoUpdater.on('update-available', info =>
-      this.setState({ status: 'downloading', latestVersion: info?.version ?? null, percent: 0 })
+    // A newer build exists but we DON'T download it — wait for the user.
+    this.autoUpdater.on('update-available', info =>
+      this.setState({ status: 'available', latestVersion: info?.version ?? null, percent: 0 })
     )
-    autoUpdater.on('update-not-available', info =>
+    this.autoUpdater.on('update-not-available', info =>
       this.setState({
         status: 'up-to-date',
         latestVersion: info?.version ?? this.state.currentVersion,
       })
     )
-    autoUpdater.on('download-progress', progress =>
+    this.autoUpdater.on('download-progress', progress =>
       this.setState({ status: 'downloading', percent: Math.round(progress?.percent ?? 0) })
     )
-    autoUpdater.on('update-downloaded', info =>
+    this.autoUpdater.on('update-downloaded', info =>
       this.setState({ status: 'downloaded', latestVersion: info?.version ?? null, percent: 100 })
     )
-    autoUpdater.on('error', error => {
+    this.autoUpdater.on('error', error => {
       const message = error instanceof Error ? error.message : String(error)
       this.log('[ModelibrDesktop][update] Error', { error: message })
       this.setState({ status: 'error', error: message })
@@ -81,7 +94,7 @@ export class UpdateManager {
 
   async check() {
     // electron-updater only works on packaged builds with update metadata.
-    if (!app.isPackaged) {
+    if (!this.isPackaged) {
       this.setState({ status: 'up-to-date' })
       return
     }
@@ -90,7 +103,7 @@ export class UpdateManager {
     this.setState({ status: 'checking', error: null })
 
     try {
-      await autoUpdater.checkForUpdates()
+      await this.autoUpdater.checkForUpdates()
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       this.log('[ModelibrDesktop][update] Check failed', { error: message })
@@ -98,12 +111,28 @@ export class UpdateManager {
     }
   }
 
-  // The "Update" button: install a downloaded build, otherwise open the releases
-  // page (covers unsigned macOS and the "not downloaded yet" case).
+  // The "Download update" button: start pulling the available build down. On
+  // unsigned macOS the download can error — fall back to the releases page so the
+  // user can grab the installer manually.
+  async download() {
+    this._wire()
+    this.setState({ status: 'downloading', percent: 0, error: null })
+    try {
+      await this.autoUpdater.downloadUpdate()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.log('[ModelibrDesktop][update] Download failed', { error: message })
+      this.setState({ status: 'error', error: message })
+      this.openExternal(this.releaseUrl)
+    }
+  }
+
+  // The "Restart & Install" button: install a downloaded build, otherwise open
+  // the releases page (covers unsigned macOS and the "not downloaded yet" case).
   install() {
     if (this.state.status === 'downloaded') {
       try {
-        autoUpdater.quitAndInstall()
+        this.autoUpdater.quitAndInstall()
         return
       } catch (error) {
         this.log('[ModelibrDesktop][update] quitAndInstall failed', {
@@ -112,6 +141,6 @@ export class UpdateManager {
       }
     }
 
-    void shell.openExternal(this.releaseUrl)
+    this.openExternal(this.releaseUrl)
   }
 }

--- a/src/desktop/test/updateManager.test.js
+++ b/src/desktop/test/updateManager.test.js
@@ -1,0 +1,122 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { UpdateManager } from '../src/updateManager.js'
+
+// A stand-in for electron-updater's autoUpdater: an EventEmitter with spy methods
+// and the two flags the manager is expected to flip off. Lets us drive the update
+// lifecycle deterministically without Electron or a real GitHub feed.
+function makeFakeAutoUpdater(overrides = {}) {
+  const au = new EventEmitter()
+  au.autoDownload = true
+  au.autoInstallOnAppQuit = true
+  au.calls = { checkForUpdates: 0, downloadUpdate: 0, quitAndInstall: 0 }
+  au.checkForUpdates = async () => {
+    au.calls.checkForUpdates++
+  }
+  au.downloadUpdate = async () => {
+    au.calls.downloadUpdate++
+  }
+  au.quitAndInstall = () => {
+    au.calls.quitAndInstall++
+  }
+  return Object.assign(au, overrides)
+}
+
+function makeManager(overrides = {}) {
+  const au = overrides.autoUpdater ?? makeFakeAutoUpdater()
+  const opened = []
+  const mgr = new UpdateManager({
+    currentVersion: '0.1.0',
+    isPackaged: true,
+    openExternal: url => opened.push(url),
+    log: () => {},
+    ...overrides,
+    autoUpdater: au,
+  })
+  return { mgr, au, opened }
+}
+
+test('check() opts out of background download and install-on-quit', async () => {
+  const { mgr, au } = makeManager()
+  await mgr.check()
+  assert.equal(au.autoDownload, false, 'autoDownload must be disabled')
+  assert.equal(au.autoInstallOnAppQuit, false, 'autoInstallOnAppQuit must be disabled')
+  assert.equal(au.calls.checkForUpdates, 1)
+})
+
+test('check() is a no-op on an unpackaged (dev) build', async () => {
+  const { mgr, au } = makeManager({ isPackaged: false })
+  await mgr.check()
+  assert.equal(mgr.state.status, 'up-to-date')
+  assert.equal(au.calls.checkForUpdates, 0, 'must not hit the feed in dev')
+})
+
+test('an available update is surfaced but NOT downloaded automatically', async () => {
+  const { mgr, au } = makeManager()
+  await mgr.check()
+  au.emit('update-available', { version: '0.2.0' })
+
+  assert.equal(mgr.state.status, 'available')
+  assert.equal(mgr.state.latestVersion, '0.2.0')
+  assert.equal(au.calls.downloadUpdate, 0, 'nothing should download until the user asks')
+})
+
+test('update-not-available marks the app up to date', async () => {
+  const { mgr, au } = makeManager()
+  await mgr.check()
+  au.emit('update-not-available', { version: '0.1.0' })
+  assert.equal(mgr.state.status, 'up-to-date')
+})
+
+test('download() starts the download only when the user clicks, then tracks progress', async () => {
+  const { mgr, au } = makeManager()
+  await mgr.check()
+  au.emit('update-available', { version: '0.2.0' })
+
+  await mgr.download()
+  assert.equal(au.calls.downloadUpdate, 1)
+  assert.equal(mgr.state.status, 'downloading')
+
+  au.emit('download-progress', { percent: 42.6 })
+  assert.equal(mgr.state.percent, 43, 'progress is rounded')
+
+  au.emit('update-downloaded', { version: '0.2.0' })
+  assert.equal(mgr.state.status, 'downloaded')
+  assert.equal(mgr.state.percent, 100)
+})
+
+test('download() falls back to the releases page when the download errors (e.g. unsigned macOS)', async () => {
+  const au = makeFakeAutoUpdater({
+    downloadUpdate: async () => {
+      throw new Error('not signed')
+    },
+  })
+  const { mgr, opened } = makeManager({ autoUpdater: au })
+  await mgr.check()
+  au.emit('update-available', { version: '0.2.0' })
+
+  await mgr.download()
+  assert.equal(mgr.state.status, 'error')
+  assert.equal(opened.length, 1)
+  assert.match(opened[0], /\/releases$/)
+})
+
+test('install() restarts into a downloaded build', async () => {
+  const { mgr, au, opened } = makeManager()
+  await mgr.check()
+  au.emit('update-downloaded', { version: '0.2.0' })
+
+  mgr.install()
+  assert.equal(au.calls.quitAndInstall, 1)
+  assert.equal(opened.length, 0, 'should restart, not open a browser')
+})
+
+test('install() opens the releases page when nothing is downloaded yet', async () => {
+  const { mgr, au, opened } = makeManager()
+  mgr.install()
+  assert.equal(au.calls.quitAndInstall, 0)
+  assert.equal(opened.length, 1)
+  assert.match(opened[0], /\/releases$/)
+})

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/upgrade/drive-update.mjs
+++ b/tests/upgrade/drive-update.mjs
@@ -1,0 +1,80 @@
+// Drives the host's *in-app* updater headlessly, over the Chrome DevTools
+// Protocol. The host is a tray app that never quits when its window closes
+// (main.js: window-all-closed is a no-op), so a CI job can't trigger an install
+// by killing/closing it — autoInstallOnAppQuit only runs on a real app.quit().
+// Instead we connect to the running app's status window and call the same update
+// IPC the tray buttons use:
+//
+//   1. poll window.modelibr.getUpdate() until status === 'downloaded'
+//      (electron-updater downloads from the live GitHub release feed),
+//   2. call window.modelibr.openUpdate() → install() → quitAndInstall(), which
+//      installs the new version and relaunches it.
+//
+// Launch the app with --remote-debugging-port=9222 first. Used by the
+// upgrade-test "self-update" job on Windows + Linux (macOS can't self-update
+// while unsigned).
+
+import { chromium } from 'playwright-core'
+
+const CDP_URL = process.env.CDP_URL || 'http://127.0.0.1:9222'
+const TIMEOUT_MS = Number(process.env.UPDATE_TIMEOUT_MS || 600000) // 10 min
+const POLL_MS = 5000
+
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+// Find the page that actually exposes the update bridge (the status window).
+async function findUpdatePage(browser) {
+  for (const context of browser.contexts()) {
+    for (const page of context.pages()) {
+      const hasBridge = await page
+        .evaluate(() => typeof window.modelibr?.getUpdate === 'function')
+        .catch(() => false)
+      if (hasBridge) return page
+    }
+  }
+  return null
+}
+
+async function main() {
+  console.log(`[drive-update] connecting to ${CDP_URL}`)
+  const browser = await chromium.connectOverCDP(CDP_URL)
+
+  let page = null
+  for (let i = 0; i < 30 && !page; i++) {
+    page = await findUpdatePage(browser)
+    if (!page) await sleep(1000)
+  }
+  if (!page) {
+    throw new Error('could not find a window exposing window.modelibr.getUpdate over CDP')
+  }
+
+  const deadline = Date.now() + TIMEOUT_MS
+  let state = null
+  while (Date.now() < deadline) {
+    state = await page.evaluate(() => window.modelibr.getUpdate()).catch(() => null)
+    console.log(`[drive-update] update state: ${JSON.stringify(state)}`)
+    if (state?.status === 'downloaded') break
+    if (state?.status === 'error') {
+      throw new Error(`updater reported an error: ${state.error ?? 'unknown'}`)
+    }
+    await sleep(POLL_MS)
+  }
+
+  if (state?.status !== 'downloaded') {
+    throw new Error(`update was not downloaded before timeout (last status: ${state?.status ?? 'none'})`)
+  }
+
+  console.log('[drive-update] downloaded — triggering install (quitAndInstall + relaunch)')
+  // This quits the app, so the evaluate / connection won't return cleanly — that's
+  // expected. The workflow then waits for the relaunched (new) version on :3010.
+  await page.evaluate(() => window.modelibr.openUpdate()).catch(() => {})
+  await browser.close().catch(() => {})
+  console.log('[drive-update] install triggered')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error('[drive-update] FAIL:', error.message || error)
+    process.exit(1)
+  })

--- a/tests/upgrade/lib.mjs
+++ b/tests/upgrade/lib.mjs
@@ -1,0 +1,175 @@
+// Shared helpers for the upgrade-integrity scripts (seed + verify). Zero external
+// deps — only Node built-ins — so the scripts run on a bare CI runner against the
+// installed app, exactly like src/desktop/scripts/integration/data-folder-migration.mjs.
+
+import crypto from 'crypto'
+import http from 'http'
+import https from 'https'
+
+// Default to the edge-proxied public API of an installed host. Override with
+// MODELIBR_API_BASE (e.g. the self-signed docker stack at https://127.0.0.1:3010/api).
+export const API_BASE = process.env.MODELIBR_API_BASE || 'http://127.0.0.1:3010/api'
+
+export function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex')
+}
+
+export function request(method, url, { headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url)
+    const transport = u.protocol === 'https:' ? https : http
+    const req = transport.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method,
+        headers,
+        // The local docker stack serves a self-signed cert on :3010; the installed
+        // app is plain http. Accept self-signed so the same script covers both.
+        rejectUnauthorized: false,
+      },
+      res => {
+        const chunks = []
+        res.on('data', c => chunks.push(c))
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode,
+            buffer: Buffer.concat(chunks),
+            json() {
+              return JSON.parse(Buffer.concat(chunks).toString())
+            },
+          })
+        )
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(60000, () => req.destroy(new Error('request timed out')))
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+// Build a multipart/form-data body. `fields` is an array of either
+// { name, value } (text) or { name, filename, content } (file).
+export function multipart(fields) {
+  const boundary = '----modelibr-upgrade' + crypto.randomBytes(8).toString('hex')
+  const parts = []
+  for (const field of fields) {
+    if (field.filename != null) {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"; filename="${field.filename}"\r\n` +
+            `Content-Type: application/octet-stream\r\n\r\n`
+        ),
+        field.content,
+        Buffer.from('\r\n')
+      )
+    } else {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"\r\n\r\n` +
+            `${field.value}\r\n`
+        )
+      )
+    }
+  }
+  parts.push(Buffer.from(`--${boundary}--\r\n`))
+  return { body: Buffer.concat(parts), contentType: `multipart/form-data; boundary=${boundary}` }
+}
+
+// ───── Tiny inline fixtures (no committed binaries) ─────
+
+const OBJ = Buffer.from('# modelibr upgrade cube\no cube\nv 0 0 0\nv 1 0 0\nv 1 1 0\nf 1 2 3\n')
+
+// 1×1 opaque-red PNG.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+// A valid 16-bit PCM mono WAV with a few samples (≈ a click of audio).
+function makeWav() {
+  const sampleRate = 8000
+  const samples = 16
+  const dataLen = samples * 2
+  const buf = Buffer.alloc(44 + dataLen)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(36 + dataLen, 4)
+  buf.write('WAVE', 8)
+  buf.write('fmt ', 12)
+  buf.writeUInt32LE(16, 16) // PCM chunk size
+  buf.writeUInt16LE(1, 20) // PCM
+  buf.writeUInt16LE(1, 22) // mono
+  buf.writeUInt32LE(sampleRate, 24)
+  buf.writeUInt32LE(sampleRate * 2, 28) // byte rate
+  buf.writeUInt16LE(2, 32) // block align
+  buf.writeUInt16LE(16, 34) // bits per sample
+  buf.write('data', 36)
+  buf.writeUInt32LE(dataLen, 40)
+  for (let i = 0; i < samples; i++) buf.writeInt16LE((i % 2 ? 8000 : -8000), 44 + i * 2)
+  return buf
+}
+
+const WAV = makeWav()
+
+// The asset types a v0.1.0 host supports. Each is seeded once, then looked up by
+// its unique name after the upgrade. `listKey` is the array property in the list
+// response (null = the response IS the array, as for /models). `fileCheck` pulls
+// the bytes back and compares the sha256 (only /models exposes /{id}/file).
+export function assetTypes(tag) {
+  return [
+    {
+      type: 'model',
+      uploadPath: '/models',
+      listPath: '/models',
+      listKey: null,
+      name: `upgrade-model-${tag}`,
+      filename: `upgrade-model-${tag}.obj`,
+      content: OBJ,
+      fileUrlFor: id => `/models/${id}/file`,
+    },
+    {
+      type: 'texture-set',
+      uploadPath: '/texture-sets/with-file',
+      listPath: '/texture-sets',
+      listKey: 'textureSets',
+      name: `upgrade-texset-${tag}`,
+      filename: `upgrade-texset-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sprite',
+      uploadPath: '/sprites/with-file',
+      listPath: '/sprites',
+      listKey: 'sprites',
+      name: `upgrade-sprite-${tag}`,
+      filename: `upgrade-sprite-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sound',
+      uploadPath: '/sounds/with-file',
+      listPath: '/sounds',
+      listKey: 'sounds',
+      name: `upgrade-sound-${tag}`,
+      filename: `upgrade-sound-${tag}.wav`,
+      content: WAV,
+    },
+    {
+      type: 'environment-map',
+      uploadPath: '/environment-maps/with-file',
+      listPath: '/environment-maps',
+      listKey: 'environmentMaps',
+      name: `upgrade-envmap-${tag}`,
+      filename: `upgrade-envmap-${tag}.png`,
+      content: PNG,
+    },
+  ]
+}
+
+export function listArray(payload, listKey) {
+  return listKey ? (payload?.[listKey] ?? []) : payload
+}

--- a/tests/upgrade/lib.mjs
+++ b/tests/upgrade/lib.mjs
@@ -1,0 +1,175 @@
+// Shared helpers for the upgrade-integrity scripts (seed + verify). Zero external
+// deps — only Node built-ins — so the scripts run on a bare CI runner against the
+// installed app, exactly like src/desktop/scripts/integration/data-folder-migration.mjs.
+
+import crypto from 'crypto'
+import http from 'http'
+import https from 'https'
+
+// Default to the edge-proxied public API of an installed host. Override with
+// MODELIBR_API_BASE (e.g. the self-signed docker stack at https://127.0.0.1:3010/api).
+export const API_BASE = process.env.MODELIBR_API_BASE || 'http://127.0.0.1:3010/api'
+
+export function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex')
+}
+
+export function request(method, url, { headers = {}, body = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url)
+    const transport = u.protocol === 'https:' ? https : http
+    const req = transport.request(
+      {
+        hostname: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method,
+        headers,
+        // CI hits the installed app over plain http, so TLS validation stays on.
+        // For local runs against the self-signed docker stack (https on :3010),
+        // export NODE_TLS_REJECT_UNAUTHORIZED=0 rather than disabling it here.
+      },
+      res => {
+        const chunks = []
+        res.on('data', c => chunks.push(c))
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode,
+            buffer: Buffer.concat(chunks),
+            json() {
+              return JSON.parse(Buffer.concat(chunks).toString())
+            },
+          })
+        )
+      }
+    )
+    req.on('error', reject)
+    req.setTimeout(60000, () => req.destroy(new Error('request timed out')))
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+// Build a multipart/form-data body. `fields` is an array of either
+// { name, value } (text) or { name, filename, content } (file).
+export function multipart(fields) {
+  const boundary = '----modelibr-upgrade' + crypto.randomBytes(8).toString('hex')
+  const parts = []
+  for (const field of fields) {
+    if (field.filename != null) {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"; filename="${field.filename}"\r\n` +
+            `Content-Type: application/octet-stream\r\n\r\n`
+        ),
+        field.content,
+        Buffer.from('\r\n')
+      )
+    } else {
+      parts.push(
+        Buffer.from(
+          `--${boundary}\r\n` +
+            `Content-Disposition: form-data; name="${field.name}"\r\n\r\n` +
+            `${field.value}\r\n`
+        )
+      )
+    }
+  }
+  parts.push(Buffer.from(`--${boundary}--\r\n`))
+  return { body: Buffer.concat(parts), contentType: `multipart/form-data; boundary=${boundary}` }
+}
+
+// ───── Tiny inline fixtures (no committed binaries) ─────
+
+const OBJ = Buffer.from('# modelibr upgrade cube\no cube\nv 0 0 0\nv 1 0 0\nv 1 1 0\nf 1 2 3\n')
+
+// 1×1 opaque-red PNG.
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+// A valid 16-bit PCM mono WAV with a few samples (≈ a click of audio).
+function makeWav() {
+  const sampleRate = 8000
+  const samples = 16
+  const dataLen = samples * 2
+  const buf = Buffer.alloc(44 + dataLen)
+  buf.write('RIFF', 0)
+  buf.writeUInt32LE(36 + dataLen, 4)
+  buf.write('WAVE', 8)
+  buf.write('fmt ', 12)
+  buf.writeUInt32LE(16, 16) // PCM chunk size
+  buf.writeUInt16LE(1, 20) // PCM
+  buf.writeUInt16LE(1, 22) // mono
+  buf.writeUInt32LE(sampleRate, 24)
+  buf.writeUInt32LE(sampleRate * 2, 28) // byte rate
+  buf.writeUInt16LE(2, 32) // block align
+  buf.writeUInt16LE(16, 34) // bits per sample
+  buf.write('data', 36)
+  buf.writeUInt32LE(dataLen, 40)
+  for (let i = 0; i < samples; i++) buf.writeInt16LE((i % 2 ? 8000 : -8000), 44 + i * 2)
+  return buf
+}
+
+const WAV = makeWav()
+
+// The asset types a v0.1.0 host supports. Each is seeded once, then looked up by
+// its unique name after the upgrade. `listKey` is the array property in the list
+// response (null = the response IS the array, as for /models). `fileCheck` pulls
+// the bytes back and compares the sha256 (only /models exposes /{id}/file).
+export function assetTypes(tag) {
+  return [
+    {
+      type: 'model',
+      uploadPath: '/models',
+      listPath: '/models',
+      listKey: null,
+      name: `upgrade-model-${tag}`,
+      filename: `upgrade-model-${tag}.obj`,
+      content: OBJ,
+      fileUrlFor: id => `/models/${id}/file`,
+    },
+    {
+      type: 'texture-set',
+      uploadPath: '/texture-sets/with-file',
+      listPath: '/texture-sets',
+      listKey: 'textureSets',
+      name: `upgrade-texset-${tag}`,
+      filename: `upgrade-texset-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sprite',
+      uploadPath: '/sprites/with-file',
+      listPath: '/sprites',
+      listKey: 'sprites',
+      name: `upgrade-sprite-${tag}`,
+      filename: `upgrade-sprite-${tag}.png`,
+      content: PNG,
+    },
+    {
+      type: 'sound',
+      uploadPath: '/sounds/with-file',
+      listPath: '/sounds',
+      listKey: 'sounds',
+      name: `upgrade-sound-${tag}`,
+      filename: `upgrade-sound-${tag}.wav`,
+      content: WAV,
+    },
+    {
+      type: 'environment-map',
+      uploadPath: '/environment-maps/with-file',
+      listPath: '/environment-maps',
+      listKey: 'environmentMaps',
+      name: `upgrade-envmap-${tag}`,
+      filename: `upgrade-envmap-${tag}.png`,
+      content: PNG,
+    },
+  ]
+}
+
+export function listArray(payload, listKey) {
+  return listKey ? (payload?.[listKey] ?? []) : payload
+}

--- a/tests/upgrade/seed-assets.mjs
+++ b/tests/upgrade/seed-assets.mjs
@@ -1,0 +1,60 @@
+// Upgrade-integrity test — STEP 1 (seed). Uploads one of every asset type the
+// previous (old) Modelibr version supports through the host's public API, then
+// writes a manifest (name + uploaded-bytes sha256 per asset) for verify-assets.mjs
+// to check after the app has been upgraded in place.
+//
+// Usage: node tests/upgrade/seed-assets.mjs [manifestPath]
+//   MODELIBR_API_BASE  API base (default http://127.0.0.1:3010/api)
+
+import fs from 'fs/promises'
+
+import { API_BASE, assetTypes, multipart, request, sha256 } from './lib.mjs'
+
+const manifestPath = process.argv[2] || 'upgrade-manifest.json'
+
+async function seedOne(spec) {
+  const fields = [
+    { name: 'file', filename: spec.filename, content: spec.content },
+    { name: 'name', value: spec.name },
+  ]
+  const { body, contentType } = multipart(fields)
+  const res = await request('POST', `${API_BASE}${spec.uploadPath}`, {
+    headers: { 'content-type': contentType, 'content-length': body.length },
+    body,
+  })
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(
+      `seed ${spec.type} failed: POST ${spec.uploadPath} -> ${res.status} ${res.buffer
+        .toString()
+        .slice(0, 300)}`
+    )
+  }
+  console.log(`[seed] ${spec.type.padEnd(16)} "${spec.name}" (${res.status})`)
+  return {
+    type: spec.type,
+    name: spec.name,
+    listPath: spec.listPath,
+    listKey: spec.listKey,
+    sha256: sha256(spec.content),
+    hasFileUrl: typeof spec.fileUrlFor === 'function',
+  }
+}
+
+async function main() {
+  const tag = process.env.MODELIBR_SEED_TAG || `${Date.now()}`
+  console.log(`[seed] API ${API_BASE} — tag ${tag}`)
+
+  const records = []
+  for (const spec of assetTypes(tag)) {
+    records.push(await seedOne(spec))
+  }
+
+  const manifest = { tag, apiBase: API_BASE, seededAt: new Date().toISOString(), records }
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
+  console.log(`[seed] ✅ seeded ${records.length} assets — manifest written to ${manifestPath}`)
+}
+
+main().catch(error => {
+  console.error('[seed] ❌ FAIL:', error.message || error)
+  process.exit(1)
+})

--- a/tests/upgrade/verify-assets.mjs
+++ b/tests/upgrade/verify-assets.mjs
@@ -1,0 +1,91 @@
+// Upgrade-integrity test — STEP 2 (verify). Reads the manifest written by
+// seed-assets.mjs (before the upgrade) and confirms, against the UPGRADED host,
+// that every seeded asset is still there (by name), the model's bytes are
+// byte-identical (sha256), and a brand-new 0.2.0-only asset type (Script) can be
+// created — i.e. the upgrade preserved data AND the app still works.
+//
+// Usage: node tests/upgrade/verify-assets.mjs [manifestPath]
+//   MODELIBR_API_BASE  API base (default http://127.0.0.1:3010/api)
+
+import fs from 'fs/promises'
+
+import { API_BASE, listArray, multipart, request, sha256 } from './lib.mjs'
+
+const manifestPath = process.argv[2] || 'upgrade-manifest.json'
+
+const failures = []
+function check(ok, message) {
+  if (ok) {
+    console.log(`[verify] ✓ ${message}`)
+  } else {
+    console.error(`[verify] ✗ ${message}`)
+    failures.push(message)
+  }
+}
+
+async function findByName(record) {
+  const res = await request('GET', `${API_BASE}${record.listPath}`)
+  if (res.status !== 200) {
+    return { ok: false, detail: `GET ${record.listPath} -> ${res.status}` }
+  }
+  const entry = listArray(res.json(), record.listKey).find(a => a?.name === record.name)
+  return { ok: !!entry, entry }
+}
+
+async function verifyModelBytes(record, entry) {
+  const id = entry.id ?? entry.Id
+  const res = await request('GET', `${API_BASE}/models/${id}/file`)
+  check(res.status === 200, `model #${id} file is downloadable`)
+  check(sha256(res.buffer) === record.sha256, `model #${id} bytes are byte-identical after upgrade`)
+}
+
+async function verifyNewFeatureWorks() {
+  // Scripts did not exist in v0.1.0 — creating one proves the schema migrated and
+  // the upgraded app accepts writes for a type the old DB never had.
+  const name = `upgrade-postcheck-script-${Date.now()}`
+  const { body, contentType } = multipart([
+    { name: 'file', filename: `${name}.cs`, content: Buffer.from('// post-upgrade smoke\n') },
+    { name: 'name', value: name },
+  ])
+  const res = await request('POST', `${API_BASE}/scripts/with-file`, {
+    headers: { 'content-type': contentType, 'content-length': body.length },
+    body,
+  })
+  check(res.status >= 200 && res.status < 300, `can create a Script (0.2.0 feature) post-upgrade (${res.status})`)
+  if (res.status < 200 || res.status >= 300) {
+    return
+  }
+
+  // Read the new script back by the id the create returned — deterministic, so it
+  // doesn't depend on /scripts list ordering or pagination.
+  const created = res.json()
+  const id = created.scriptId ?? created.id ?? created.Id
+  const readBack = await request('GET', `${API_BASE}/scripts/${id}`)
+  check(readBack.status === 200, `the new Script (#${id}) is readable from the upgraded app`)
+}
+
+async function main() {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+  console.log(`[verify] API ${API_BASE} — manifest tag ${manifest.tag} (${manifest.records.length} assets)`)
+
+  for (const record of manifest.records) {
+    const { ok, entry, detail } = await findByName(record)
+    check(ok, `${record.type} "${record.name}" survived the upgrade${detail ? ` (${detail})` : ''}`)
+    if (ok && record.hasFileUrl && record.type === 'model') {
+      await verifyModelBytes(record, entry)
+    }
+  }
+
+  await verifyNewFeatureWorks()
+
+  if (failures.length) {
+    console.error(`[verify] ❌ FAIL — ${failures.length} check(s) failed`)
+    process.exit(1)
+  }
+  console.log('[verify] ✅ PASS — all assets survived the upgrade and the app works')
+}
+
+main().catch(error => {
+  console.error('[verify] ❌ FAIL:', error.message || error)
+  process.exit(1)
+})


### PR DESCRIPTION
`version/0.3` was branched from `main` at 0.2.0 and has no unique commits, so it had fallen 6 commits behind. This brings it up to the released **0.2.1** state (opt-in updates, Node 24 actions, the in-app self-update test, and the Prettier fix + gate) so it's a current base for future 0.3 work.

Clean fast-forward — `version/0.3` is strictly behind `main`. (package.json stays at 0.2.1; it gets bumped to 0.3.0 at 0.3 release-prep, per the version-branch convention.)