### PR TITLE
test(e2e): fix backup-restore Settings nav + run it with the full local e2e

### DIFF
--- a/scripts/test-runner/suites.config.mjs
+++ b/scripts/test-runner/suites.config.mjs
@@ -100,7 +100,10 @@ export const suites = [
         name: "E2E — all tiers incl. @slow Blender (Docker)",
         kind: "playwright",
         cwd: "tests/e2e",
-        command: "npm test",
+        // `node run-e2e.js` (not `npm test`) so the mega-runner runs the main
+        // E2E only — backup-restore is tracked as its own suite below, so it
+        // must not be double-run via the package's --with-backup-restore flag.
+        command: "node run-e2e.js",
         tier: "slow",
         requiresDocker: true,
         detectPath: "tests/e2e/package.json",

--- a/tests/backup-restore-e2e/helpers/settings-page.ts
+++ b/tests/backup-restore-e2e/helpers/settings-page.ts
@@ -1,11 +1,15 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
 /**
- * Page object for the Settings tab and its "Backup & Restore" accordion section.
+ * Page object for the Settings tab and its "Backup & Restore" section.
  *
  * Modelibr opens tabs through a dock-bar "+" button → "New Tab" picker. The
  * Settings tab type is reached by clicking the picker's "Settings" tile.
  * This mirrors the main e2e suite's `openTabViaMenu` helper.
+ *
+ * Since PR #508 the Settings tab is a grid of section cards → detail view (no
+ * accordion). Backup lives behind the "Backup & Restore" card, which opens a
+ * `.section-detail` that renders the `.backups-section` body.
  */
 export class SettingsPage {
     constructor(public readonly page: Page) {}
@@ -18,7 +22,7 @@ export class SettingsPage {
             timeout: 30000,
         });
         await this.openSettingsTab();
-        await this.expandBackupSection();
+        await this.openBackupSection();
     }
 
     private async openSettingsTab(): Promise<void> {
@@ -47,26 +51,34 @@ export class SettingsPage {
             await expect(newtabPage).toBeHidden({ timeout: 10000 });
         }
 
-        await expect(
-            this.page.getByRole("heading", { name: /application settings/i }),
-        ).toBeVisible({ timeout: 30000 });
+        // The redesigned Settings (PR #508) renders inside `.settings-container`,
+        // opening on the grid of section cards.
+        await expect(this.page.locator(".settings-container")).toBeVisible({
+            timeout: 30000,
+        });
     }
 
-    private async expandBackupSection(): Promise<void> {
-        const header = this.page
-            .locator(".settings-section-header")
-            .filter({ hasText: /backup\s*&\s*restore/i })
-            .first();
-        await expect(header).toBeVisible();
-        // Sections default to expanded for non-demo mode. If the body isn't
-        // already in the DOM (different layout, e.g. mobile), expand it.
-        const list = this.page.locator(".backups-section");
-        if (!(await list.isVisible())) {
-            await header.click();
+    private async openBackupSection(): Promise<void> {
+        // Land on the grid. A leftover section-detail from an earlier run is
+        // dismissed via the Back button so the Backup card is reachable.
+        const grid = this.page.locator(".settings-grid");
+        if (!(await grid.isVisible())) {
+            const back = this.page.locator(".btn-back");
+            if (await back.count()) await back.click();
         }
-        await expect(list).toBeVisible();
-        // Scroll the section into view for stable button clicks.
-        await header.scrollIntoViewIfNeeded();
+        await expect(grid).toBeVisible({ timeout: 10000 });
+
+        // Open the "Backup & Restore" section card → detail view. (Real,
+        // non-demo stack, so the card is enabled and renders BackupsSection.)
+        await this.page
+            .locator(".setting-card")
+            .filter({ hasText: /backup\s*&\s*restore/i })
+            .first()
+            .click();
+
+        const list = this.page.locator(".backups-section");
+        await expect(list).toBeVisible({ timeout: 10000 });
+        await list.scrollIntoViewIfNeeded();
     }
 
     // ── Operations ──────────────────────────────────────────────────────

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,7 +4,7 @@
     "description": "E2E tests for Modelibr using Playwright and BDD",
     "type": "module",
     "scripts": {
-        "test": "node run-e2e.js",
+        "test": "node run-e2e.js --with-backup-restore",
         "test:demo": "node run-demo-e2e.js",
         "test:quick": "node run-e2e-fast.js",
         "test:ci": "node run-e2e-fast.js --fast-only",

--- a/tests/e2e/run-e2e.js
+++ b/tests/e2e/run-e2e.js
@@ -118,6 +118,23 @@ function preserveBlobs(phase) {
   }
 }
 
+/**
+ * Run the sibling backup-restore E2E suite. It lives in its own package with a
+ * separate Docker stack (ports 3102/8190) and restarts the webapi mid-test, so
+ * it cannot share the main run — its `test:full` script self-provisions
+ * setup → specs → teardown. Returns the suite's exit code.
+ */
+function runBackupRestore() {
+  console.log("\n📋 Phase 6: Backup/restore E2E (separate Docker stack)\n");
+  const brDir = path.join(__dirname, "..", "backup-restore-e2e");
+  // Silent leading teardown clears containers/data left by a crashed earlier
+  // run so state can't leak in. Run it as its own step (output suppressed via
+  // stdio, not a POSIX `> /dev/null`) so this stays cross-platform like the
+  // rest of run-e2e.js; its exit code is intentionally ignored.
+  run("npm run test:teardown", { cwd: brDir, stdio: "ignore" });
+  return run("npm run test:full", { cwd: brDir });
+}
+
 async function main() {
   const startTime = Date.now();
 
@@ -170,7 +187,11 @@ async function main() {
   //   to the slowest thumbnail (~10.5min) instead of ~13min with workers=2.
   //   CI uses 3 workers (same as local) — 4 workers caused asset-processor
   //   contention on slower CI hardware, leading to thumbnail generation timeouts.
-  const args = process.argv.slice(2).join(" ");
+  // `--with-backup-restore` runs the sibling backup-restore E2E suite after the
+  // main run (see Phase 6). Strip it from the args forwarded to Playwright.
+  const rawArgs = process.argv.slice(2);
+  const withBackupRestore = rawArgs.includes("--with-backup-restore");
+  const args = rawArgs.filter((a) => a !== "--with-backup-restore").join(" ");
   const setupEnv = { ...testEnv, PW_WORKERS: "1" };
   const chromiumWorkers = process.env.CI ? "3" : "3";
   const chromiumEnv = { ...testEnv, PW_WORKERS: chromiumWorkers };
@@ -230,12 +251,11 @@ async function main() {
     },
   );
 
-  // Cleanup
+  // Tear the main E2E stack down before any further stack comes up so two
+  // Docker environments never run concurrently and compete for resources.
   cleanup();
 
-  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
-
-  const exitCode =
+  const mainExitCode =
     testResult !== 0
       ? testResult
       : serialResult !== 0
@@ -245,6 +265,17 @@ async function main() {
           : demoResult !== 0
             ? demoResult
             : mergeResult;
+
+  // Phase 6 (opt-in): backup-restore E2E on its own stack. The flag is set by
+  // `cd tests/e2e && npm test` so a full local run covers it; the mega-runner
+  // keeps running backup-restore as its own suite, so it isn't double-run there.
+  let backupRestoreExitCode = 0;
+  if (withBackupRestore) {
+    backupRestoreExitCode = runBackupRestore();
+  }
+
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+  const exitCode = mainExitCode !== 0 ? mainExitCode : backupRestoreExitCode;
 
   if (exitCode === 0) {
     console.log(`\n✅ All tests passed in ${duration}s\n`);


### PR DESCRIPTION
## Why

The `backup-restore` E2E suite (`tests/backup-restore-e2e/`) silently rotted: it gates no CI, and the PR #508 Settings redesign (heading + accordion → grid-of-cards → detail view) broke its page-object navigation, so every UI-driven spec timed out on `getByRole('heading', { name: /application settings/i })`.

## What

**1. Repair the navigation (`fix(e2e)`)**
Rewrote `helpers/settings-page.ts` for the new layout: wait for `.settings-container`, open the **Backup & Restore** section card, and assert the `.backups-section` detail body (with a Back-button fallback if a prior run left a detail open). These are the same structural selectors the up-to-date main suite (`tests/e2e/pages/SettingsPage.ts`) uses.

Every *operation* selector (create modal, the 3 include-checkboxes, table rows, download/restore/delete, confirm dialogs) already matched current markup and is unchanged. **Navigation/selectors only — no assertions weakened.** The restore round-trip's entity-by-entity verification is intact. Spec 03 is API-only and was never affected.

**2. Stop it rotting — run it with the full local e2e (`test(e2e)`)**
`cd tests/e2e && npm test` now passes `--with-backup-restore`, so `run-e2e.js` runs the backup-restore suite as a final **Phase 6** after the main stack is torn down (its own Docker stack on ports 3102/8190, self-provisioned). The run fails if *either* suite fails. The mega-runner keeps backup-restore as its own tracked suite, so `e2e-full` now invokes `node run-e2e.js` (without the flag) to avoid double-running it. No GitHub CI is affected (CI uses `run-e2e-fast.js` / `--project=slow` directly).

## Testing

- `npm run test:all -- --only=backup-restore --yes --no-open` → **7/7 passed, run twice** (the two formerly-broken UI specs 01 & 02 are green; 03/04 stayed green).
- `npm run test:audit` → green (10 suites, everything tracked).
- `run-e2e.js` syntax + flag-parse/path wiring verified; Phase 6 invocation is cross-platform (no POSIX-only shell in `run-e2e.js`).