### PR TITLE
chore: forward version/0.2 (format gate) into version/0.3

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -293,6 +293,12 @@ jobs:
                   path: test-results/asset-processor-results.json
                   retention-days: 30
 
+            # Gate formatting here (this job is required and runs on every PR), so
+            # Prettier drift is caught at PR time instead of surfacing on the
+            # release merge. Code Quality stays non-required (it's path-filtered).
+            - name: Check Prettier formatting
+              run: npm run format:check
+
     build-storybook:
         name: Build Storybook
         runs-on: ubuntu-latest

--- a/src/asset-processor/tests/metadataExtraction.test.js
+++ b/src/asset-processor/tests/metadataExtraction.test.js
@@ -11,7 +11,12 @@ vi.mock('../logger.js', () => ({
   default: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }))
 
-const jobLogger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }
+const jobLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+}
 
 describe('extractTextureDimensions', () => {
   let tmpDir


### PR DESCRIPTION
Completes the version/0.3 refresh. After syncing version/0.3 up to main (0.2.1), the only thing still missing was the `format:check` gate on the required *Asset Processor Tests* job (#531), which lives on `version/0.2` and hasn't reached `main` yet. This brings it across so `version/0.3` PRs get the same Prettier gating and the next-dev line is fully current with the active maintenance line.

Single-file delta (`ci-and-deploy.yml`); the rest of version/0.2 is already on version/0.3 via main.