### PR TITLE
fix(models): unify model-preview lighting & textures onto one shared cross-runtime lib

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,16 @@ the code and fix the skill in the same session.**
 | Layer touched | Command |
 |---|---|
 | Backend | `dotnet build Modelibr.sln && dotnet test Modelibr.sln --no-build --filter "Category!=Integration"` |
-| Frontend | `cd src/frontend && npm test && npm run lint && npm run build` |
-| Worker | `cd src/asset-processor && npm test && npm run lint` |
+| Frontend | `cd src/frontend && npm test && npm run lint && npm run format:check && npm run build` |
+| Worker | `cd src/asset-processor && npm test && npm run lint && npm run format:check` |
 | UI-visible behavior | the affected E2E scope (see testing rules below) |
 | Anything broad | `npm run test:all -- --only=<suite,...> --yes --no-open` |
+
+`npm run format:check` (Prettier) is a **required** CI gate and is **not**
+covered by `npm run lint`: ESLint's `prettier/prettier` rule only runs on the
+files ESLint lints (`**/*.js[x]`/`.ts[x]`, and `tests/` is eslint-ignored), so
+formatting drift in Markdown/JSON/CSS/etc. passes lint locally but fails CI. Run
+`npm run format` to auto-fix.
 
 Never finish with known-failing checks; if a failure is environmental, say so
 explicitly instead of claiming verified.

--- a/src/asset-processor/lib/README.md
+++ b/src/asset-processor/lib/README.md
@@ -39,6 +39,27 @@ not in two places.
 - **`stlMesh.js`** — STL `BufferGeometry` → configured Mesh/Group, including
   binary-STL vertex colors (THREE injected). Shared by the viewer, the worker
   thumbnail, and demo mode.
+- **`sceneLighting.js`** — the balanced model-preview light rig
+  (`DEFAULT_LIGHTING` + `resolveSceneLighting` + `buildSceneLights`, THREE
+  injected). Single source for the ambient/directional/point/spot rig and the
+  IBL `environmentIntensity`. The worker render template builds real lights from
+  it; the frontend viewer maps the resolved descriptor to R3F primitives so the
+  ambient/directional/environment controls land on one rig instead of being
+  swamped by a second one. (Demo mode still has its own simpler no-IBL rig — a
+  candidate to migrate here once its environment is ported.)
+- **`textureMaterial.js`** — texture-set → material pipeline slices shared by
+  the viewer and (eventually) the worker. No THREE import.
+  - `resolveTextureMaterialConfig(presentMaps)` — the metalness/roughness/
+    specular gating rule (keyed on each map, not on the base-color map).
+    Extracted after the viewer drifted to gating metalness on the base-color
+    map, which made textured non-metal surfaces render as black mirrors in the
+    viewer only.
+  - `ensureAoMapUv2(geometry)` — copy `uv` -> `uv2` so an AO map samples the
+    second UV set. Without it the AO term collapses and kills ALL indirect light
+    (ambient + environment IBL), which made those viewer controls look inert.
+  The worker still has equivalent inline rules in `puppeteerRenderer.js`
+  applyTextures and should adopt these when that pipeline is migrated (prompt-16
+  Target 2).
 
 ## Adding to this directory
 

--- a/src/asset-processor/lib/README.md
+++ b/src/asset-processor/lib/README.md
@@ -58,7 +58,7 @@ not in two places.
     second UV set. Without it the AO term collapses and kills ALL indirect light
     (ambient + environment IBL), which made those viewer controls look inert.
 - **`displacementNormal.js`** — `addSharedDisplacementNormal(THREE, geometry)` +
-  `applyDispNormalDisplacement(material)`: average the displacement *direction*
+  `applyDispNormalDisplacement(material)`: average the displacement _direction_
   across coincident-position vertex duplicates (instead of welding) so hard-edged
   displaced meshes stay watertight without smearing per-face UVs. Holds the two
   displacement GLSL chunks as the single source. The frontend imports it through
@@ -79,7 +79,7 @@ not in two places.
     `CHANNEL_VERTEX_SHADER` / `CHANNEL_EXTRACT_FRAGMENT_SHADER` (0-based
     `uChannel`, `uInvert`) / `RGB_INVERT_FRAGMENT_SHADER` GLSL. Previously the
     frontend (0-based) and worker (1-based) extraction shaders used different
-    channel numbering. The render-to-target *orchestration* (render-target size,
+    channel numbering. The render-to-target _orchestration_ (render-target size,
     camera, clone/dispose, color-space assignment) stays per-runtime.
   - `slotIsColorData(slot)` — which slots are sRGB color vs linear data.
 

--- a/src/asset-processor/lib/README.md
+++ b/src/asset-processor/lib/README.md
@@ -45,10 +45,10 @@ not in two places.
   IBL `environmentIntensity`. The worker render template builds real lights from
   it; the frontend viewer maps the resolved descriptor to R3F primitives so the
   ambient/directional/environment controls land on one rig instead of being
-  swamped by a second one. (Demo mode still has its own simpler no-IBL rig — a
-  candidate to migrate here once its environment is ported.)
-- **`textureMaterial.js`** — texture-set → material pipeline slices shared by
-  the viewer and (eventually) the worker. No THREE import.
+  swamped by a second one. Demo mode (browserAssetProcessor) also builds its rig
+  from this (plus a neutral RoomEnvironment IBL) so its thumbnails match.
+- **`textureMaterial.js`** — texture-set → material pipeline slices shared by the
+  viewer and the worker `applyTextures`. No THREE import.
   - `resolveTextureMaterialConfig(presentMaps)` — the metalness/roughness/
     specular gating rule (keyed on each map, not on the base-color map).
     Extracted after the viewer drifted to gating metalness on the base-color
@@ -57,14 +57,19 @@ not in two places.
   - `ensureAoMapUv2(geometry)` — copy `uv` -> `uv2` so an AO map samples the
     second UV set. Without it the AO term collapses and kills ALL indirect light
     (ambient + environment IBL), which made those viewer controls look inert.
-  The worker still has equivalent inline rules in `puppeteerRenderer.js`
-  applyTextures and should adopt these when that pipeline is migrated (prompt-16
-  Target 2).
+- **`displacementNormal.js`** — `addSharedDisplacementNormal(THREE, geometry)` +
+  `applyDispNormalDisplacement(material)`: average the displacement *direction*
+  across coincident-position vertex duplicates (instead of welding) so hard-edged
+  displaced meshes stay watertight without smearing per-face UVs. Holds the two
+  displacement GLSL chunks as the single source. The frontend imports it through
+  the `shared/three/sharedDisplacementNormal.ts` wrapper (which injects THREE);
+  the worker `applyTextures` calls it via `window.modelibrDispNormal`.
 
 ## Adding to this directory
 
 Adding viewer logic that the thumbnail render or demo must match? Put it here,
-not in two places. Known not-yet-migrated case: the displacement-normal shader
-lives in `frontend/src/shared/three/sharedDisplacementNormal.ts` and is currently
-hand-copied into `../puppeteerRenderer.js` — migrate it here when you next touch
-either side.
+not in two places. Remaining not-yet-migrated case: the texture-type → material
+slot map and the channel-extraction shader strings are still duplicated between
+`useChannelExtractedTextures` / `TEXTURE_SLOTS` (frontend) and the
+`applyTextures` `page.evaluate` (worker) — migrate the data/shaders here when you
+next touch either side (the render *orchestration* stays per-runtime).

--- a/src/asset-processor/lib/README.md
+++ b/src/asset-processor/lib/README.md
@@ -64,12 +64,28 @@ not in two places.
   displacement GLSL chunks as the single source. The frontend imports it through
   the `shared/three/sharedDisplacementNormal.ts` wrapper (which injects THREE);
   the worker `applyTextures` calls it via `window.modelibrDispNormal`.
+- **`textureChannels.js`** — the texture-type → material-slot map and the
+  channel-extraction shaders. No THREE import (plain data + GLSL strings).
+  - `MATERIAL_SLOT_BY_TEXTURE_TYPE` / `resolveMaterialSlot(type)` — which
+    MeshPhysicalMaterial slot each `TextureType` feeds (Height & Displacement →
+    `displacementMap`; Roughness & Glossiness → `roughnessMap`).
+  - `TEXTURE_TYPE` / `TEXTURE_CHANNEL` — enum mirrors of
+    `Domain/ValueObjects/TextureType.cs` / `TextureChannel.cs` (the API
+    serializes the enums as numbers), so no runtime sprinkles magic literals.
+  - `textureTypeNeedsInvert(type)` — Glossiness is inverted roughness, so it
+    feeds `roughnessMap` flipped. The worker had **no** Glossiness slot and was
+    silently dropping it; sharing the map + invert rule fixed that drift.
+  - `getChannelUniformIndex` / `channelNeedsExtraction` + the
+    `CHANNEL_VERTEX_SHADER` / `CHANNEL_EXTRACT_FRAGMENT_SHADER` (0-based
+    `uChannel`, `uInvert`) / `RGB_INVERT_FRAGMENT_SHADER` GLSL. Previously the
+    frontend (0-based) and worker (1-based) extraction shaders used different
+    channel numbering. The render-to-target *orchestration* (render-target size,
+    camera, clone/dispose, color-space assignment) stays per-runtime.
+  - `slotIsColorData(slot)` — which slots are sRGB color vs linear data.
 
 ## Adding to this directory
 
 Adding viewer logic that the thumbnail render or demo must match? Put it here,
-not in two places. Remaining not-yet-migrated case: the texture-type → material
-slot map and the channel-extraction shader strings are still duplicated between
-`useChannelExtractedTextures` / `TEXTURE_SLOTS` (frontend) and the
-`applyTextures` `page.evaluate` (worker) — migrate the data/shaders here when you
-next touch either side (the render *orchestration* stays per-runtime).
+not in two places. The texture-set → material pipeline now lives across
+`textureMaterial.js` (material config + AO uv2) and `textureChannels.js` (slot
+map + channel shaders); only the per-runtime render orchestration stays inline.

--- a/src/asset-processor/lib/displacementNormal.d.ts
+++ b/src/asset-processor/lib/displacementNormal.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Type declarations for the shared displacement-normal helpers. Implementation
+ * in `./displacementNormal.js` is plain ESM; this shim lets the TypeScript
+ * frontend (via the `sharedDisplacementNormal.ts` wrapper) import it without
+ * `// @ts-expect-error`.
+ */
+import type * as THREE from 'three'
+
+export function addSharedDisplacementNormal(
+  // Only BufferAttribute is constructed, so callers may inject the full `three`
+  // namespace or a subset.
+  three: Pick<typeof THREE, 'BufferAttribute'>,
+  geometry: THREE.BufferGeometry,
+  tolerance?: number
+): THREE.BufferGeometry
+
+export function applyDispNormalDisplacement(material: THREE.Material): void

--- a/src/asset-processor/lib/displacementNormal.js
+++ b/src/asset-processor/lib/displacementNormal.js
@@ -1,0 +1,150 @@
+/**
+ * Shared "displacement direction" logic for hard-edged meshes, used identically
+ * by the frontend viewer (via the `shared/three/sharedDisplacementNormal.ts`
+ * wrapper) and the worker Puppeteer thumbnail (via the window side-effect).
+ *
+ * The problem this solves: three.js's BoxGeometry and many user-uploaded
+ * hard-edged meshes carry duplicated vertices at every shared edge — each copy
+ * holds the same position but a face-aligned normal and a face-local UV island.
+ * Under per-vertex displacement, those copies push along their own face normal
+ * and tear the seam open. Merging the vertices (welding) closes the tear but
+ * collapses the UVs to a single "first occurrence wins" value, leaving a
+ * one-triangle-wide texture-smear band along every edge.
+ *
+ * The clean alternative is to keep both copies (so each face's UV island stays
+ * intact and color sampling is unaffected) but make their *displacement*
+ * direction identical: the average of the normals at that shared position.
+ *
+ *   1. `addSharedDisplacementNormal(THREE, geom)` writes the averaged direction
+ *      into a custom `aDispNormal` attribute (falls back to the per-vertex
+ *      normal where a position has no duplicates).
+ *   2. `applyDispNormalDisplacement(mat)` injects an `onBeforeCompile` hook that
+ *      replaces three's stock displacement vertex chunk with one that pushes
+ *      along `aDispNormal` instead of `objectNormal`.
+ *
+ * THREE is injected into `addSharedDisplacementNormal` (it constructs a
+ * BufferAttribute); `applyDispNormalDisplacement` only mutates material hooks, so
+ * it needs no THREE. The two GLSL chunks below are the single source of truth.
+ */
+
+const DISP_NORMAL_ATTR = 'aDispNormal'
+
+const VERTEX_PARS_INJECTION = `
+#include <displacementmap_pars_vertex>
+attribute vec3 aDispNormal;
+`
+
+const VERTEX_DISPLACEMENT_INJECTION = `
+#ifdef USE_DISPLACEMENTMAP
+	transformed += normalize( aDispNormal ) * ( texture2D( displacementMap, vDisplacementMapUv ).x * displacementScale + displacementBias );
+#endif
+`
+
+/**
+ * Compute averaged-by-position normals and store them on the geometry as
+ * `aDispNormal`. Returns the same geometry for chaining. Idempotent — if the
+ * attribute already exists, leaves it alone. A no-op when position or normal is
+ * missing.
+ *
+ * @param {object} THREE - The three namespace (only `BufferAttribute` is used).
+ * @param {object} geometry - A BufferGeometry.
+ * @param {number} [tolerance] - Position-quantization tolerance for grouping
+ *   coincident vertices (default 1e-4).
+ */
+export function addSharedDisplacementNormal(THREE, geometry, tolerance = 1e-4) {
+  if (geometry.getAttribute(DISP_NORMAL_ATTR)) return geometry
+
+  const position = geometry.getAttribute('position')
+  const normal = geometry.getAttribute('normal')
+  if (!position || !normal) return geometry
+
+  const count = position.count
+  const mult = 1 / tolerance
+
+  // Bucket vertices by quantized position.
+  const groups = new Map()
+  for (let i = 0; i < count; i++) {
+    const x = Math.round(position.getX(i) * mult)
+    const y = Math.round(position.getY(i) * mult)
+    const z = Math.round(position.getZ(i) * mult)
+    const key = `${x},${y},${z}`
+    let bucket = groups.get(key)
+    if (!bucket) {
+      bucket = []
+      groups.set(key, bucket)
+    }
+    bucket.push(i)
+  }
+
+  const dispNormals = new Float32Array(count * 3)
+  for (const indices of groups.values()) {
+    let nx = 0
+    let ny = 0
+    let nz = 0
+    for (const idx of indices) {
+      nx += normal.getX(idx)
+      ny += normal.getY(idx)
+      nz += normal.getZ(idx)
+    }
+    const len = Math.hypot(nx, ny, nz)
+    if (len > 0) {
+      nx /= len
+      ny /= len
+      nz /= len
+    }
+    for (const idx of indices) {
+      dispNormals[idx * 3] = nx
+      dispNormals[idx * 3 + 1] = ny
+      dispNormals[idx * 3 + 2] = nz
+    }
+  }
+
+  geometry.setAttribute(
+    DISP_NORMAL_ATTR,
+    new THREE.BufferAttribute(dispNormals, 3)
+  )
+  return geometry
+}
+
+/**
+ * Swap the displacement direction from `objectNormal` to the `aDispNormal`
+ * attribute. Idempotent on the same material (caches via `userData`). No THREE
+ * needed — only material hooks are touched.
+ *
+ * @param {object} material - A three Material.
+ */
+export function applyDispNormalDisplacement(material) {
+  if (material.userData.dispNormalShaderApplied) return
+  material.userData.dispNormalShaderApplied = true
+
+  const previousOnBeforeCompile = material.onBeforeCompile
+  material.onBeforeCompile = (shader, renderer) => {
+    if (previousOnBeforeCompile) {
+      previousOnBeforeCompile.call(material, shader, renderer)
+    }
+
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <displacementmap_pars_vertex>',
+      VERTEX_PARS_INJECTION.trim()
+    )
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <displacementmap_vertex>',
+      VERTEX_DISPLACEMENT_INJECTION.trim()
+    )
+  }
+
+  const previousCacheKey = material.customProgramCacheKey
+  material.customProgramCacheKey = () => {
+    const prev = previousCacheKey ? previousCacheKey.call(material) : ''
+    return prev ? `disp-normal|${prev}` : 'disp-normal'
+  }
+}
+
+// Side-effect: expose on window for the Puppeteer page.evaluate (classic-script
+// context), parity with the other shared modules.
+if (typeof window !== 'undefined') {
+  window.modelibrDispNormal = {
+    addSharedDisplacementNormal,
+    applyDispNormalDisplacement,
+  }
+}

--- a/src/asset-processor/lib/sceneLighting.d.ts
+++ b/src/asset-processor/lib/sceneLighting.d.ts
@@ -1,0 +1,82 @@
+/**
+ * Type declarations for the shared scene-lighting rig. Implementation in
+ * `./sceneLighting.js` is plain ESM; this shim lets TS-aware callers (the
+ * frontend viewer) import it without `// @ts-expect-error`.
+ */
+import type * as THREE from 'three'
+
+export interface AmbientLightDescriptor {
+  color: number
+  intensity: number
+}
+
+export interface DirectionalLightDescriptor {
+  color: number
+  intensity: number
+  position: [number, number, number]
+  castShadow?: boolean
+  shadowMapSize?: number
+}
+
+export interface PointLightDescriptor {
+  color: number
+  intensity: number
+  position: [number, number, number]
+}
+
+export interface SpotLightDescriptor {
+  color: number
+  intensity: number
+  position: [number, number, number]
+  angle: number
+  penumbra: number
+  castShadow?: boolean
+}
+
+export interface SceneLightingDescriptor {
+  ambient: AmbientLightDescriptor
+  directional: DirectionalLightDescriptor
+  point: PointLightDescriptor
+  spot: SpotLightDescriptor
+  /** Applied to `scene.environmentIntensity` (the IBL contribution). */
+  environmentIntensity: number
+}
+
+export interface SceneLightingSettings {
+  /** Absolute ambient light intensity. */
+  ambientIntensity?: number
+  /** Multiplier on the directional/point/spot triplet. */
+  directionalIntensity?: number
+  /** Absolute scene.environmentIntensity. */
+  environmentIntensity?: number
+}
+
+export interface SceneLightRig {
+  ambient: THREE.AmbientLight
+  directional: THREE.DirectionalLight
+  point: THREE.PointLight
+  spot: THREE.SpotLight
+  lights: THREE.Light[]
+}
+
+export const DEFAULT_LIGHTING: SceneLightingDescriptor
+
+export const ENVIRONMENT_PREVIEW_LIGHTING: {
+  ambient: number
+  directional: number
+  point: number
+  spot: number
+}
+
+export function resolveSceneLighting(
+  settings?: SceneLightingSettings,
+  base?: SceneLightingDescriptor
+): SceneLightingDescriptor
+
+export function buildSceneLights(
+  three: Pick<
+    typeof THREE,
+    'AmbientLight' | 'DirectionalLight' | 'PointLight' | 'SpotLight'
+  >,
+  descriptor?: SceneLightingDescriptor
+): SceneLightRig

--- a/src/asset-processor/lib/sceneLighting.js
+++ b/src/asset-processor/lib/sceneLighting.js
@@ -1,0 +1,176 @@
+/**
+ * Shared scene-lighting rig, used by every runtime that renders a model preview
+ * so they all light it identically:
+ *   - the frontend viewer (Vite bundle, React-Three-Fiber) — maps the resolved
+ *     descriptor to declarative <ambientLight>/<directionalLight>/... primitives,
+ *   - the worker Puppeteer thumbnail render (`render-template.html`) — builds
+ *     real THREE light instances via buildSceneLights,
+ *   - demo mode (browserAssetProcessor) — same builder.
+ *
+ * Before this module the rig was hand-copied into all three with different
+ * numbers, so the in-app viewer (drei <Stage> + a second manual rig) was wildly
+ * over-lit and the ambient/environment controls were swamped, while the
+ * thumbnail used a single balanced rig. This is the single source of truth for
+ * the balanced rig (the thumbnail's numbers win).
+ *
+ * THREE is injected (like the TIFF decoder's UTIF and stlMesh's THREE) so the
+ * one file runs in both a bundler and a raw browser page without pulling in a
+ * second three instance.
+ */
+
+/**
+ * The canonical balanced rig — these are the worker thumbnail's numbers, which
+ * are the reference "correct" look. Direct lights are deliberately low so PBR
+ * materials aren't overexposed; the image-based lighting (environmentIntensity)
+ * carries soft fill.
+ */
+export const DEFAULT_LIGHTING = {
+  ambient: { color: 0xffffff, intensity: 0.35 },
+  directional: {
+    color: 0xffffff,
+    intensity: 0.45,
+    position: [20, 15, 20],
+    castShadow: true,
+    shadowMapSize: 2048,
+  },
+  point: { color: 0xffffff, intensity: 0.2, position: [-15, 5, -15] },
+  spot: {
+    color: 0xffffff,
+    intensity: 0.25,
+    position: [0, 20, 0],
+    angle: 0.4,
+    penumbra: 1,
+    castShadow: true,
+  },
+  // Applied as scene.environmentIntensity (the IBL contribution).
+  environmentIntensity: 0.3,
+}
+
+/**
+ * Dimmed direct-light intensities used while showing an environment-map preview
+ * (the env map itself provides the illumination, so the rig is pulled down to
+ * near-fill). Keyed by light so a caller can set each `.intensity` directly.
+ */
+export const ENVIRONMENT_PREVIEW_LIGHTING = {
+  ambient: 0.06,
+  directional: 0.12,
+  point: 0.05,
+  spot: 0.08,
+}
+
+/**
+ * Resolve a rig descriptor for a given set of user-facing viewer settings.
+ *
+ * Semantics (matching the historical viewer sliders):
+ *   - ambientIntensity     — absolute ambient light intensity (default = base).
+ *   - directionalIntensity — multiplier on the whole directional triplet
+ *     (directional/point/spot), default 1 → exactly the base rig.
+ *   - environmentIntensity — absolute scene.environmentIntensity (default = base).
+ *
+ * With no settings (or all undefined) this returns the base rig unchanged, so
+ * the viewer's default matches the thumbnail.
+ *
+ * @param {{ ambientIntensity?: number, directionalIntensity?: number,
+ *   environmentIntensity?: number }} [settings]
+ * @param {typeof DEFAULT_LIGHTING} [base]
+ * @returns {typeof DEFAULT_LIGHTING}
+ */
+export function resolveSceneLighting(settings = {}, base = DEFAULT_LIGHTING) {
+  const directionalScale =
+    settings.directionalIntensity != null ? settings.directionalIntensity : 1
+
+  return {
+    ambient: {
+      ...base.ambient,
+      intensity:
+        settings.ambientIntensity != null
+          ? settings.ambientIntensity
+          : base.ambient.intensity,
+    },
+    directional: {
+      ...base.directional,
+      intensity: base.directional.intensity * directionalScale,
+    },
+    point: {
+      ...base.point,
+      intensity: base.point.intensity * directionalScale,
+    },
+    spot: {
+      ...base.spot,
+      intensity: base.spot.intensity * directionalScale,
+    },
+    environmentIntensity:
+      settings.environmentIntensity != null
+        ? settings.environmentIntensity
+        : base.environmentIntensity,
+  }
+}
+
+/**
+ * Build real THREE light instances from a rig descriptor. Used by the imperative
+ * runtimes (worker render template, demo mode). The frontend viewer maps the
+ * descriptor to R3F primitives instead, so it does not call this.
+ *
+ * The lights are returned individually (and as a `lights` array); the caller
+ * adds them to its scene. environmentIntensity is descriptor data, not a light,
+ * so the caller applies it to `scene.environmentIntensity` separately.
+ *
+ * @param {object} THREE - The three namespace (or a subset with the four light
+ *   constructors and Vector3-style positions).
+ * @param {typeof DEFAULT_LIGHTING} [descriptor]
+ */
+export function buildSceneLights(THREE, descriptor = DEFAULT_LIGHTING) {
+  const ambient = new THREE.AmbientLight(
+    descriptor.ambient.color,
+    descriptor.ambient.intensity
+  )
+
+  const directional = new THREE.DirectionalLight(
+    descriptor.directional.color,
+    descriptor.directional.intensity
+  )
+  directional.position.set(...descriptor.directional.position)
+  if (descriptor.directional.castShadow) {
+    directional.castShadow = true
+    const size = descriptor.directional.shadowMapSize || 2048
+    directional.shadow.mapSize.width = size
+    directional.shadow.mapSize.height = size
+  }
+
+  const point = new THREE.PointLight(
+    descriptor.point.color,
+    descriptor.point.intensity
+  )
+  point.position.set(...descriptor.point.position)
+
+  const spot = new THREE.SpotLight(
+    descriptor.spot.color,
+    descriptor.spot.intensity
+  )
+  spot.position.set(...descriptor.spot.position)
+  spot.angle = descriptor.spot.angle
+  spot.penumbra = descriptor.spot.penumbra
+  if (descriptor.spot.castShadow) {
+    spot.castShadow = true
+  }
+
+  return {
+    ambient,
+    directional,
+    point,
+    spot,
+    lights: [ambient, directional, point, spot],
+  }
+}
+
+// Side-effect: expose on window for the Puppeteer scene (parity with the shared
+// TIFF decoder / STL builder), in case a page.evaluate classic-script context
+// needs it.
+if (typeof window !== 'undefined') {
+  window.modelibrLighting = {
+    DEFAULT_LIGHTING,
+    ENVIRONMENT_PREVIEW_LIGHTING,
+    resolveSceneLighting,
+    buildSceneLights,
+  }
+}

--- a/src/asset-processor/lib/textureChannels.d.ts
+++ b/src/asset-processor/lib/textureChannels.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Type declarations for the shared texture-type → material-slot map and the
+ * channel-extraction shaders. Implementation in `./textureChannels.js` is plain
+ * ESM; this shim lets the TypeScript frontend import it without
+ * `// @ts-expect-error`.
+ */
+
+/** TextureType enum mirror (matches `Domain/ValueObjects/TextureType.cs`). */
+export const TEXTURE_TYPE: Readonly<Record<string, number>>
+
+/** TextureChannel enum mirror (matches `Domain/ValueObjects/TextureChannel.cs`). */
+export const TEXTURE_CHANNEL: Readonly<Record<string, number>>
+
+/** Canonical texture type → MeshPhysicalMaterial slot. */
+export const MATERIAL_SLOT_BY_TEXTURE_TYPE: Readonly<Record<number, string>>
+
+/** Texture types whose values must be inverted at load (Glossiness). */
+export const INVERTED_TEXTURE_TYPES: ReadonlySet<number>
+
+/** Material slots that carry sRGB color data (vs linear data). */
+export const COLOR_MATERIAL_SLOTS: ReadonlySet<string>
+
+/** Resolve the material slot a texture type feeds, or null if it has none. */
+export function resolveMaterialSlot(textureType: number): string | null
+
+/** Whether a texture type's values must be inverted at load (Glossiness). */
+export function textureTypeNeedsInvert(textureType: number): boolean
+
+/** Whether a material slot carries sRGB color data (vs linear data). */
+export function slotIsColorData(slot: string): boolean
+
+/** Map a TextureChannel value to the 0-based `uChannel` shader index. */
+export function getChannelUniformIndex(channel: number): number
+
+/** Whether a TextureChannel value selects a single channel to extract (R/G/B/A). */
+export function channelNeedsExtraction(channel: number): boolean
+
+/** Fullscreen-quad passthrough vertex shader for the extraction passes. */
+export const CHANNEL_VERTEX_SHADER: string
+
+/** Extracts a single channel to grayscale (`uChannel` 0-based, `uInvert` 0/1). */
+export const CHANNEL_EXTRACT_FRAGMENT_SHADER: string
+
+/** Inverts the RGB channels (alpha preserved); for full-RGB Glossiness. */
+export const RGB_INVERT_FRAGMENT_SHADER: string

--- a/src/asset-processor/lib/textureChannels.js
+++ b/src/asset-processor/lib/textureChannels.js
@@ -166,8 +166,10 @@ export function channelNeedsExtraction(channel) {
 
 /**
  * Fullscreen-quad passthrough vertex shader for the channel-extraction passes.
- * Writes clip-space directly from the unit quad's position so it works for any
- * camera orchestration (the runtimes set up their ortho camera differently).
+ * Writes clip-space directly from the unit-quad position (a `PlaneGeometry(2, 2)`
+ * whose vertices sit at ±1), so the camera setup is irrelevant — but the source
+ * geometry MUST be that 2×2 quad. The runtimes' ortho cameras differ; this shader
+ * intentionally ignores them.
  * @type {string}
  */
 export const CHANNEL_VERTEX_SHADER = `

--- a/src/asset-processor/lib/textureChannels.js
+++ b/src/asset-processor/lib/textureChannels.js
@@ -1,0 +1,240 @@
+/**
+ * Shared texture-type → material-slot map and channel-extraction shaders. Single
+ * source of truth for the *data* (which MeshPhysicalMaterial slot a texture type
+ * feeds, which types invert, which slots carry sRGB color) and the GLSL that
+ * extracts a single R/G/B/A channel to grayscale.
+ *
+ * These were hand-duplicated across the three runtimes that must agree:
+ *   - the frontend viewer (`useChannelExtractedTextures.ts` + `TexturedModel`'s
+ *     `TEXTURE_SLOTS`),
+ *   - the worker thumbnail render (`puppeteerRenderer.js` applyTextures, which
+ *     reaches this through the `window.modelibrTextureChannels` side-effect),
+ *   - demo mode (which uses the enum constants).
+ *
+ * The duplication had already drifted: the two channel-extraction shaders used
+ * different channel numbering (frontend 0-based `uChannel`, worker 1-based
+ * `channel`), and the worker's slot map had no Glossiness entry at all — so a
+ * Glossiness map (inverted roughness) was silently dropped in the thumbnail
+ * while the viewer applied it as an inverted roughnessMap. Both are fixed by
+ * sharing the map + shaders here.
+ *
+ * No THREE import — the maps are plain data, the shaders are strings, and the
+ * channel index is arithmetic. Each runtime keeps its own render-to-target
+ * orchestration (render-target size, camera, clone/dispose, color-space
+ * assignment); only the data and the GLSL live here.
+ */
+
+/**
+ * TextureType enum — mirrors `Domain/ValueObjects/TextureType.cs` (the API
+ * serializes the enum as its numeric value). Kept here so all three runtimes
+ * name the same numbers instead of sprinkling magic literals.
+ * @type {Readonly<Record<string, number>>}
+ */
+export const TEXTURE_TYPE = Object.freeze({
+  SplitChannel: 0,
+  Albedo: 1,
+  Normal: 2,
+  Height: 3,
+  AO: 4,
+  Roughness: 5,
+  Metallic: 6,
+  Specular: 8,
+  Emissive: 9,
+  Bump: 10,
+  Alpha: 11,
+  Displacement: 12,
+  Glossiness: 13,
+})
+
+/**
+ * TextureChannel enum — mirrors `Domain/ValueObjects/TextureChannel.cs`. RGB
+ * means "use the whole texture, no channel extraction".
+ * @type {Readonly<Record<string, number>>}
+ */
+export const TEXTURE_CHANNEL = Object.freeze({
+  R: 1,
+  G: 2,
+  B: 3,
+  A: 4,
+  RGB: 5,
+})
+
+/**
+ * Canonical texture type → MeshPhysicalMaterial slot. Both Height and
+ * Displacement feed `displacementMap`; both Roughness and Glossiness feed
+ * `roughnessMap` (Glossiness inverted, see {@link INVERTED_TEXTURE_TYPES}).
+ * SplitChannel (0) is a source-only placeholder and has no slot.
+ * @type {Readonly<Record<number, string>>}
+ */
+export const MATERIAL_SLOT_BY_TEXTURE_TYPE = Object.freeze({
+  [TEXTURE_TYPE.Albedo]: 'map',
+  [TEXTURE_TYPE.Normal]: 'normalMap',
+  [TEXTURE_TYPE.Height]: 'displacementMap',
+  [TEXTURE_TYPE.AO]: 'aoMap',
+  [TEXTURE_TYPE.Roughness]: 'roughnessMap',
+  [TEXTURE_TYPE.Metallic]: 'metalnessMap',
+  [TEXTURE_TYPE.Specular]: 'specularColorMap',
+  [TEXTURE_TYPE.Emissive]: 'emissiveMap',
+  [TEXTURE_TYPE.Bump]: 'bumpMap',
+  [TEXTURE_TYPE.Alpha]: 'alphaMap',
+  [TEXTURE_TYPE.Displacement]: 'displacementMap',
+  [TEXTURE_TYPE.Glossiness]: 'roughnessMap',
+})
+
+/**
+ * Texture types whose values must be inverted at load. Glossiness is inverted
+ * roughness (gloss = 1 - rough), so it feeds `roughnessMap` flipped.
+ * @type {ReadonlySet<number>}
+ */
+export const INVERTED_TEXTURE_TYPES = Object.freeze(
+  new Set([TEXTURE_TYPE.Glossiness])
+)
+
+/**
+ * Material slots that carry sRGB *color* data; everything else is linear data
+ * (normals, roughness, AO, height…). Used to pick the texture color space.
+ * @type {ReadonlySet<string>}
+ */
+export const COLOR_MATERIAL_SLOTS = Object.freeze(
+  new Set(['map', 'emissiveMap', 'specularColorMap'])
+)
+
+/**
+ * Resolve the MeshPhysicalMaterial slot a texture type feeds, or null if the
+ * type has no slot (e.g. SplitChannel).
+ * @param {number} textureType
+ * @returns {string | null}
+ */
+export function resolveMaterialSlot(textureType) {
+  return MATERIAL_SLOT_BY_TEXTURE_TYPE[textureType] ?? null
+}
+
+/**
+ * Whether a texture type's values must be inverted at load (Glossiness).
+ * @param {number} textureType
+ * @returns {boolean}
+ */
+export function textureTypeNeedsInvert(textureType) {
+  return INVERTED_TEXTURE_TYPES.has(textureType)
+}
+
+/**
+ * Whether a material slot carries sRGB color data (vs linear data).
+ * @param {string} slot
+ * @returns {boolean}
+ */
+export function slotIsColorData(slot) {
+  return COLOR_MATERIAL_SLOTS.has(slot)
+}
+
+/**
+ * Map a TextureChannel enum value to the 0-based index the extraction fragment
+ * shader's `uChannel` uniform expects (R=0, G=1, B=2, A=3). RGB / anything else
+ * falls back to 0 (the caller shouldn't extract a channel for RGB sources).
+ * @param {number} channel
+ * @returns {number}
+ */
+export function getChannelUniformIndex(channel) {
+  switch (channel) {
+    case TEXTURE_CHANNEL.R:
+      return 0
+    case TEXTURE_CHANNEL.G:
+      return 1
+    case TEXTURE_CHANNEL.B:
+      return 2
+    case TEXTURE_CHANNEL.A:
+      return 3
+    default:
+      return 0
+  }
+}
+
+/**
+ * Whether a TextureChannel value selects a single channel that must be extracted
+ * (R/G/B/A) as opposed to RGB / a non-extracting value.
+ * @param {number} channel
+ * @returns {boolean}
+ */
+export function channelNeedsExtraction(channel) {
+  return (
+    channel === TEXTURE_CHANNEL.R ||
+    channel === TEXTURE_CHANNEL.G ||
+    channel === TEXTURE_CHANNEL.B ||
+    channel === TEXTURE_CHANNEL.A
+  )
+}
+
+/**
+ * Fullscreen-quad passthrough vertex shader for the channel-extraction passes.
+ * Writes clip-space directly from the unit quad's position so it works for any
+ * camera orchestration (the runtimes set up their ortho camera differently).
+ * @type {string}
+ */
+export const CHANNEL_VERTEX_SHADER = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position, 1.0);
+  }
+`
+
+/**
+ * Extracts a single channel to grayscale. `uChannel` is 0-based (R=0, G=1, B=2,
+ * A=3); `uInvert` (0/1) flips the value (Glossiness → Roughness).
+ * @type {string}
+ */
+export const CHANNEL_EXTRACT_FRAGMENT_SHADER = `
+  uniform sampler2D uTexture;
+  uniform int uChannel; // 0=R, 1=G, 2=B, 3=A
+  uniform int uInvert; // 0=no, 1=output 1.0 - value
+  varying vec2 vUv;
+
+  void main() {
+    vec4 texColor = texture2D(uTexture, vUv);
+    float channelValue;
+
+    if (uChannel == 0) channelValue = texColor.r;
+    else if (uChannel == 1) channelValue = texColor.g;
+    else if (uChannel == 2) channelValue = texColor.b;
+    else channelValue = texColor.a;
+
+    float v = uInvert == 1 ? 1.0 - channelValue : channelValue;
+    gl_FragColor = vec4(v, v, v, 1.0);
+  }
+`
+
+/**
+ * Inverts the RGB channels (alpha preserved). Used for a Glossiness texture
+ * sourced as full-RGB grayscale that needs flipping to behave as roughness.
+ * @type {string}
+ */
+export const RGB_INVERT_FRAGMENT_SHADER = `
+  uniform sampler2D uTexture;
+  varying vec2 vUv;
+
+  void main() {
+    vec4 texColor = texture2D(uTexture, vUv);
+    gl_FragColor = vec4(1.0 - texColor.rgb, texColor.a);
+  }
+`
+
+// Side-effect: expose on window for the Puppeteer page.evaluate (classic-script
+// context), parity with the other shared lib modules. Lets the worker's
+// applyTextures reach the map + shaders without an import.
+if (typeof window !== 'undefined') {
+  window.modelibrTextureChannels = {
+    TEXTURE_TYPE,
+    TEXTURE_CHANNEL,
+    MATERIAL_SLOT_BY_TEXTURE_TYPE,
+    INVERTED_TEXTURE_TYPES,
+    COLOR_MATERIAL_SLOTS,
+    resolveMaterialSlot,
+    textureTypeNeedsInvert,
+    slotIsColorData,
+    getChannelUniformIndex,
+    channelNeedsExtraction,
+    CHANNEL_VERTEX_SHADER,
+    CHANNEL_EXTRACT_FRAGMENT_SHADER,
+    RGB_INVERT_FRAGMENT_SHADER,
+  }
+}

--- a/src/asset-processor/lib/textureMaterial.d.ts
+++ b/src/asset-processor/lib/textureMaterial.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Type declarations for the shared texture-set → material helpers.
+ * Implementation in `./textureMaterial.js` is plain ESM; this shim lets the
+ * TypeScript frontend import it without `// @ts-expect-error`.
+ */
+import type * as THREE from 'three'
+
+export interface TexturePresence {
+  /** Truthy when a base-color/albedo map is present. */
+  baseColorMap?: unknown
+  /** Truthy when a metalness map is present. */
+  metalnessMap?: unknown
+  /** Truthy when a roughness map is present. */
+  roughnessMap?: unknown
+  /** Truthy when a specular-color map is present. */
+  specularColorMap?: unknown
+}
+
+export interface TextureMaterialConfig {
+  /** Whether a base-color map drives the albedo (caller uses white if so). */
+  hasBaseColorMap: boolean
+  /** 1 only when a metalness map is present, else 0 (dielectric). */
+  metalness: number
+  /** 1 when a roughness map is present, else a matte default. */
+  roughness: number
+  envMapIntensity: number
+  /** 1 only when a specular-color map is present, else 0. */
+  specularIntensity: number
+}
+
+export function resolveTextureMaterialConfig(
+  maps?: TexturePresence
+): TextureMaterialConfig
+
+/**
+ * Copy `uv` -> `uv2` when missing so an AO map samples the second UV set
+ * instead of collapsing indirect lighting. Idempotent; mutates in place.
+ */
+export function ensureAoMapUv2(
+  geometry: THREE.BufferGeometry | null | undefined
+): void

--- a/src/asset-processor/lib/textureMaterial.js
+++ b/src/asset-processor/lib/textureMaterial.js
@@ -1,0 +1,81 @@
+/**
+ * Shared texture-set → material *config* resolver. Single source of truth for
+ * the "which maps are present → metalness / roughness / specular gating" rule
+ * that the worker thumbnail render (`puppeteerRenderer.js` applyTextures) and
+ * the frontend viewer (`TexturedModel.tsx`) must agree on.
+ *
+ * They drifted once, and it was nasty: the viewer gated metalness on the
+ * *base-color* map, so any textured-but-not-metal surface (a base-color map
+ * with no metalness map) became fully metallic — a mirror with no diffuse
+ * response, lit only by the environment. Under a dim viewer environment it
+ * rendered nearly black, while the worker thumbnail (which gates on the
+ * metalness map) looked correct. Keeping the rule here stops that recurring.
+ *
+ * No THREE import here. `resolveTextureMaterialConfig` is pure and returns plain
+ * numbers/booleans; the caller constructs the MeshPhysicalMaterial and sets the
+ * base color (white when a base-color map is present, else the neutral surface)
+ * so three's color management stays caller-side. `ensureAoMapUv2` mutates a
+ * geometry through its own methods. These are the incremental, low-risk slices
+ * of the texture-set → material pipeline; the channel extraction / displacement
+ * orchestration stays per-runtime.
+ */
+
+/**
+ * @param {{ baseColorMap?: unknown, metalnessMap?: unknown,
+ *   roughnessMap?: unknown, specularColorMap?: unknown }} [maps]
+ *   Truthy when the corresponding texture is present (a Texture, a URL, etc.).
+ * @returns {{ hasBaseColorMap: boolean, metalness: number, roughness: number,
+ *   envMapIntensity: number, specularIntensity: number }}
+ */
+export function resolveTextureMaterialConfig(maps = {}) {
+  return {
+    // White base color when a base-color map drives the albedo, otherwise the
+    // caller falls back to the neutral surface.
+    hasBaseColorMap: Boolean(maps.baseColorMap),
+    // Metal only with a metalness map; otherwise dielectric so the surface has
+    // a normal diffuse response under any lighting.
+    metalness: maps.metalnessMap ? 1 : 0,
+    // Full roughness lets a roughness map drive the value; without one, a
+    // sensible matte default.
+    roughness: maps.roughnessMap ? 1 : 0.8,
+    envMapIntensity: 1.0,
+    // MeshPhysicalMaterial's dielectric specular channel (intensity 1) washes
+    // the albedo toward white without a real specular map — disable it unless
+    // one is present.
+    specularIntensity: maps.specularColorMap ? 1 : 0,
+  }
+}
+
+/**
+ * AO (ambient-occlusion) maps sample the *second* UV set. A geometry that only
+ * has `uv` makes the AO term read a missing attribute and collapse toward 0,
+ * which silently kills ALL indirect light on the material — both the ambient
+ * light and the environment IBL — while leaving direct lights untouched. Symptom
+ * in the viewer: the ambient and environment-intensity controls look inert while
+ * directional intensity still works.
+ *
+ * Copy `uv` -> `uv2` (parity with the worker thumbnail) so AO samples correctly.
+ * Idempotent, and a no-op when there's no `uv` to copy. Mutates the geometry in
+ * place via its own methods — no THREE import needed.
+ *
+ * @param {{ getAttribute: Function, setAttribute: Function }} geometry
+ *   A BufferGeometry (or anything exposing get/setAttribute and a clonable uv).
+ */
+export function ensureAoMapUv2(geometry) {
+  if (!geometry || typeof geometry.getAttribute !== 'function') return
+  if (geometry.getAttribute('uv2')) return
+  const uvAttr = geometry.getAttribute('uv')
+  if (uvAttr && typeof uvAttr.clone === 'function') {
+    geometry.setAttribute('uv2', uvAttr.clone())
+  }
+}
+
+// Side-effect: expose on window for the Puppeteer page.evaluate (classic-script
+// context), parity with the shared TIFF decoder / STL builder. Lets the worker
+// adopt this without an import once its applyTextures pipeline is migrated.
+if (typeof window !== 'undefined') {
+  window.modelibrTextureMaterial = {
+    resolveTextureMaterialConfig,
+    ensureAoMapUv2,
+  }
+}

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -1148,95 +1148,17 @@ export class PuppeteerRenderer {
                       child.material.displacementBias = -0.01
                       // Push along an averaged-by-position normal so hard
                       // edges (cube faces, hard-edge user meshes) stay
-                      // watertight while keeping per-face UVs intact for
-                      // color sampling. See the frontend equivalent in
-                      // shared/three/sharedDisplacementNormal.ts.
-                      const geom = child.geometry
-                      if (
-                        geom &&
-                        geom.getAttribute('position') &&
-                        geom.getAttribute('normal') &&
-                        !geom.getAttribute('aDispNormal')
-                      ) {
-                        const pos = geom.getAttribute('position')
-                        const nor = geom.getAttribute('normal')
-                        const cnt = pos.count
-                        const mult = 1 / 1e-4
-                        const groups = new Map()
-                        for (let i = 0; i < cnt; i++) {
-                          const k = `${Math.round(pos.getX(i) * mult)},${Math.round(pos.getY(i) * mult)},${Math.round(pos.getZ(i) * mult)}`
-                          let g = groups.get(k)
-                          if (!g) {
-                            g = []
-                            groups.set(k, g)
-                          }
-                          g.push(i)
-                        }
-                        const out = new Float32Array(cnt * 3)
-                        for (const idxs of groups.values()) {
-                          let x = 0,
-                            y = 0,
-                            z = 0
-                          for (const i of idxs) {
-                            x += nor.getX(i)
-                            y += nor.getY(i)
-                            z += nor.getZ(i)
-                          }
-                          const len = Math.hypot(x, y, z)
-                          if (len > 0) {
-                            x /= len
-                            y /= len
-                            z /= len
-                          }
-                          for (const i of idxs) {
-                            out[i * 3] = x
-                            out[i * 3 + 1] = y
-                            out[i * 3 + 2] = z
-                          }
-                        }
-                        geom.setAttribute(
-                          'aDispNormal',
-                          new THREE.BufferAttribute(out, 3)
-                        )
-                      }
-                      // Idempotence guard: skip if the same material has
-                      // already been wired (e.g. shared across child meshes
-                      // or re-encountered after a hot reload). Without this
-                      // a second pass would overwrite onBeforeCompile and
-                      // drop the previous closure.
-                      if (!child.material.userData.dispNormalShaderApplied) {
-                        child.material.userData.dispNormalShaderApplied = true
-                        const previousOnBeforeCompile =
-                          child.material.onBeforeCompile
-                        child.material.onBeforeCompile = (shader, renderer) => {
-                          if (previousOnBeforeCompile) {
-                            previousOnBeforeCompile.call(
-                              child.material,
-                              shader,
-                              renderer
-                            )
-                          }
-                          shader.vertexShader = shader.vertexShader.replace(
-                            '#include <displacementmap_pars_vertex>',
-                            `#include <displacementmap_pars_vertex>
-attribute vec3 aDispNormal;`
-                          )
-                          shader.vertexShader = shader.vertexShader.replace(
-                            '#include <displacementmap_vertex>',
-                            `#ifdef USE_DISPLACEMENTMAP
-	transformed += normalize( aDispNormal ) * ( texture2D( displacementMap, vDisplacementMapUv ).x * displacementScale + displacementBias );
-#endif`
-                          )
-                        }
-                        const previousCacheKey =
-                          child.material.customProgramCacheKey
-                        child.material.customProgramCacheKey = () => {
-                          const prev = previousCacheKey
-                            ? previousCacheKey.call(child.material)
-                            : ''
-                          return prev ? `disp-normal|${prev}` : 'disp-normal'
-                        }
-                      }
+                      // watertight while keeping per-face UVs intact for color
+                      // sampling. Shared with the viewer
+                      // (asset-processor/lib/displacementNormal.js) — both
+                      // helpers are idempotent.
+                      window.modelibrDispNormal.addSharedDisplacementNormal(
+                        THREE,
+                        child.geometry
+                      )
+                      window.modelibrDispNormal.applyDispNormalDisplacement(
+                        child.material
+                      )
                       child.material.needsUpdate = true
                     }
                     if (property === 'normalMap') {

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -1025,7 +1025,20 @@ export class PuppeteerRenderer {
                 const sourceChannel = data.sourceChannel
                 const needsInvert = channels.textureTypeNeedsInvert(textureType)
                 const materialProperty =
-                  channels.resolveMaterialSlot(textureType) || type
+                  channels.resolveMaterialSlot(textureType)
+
+                // No material slot for this type (e.g. the SplitChannel source
+                // placeholder, or a type the shared map doesn't know yet). Drop it
+                // instead of stashing the texture under a junk key — keeps the
+                // color-space classification from mis-firing on a non-slot string.
+                if (!materialProperty) {
+                  console.warn(
+                    `No material slot for texture type ${type}, skipping`
+                  )
+                  texture.dispose()
+                  continue
+                }
+
                 const extracted = channels.channelNeedsExtraction(sourceChannel)
 
                 if (extracted) {

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -857,64 +857,46 @@ export class PuppeteerRenderer {
             const renderer = window.modelRenderer.renderer
             const textureLoader = new THREE.TextureLoader()
 
-            // Map texture type enum values to MeshPhysicalMaterial properties
-            const textureTypeMap = {
-              1: 'map', // Albedo
-              2: 'normalMap',
-              3: 'displacementMap', // Height
-              4: 'aoMap',
-              5: 'roughnessMap',
-              6: 'metalnessMap',
-              7: 'map', // Diffuse (legacy)
-              8: 'specularColorMap', // Specular (MeshPhysicalMaterial)
-              9: 'emissiveMap', // Emissive
-              10: 'bumpMap', // Bump
-              11: 'alphaMap', // Alpha
-              12: 'displacementMap', // Displacement
-              Albedo: 'map',
-              Normal: 'normalMap',
-              Height: 'displacementMap',
-              AO: 'aoMap',
-              Roughness: 'roughnessMap',
-              Metallic: 'metalnessMap',
-              Diffuse: 'map',
-              Specular: 'specularColorMap',
-              BaseColor: 'map',
-              AmbientOcclusion: 'aoMap',
-              Emissive: 'emissiveMap',
-              Bump: 'bumpMap',
-              Alpha: 'alphaMap',
-              Displacement: 'displacementMap',
+            // Shared cross-runtime texture-type → material-slot map and
+            // channel-extraction shaders (asset-processor/lib/textureChannels.js,
+            // reached via the window side-effect because this runs as a classic
+            // page.evaluate script). Single source of truth with the viewer: the
+            // slot map, the extraction GLSL, the 0-based channel numbering, and
+            // the Glossiness-invert rule all live there now.
+            const channels = window.modelibrTextureChannels
+
+            // Extract a single channel (R/G/B/A) to a grayscale texture, with
+            // optional value inversion (Glossiness → Roughness). Render-to-target
+            // orchestration stays per-runtime; the shader + channel index are shared.
+            function extractChannel(sourceTexture, sourceChannel, invert) {
+              return renderToGrayscale(sourceTexture, {
+                fragmentShader: channels.CHANNEL_EXTRACT_FRAGMENT_SHADER,
+                uniforms: {
+                  uTexture: { value: sourceTexture },
+                  uChannel: {
+                    value: channels.getChannelUniformIndex(sourceChannel),
+                  },
+                  uInvert: { value: invert ? 1 : 0 },
+                },
+              })
             }
 
-            // Channel extraction shader
-            const extractChannelShader = {
-              vertexShader: `
-                varying vec2 vUv;
-                void main() {
-                  vUv = uv;
-                  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-                }
-              `,
-              fragmentShader: `
-                uniform sampler2D sourceTexture;
-                uniform int channel; // 1=R, 2=G, 3=B, 4=A
-                varying vec2 vUv;
-                void main() {
-                  vec4 texColor = texture2D(sourceTexture, vUv);
-                  float value;
-                  if (channel == 1) value = texColor.r;
-                  else if (channel == 2) value = texColor.g;
-                  else if (channel == 3) value = texColor.b;
-                  else if (channel == 4) value = texColor.a;
-                  else value = texColor.r; // Default to R
-                  gl_FragColor = vec4(value, value, value, 1.0);
-                }
-              `,
+            // Invert a full-RGB texture (Glossiness stored as RGB grayscale that
+            // must be flipped to behave as roughness).
+            function invertRgbTexture(sourceTexture) {
+              return renderToGrayscale(sourceTexture, {
+                fragmentShader: channels.RGB_INVERT_FRAGMENT_SHADER,
+                uniforms: { uTexture: { value: sourceTexture } },
+              })
             }
 
-            // Function to extract a single channel to grayscale texture
-            function extractChannel(sourceTexture, channelIndex) {
+            // Shared render-to-target plumbing for the channel passes above. The
+            // passthrough vertex shader writes clip-space directly from the unit
+            // quad, so the ortho camera setup is irrelevant.
+            function renderToGrayscale(
+              sourceTexture,
+              { fragmentShader, uniforms }
+            ) {
               const size = 512 // Output texture size
               const renderTarget = new THREE.WebGLRenderTarget(size, size, {
                 minFilter: THREE.LinearFilter,
@@ -923,16 +905,12 @@ export class PuppeteerRenderer {
               })
 
               const scene = new THREE.Scene()
-              const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10)
-              camera.position.z = 1
+              const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
 
               const material = new THREE.ShaderMaterial({
-                uniforms: {
-                  sourceTexture: { value: sourceTexture },
-                  channel: { value: channelIndex },
-                },
-                vertexShader: extractChannelShader.vertexShader,
-                fragmentShader: extractChannelShader.fragmentShader,
+                uniforms,
+                vertexShader: channels.CHANNEL_VERTEX_SHADER,
+                fragmentShader,
               })
 
               const geometry = new THREE.PlaneGeometry(2, 2)
@@ -943,17 +921,17 @@ export class PuppeteerRenderer {
               renderer.render(scene, camera)
               renderer.setRenderTarget(null)
 
-              const extractedTexture = renderTarget.texture
-              extractedTexture.wrapS = sourceTexture.wrapS
-              extractedTexture.wrapT = sourceTexture.wrapT
-              extractedTexture.flipY = sourceTexture.flipY
-              extractedTexture.needsUpdate = true
+              const outputTexture = renderTarget.texture
+              outputTexture.wrapS = sourceTexture.wrapS
+              outputTexture.wrapT = sourceTexture.wrapT
+              outputTexture.flipY = sourceTexture.flipY
+              outputTexture.needsUpdate = true
 
               // Cleanup
               geometry.dispose()
               material.dispose()
 
-              return extractedTexture
+              return outputTexture
             }
 
             // Load standard texture via TextureLoader from HTTP URL
@@ -1029,13 +1007,6 @@ export class PuppeteerRenderer {
               return texture
             }
 
-            // Texture types that carry color data (need sRGB color space)
-            const colorTextureProps = new Set([
-              'map',
-              'emissiveMap',
-              'specularColorMap',
-            ])
-
             const loadedTextures = {}
             for (const [type, data] of Object.entries(textures)) {
               try {
@@ -1047,22 +1018,31 @@ export class PuppeteerRenderer {
                 } else {
                   texture = await loadTexture(data.url, shouldFlipY)
                 }
-                const sourceChannel = data.sourceChannel
 
-                // Extract channel if not RGB (0)
-                if (sourceChannel > 0 && sourceChannel <= 4) {
+                // Object.entries keys are strings; the shared Set lookups key on
+                // the numeric enum value, so coerce.
+                const textureType = Number(type)
+                const sourceChannel = data.sourceChannel
+                const needsInvert = channels.textureTypeNeedsInvert(textureType)
+                const materialProperty =
+                  channels.resolveMaterialSlot(textureType) || type
+                const extracted = channels.channelNeedsExtraction(sourceChannel)
+
+                if (extracted) {
+                  // Single channel (R/G/B/A) → grayscale, inverted for Glossiness.
                   console.log(`Extracting channel ${sourceChannel} for ${type}`)
-                  texture = extractChannel(texture, sourceChannel)
-                  // For grayscale textures, use linear color space
-                  texture.colorSpace = THREE.LinearSRGBColorSpace
+                  texture = extractChannel(texture, sourceChannel, needsInvert)
+                } else if (needsInvert) {
+                  // Glossiness stored as RGB → flip so it behaves as roughness.
+                  console.log(`Inverting RGB glossiness for ${type}`)
+                  texture = invertRgbTexture(texture)
                 }
 
-                const materialProperty = textureTypeMap[type] || type
-
-                // Set correct color space: sRGB for color textures, linear for data textures
-                if (sourceChannel > 0 && sourceChannel <= 4) {
+                // Color space: extracted/inverted data maps are linear; otherwise
+                // sRGB for color slots, linear for data slots (shared rule).
+                if (extracted || needsInvert) {
                   texture.colorSpace = THREE.LinearSRGBColorSpace
-                } else if (colorTextureProps.has(materialProperty)) {
+                } else if (channels.slotIsColorData(materialProperty)) {
                   texture.colorSpace = THREE.SRGBColorSpace
                 } else {
                   texture.colorSpace = THREE.LinearSRGBColorSpace
@@ -1070,7 +1050,7 @@ export class PuppeteerRenderer {
 
                 loadedTextures[materialProperty] = texture
                 console.log(
-                  `Loaded ${type} -> ${materialProperty} (channel: ${sourceChannel}, exr: ${!!data.isExr}, tiff: ${!!data.isTiff})`
+                  `Loaded ${type} -> ${materialProperty} (channel: ${sourceChannel}, invert: ${needsInvert}, exr: ${!!data.isExr}, tiff: ${!!data.isTiff})`
                 )
               } catch (error) {
                 console.warn(`Failed to load ${type} texture:`, error)

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -1093,12 +1093,11 @@ export class PuppeteerRenderer {
                 }
                 meshCount++
 
-                // AO maps require a second UV set — copy uv to uv2
-                if (loadedTextures.aoMap && child.geometry) {
-                  const uvAttr = child.geometry.getAttribute('uv')
-                  if (uvAttr) {
-                    child.geometry.setAttribute('uv2', uvAttr.clone())
-                  }
+                // AO maps require a second UV set — copy uv to uv2. Shared with
+                // the viewer (asset-processor/lib/textureMaterial.js) so both
+                // runtimes light AO-mapped models identically.
+                if (loadedTextures.aoMap) {
+                  window.modelibrTextureMaterial.ensureAoMapUv2(child.geometry)
                 }
 
                 // Preserve original material name for subsequent per-material calls
@@ -1106,20 +1105,25 @@ export class PuppeteerRenderer {
                   ? child.material[0]?.name || ''
                   : child.material?.name || ''
 
-                // Create new material with white base color for textures.
-                // specularIntensity defaults to 1 on MeshPhysicalMaterial,
-                // which adds a dielectric sheen even without a Specular map
-                // and visibly washes the albedo. Disable it unless a real
-                // specularColorMap is present.
+                // Material config from the shared gating rule (metalness/
+                // roughness/specular keyed on their own maps, not the base-color
+                // map). Same source of truth as the viewer.
+                const matCfg =
+                  window.modelibrTextureMaterial.resolveTextureMaterialConfig({
+                    baseColorMap: loadedTextures.map,
+                    metalnessMap: loadedTextures.metalnessMap,
+                    roughnessMap: loadedTextures.roughnessMap,
+                    specularColorMap: loadedTextures.specularColorMap,
+                  })
                 child.material = new THREE.MeshPhysicalMaterial({
                   name: originalName,
-                  color: loadedTextures.map
+                  color: matCfg.hasBaseColorMap
                     ? 0xffffff
                     : new THREE.Color(0.7, 0.7, 0.9),
-                  metalness: loadedTextures.metalnessMap ? 1 : 0,
-                  roughness: loadedTextures.roughnessMap ? 1 : 0.8,
-                  envMapIntensity: 1.0,
-                  specularIntensity: loadedTextures.specularColorMap ? 1 : 0,
+                  metalness: matCfg.metalness,
+                  roughness: matCfg.roughness,
+                  envMapIntensity: matCfg.envMapIntensity,
+                  specularIntensity: matCfg.specularIntensity,
                 })
 
                 // Apply each loaded texture with proper material settings

--- a/src/asset-processor/render-template.html
+++ b/src/asset-processor/render-template.html
@@ -59,6 +59,16 @@
       import * as BufferGeometryUtils from 'three/addons/utils/BufferGeometryUtils.js'
       import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js'
       import { buildStlModel } from './lib/stlMesh.js'
+      import {
+        DEFAULT_LIGHTING,
+        ENVIRONMENT_PREVIEW_LIGHTING,
+        buildSceneLights,
+      } from './lib/sceneLighting.js'
+      // Loaded for its window.modelibrTextureMaterial side-effect: the
+      // applyTextures page.evaluate (puppeteerRenderer.js) runs as a classic
+      // script and can't import, so it reaches the shared texture-material rules
+      // through the window global. Single source of truth with the viewer.
+      import './lib/textureMaterial.js'
 
       // Global state for external control
       window.modelRenderer = {
@@ -72,7 +82,7 @@
         disposableMaterials: [],
         disposableGeometries: [],
         defaultEnvironment: null,
-        defaultEnvironmentIntensity: 0.3,
+        defaultEnvironmentIntensity: DEFAULT_LIGHTING.environmentIntensity,
         lights: null,
         orbitMode: 'model',
         isReady: false,
@@ -157,40 +167,22 @@
 
         container.appendChild(renderer.domElement)
 
-        // Setup lighting — balanced to avoid overexposure on PBR materials
-        const ambientLight = new THREE.AmbientLight(0xffffff, 0.35)
-        scene.add(ambientLight)
-
-        // Main directional light from front-right
-        const directionalLight = new THREE.DirectionalLight(0xffffff, 0.45)
-        directionalLight.position.set(20, 15, 20)
-        directionalLight.castShadow = true
-        directionalLight.shadow.mapSize.width = 2048
-        directionalLight.shadow.mapSize.height = 2048
-        scene.add(directionalLight)
-
-        // Fill light from opposite side to reduce hard shadows
-        const pointLight = new THREE.PointLight(0xffffff, 0.2)
-        pointLight.position.set(-15, 5, -15)
-        scene.add(pointLight)
-
-        // Top light for soft fill
-        const spotLight = new THREE.SpotLight(0xffffff, 0.25)
-        spotLight.position.set(0, 20, 0)
-        spotLight.angle = 0.4
-        spotLight.penumbra = 1
-        spotLight.castShadow = true
-        scene.add(spotLight)
+        // Setup lighting from the shared cross-runtime rig (lib/sceneLighting.js)
+        // so the thumbnail and the in-app viewer light models identically.
+        // Balanced to avoid overexposure on PBR materials.
+        const lights = buildSceneLights(THREE, DEFAULT_LIGHTING)
+        scene.add(...lights.lights)
 
         // IBL via PMREMGenerator + neutral studio environment
-        // environmentIntensity is kept low so PBR model thumbnails are not overexposed;
-        // direct lights above carry the primary illumination.
+        // environmentIntensity is kept low (DEFAULT_LIGHTING) so PBR model
+        // thumbnails are not overexposed; direct lights carry the primary
+        // illumination.
         const pmremGenerator = new THREE.PMREMGenerator(renderer)
         pmremGenerator.compileEquirectangularShader()
         const roomEnv = new RoomEnvironment(renderer)
         const envMap = pmremGenerator.fromScene(roomEnv).texture
         scene.environment = envMap
-        scene.environmentIntensity = 0.3
+        scene.environmentIntensity = DEFAULT_LIGHTING.environmentIntensity
         roomEnv.dispose()
 
         window.modelRenderer.scene = scene
@@ -198,12 +190,13 @@
         window.modelRenderer.renderer = renderer
         window.modelRenderer.pmremGenerator = pmremGenerator
         window.modelRenderer.defaultEnvironment = envMap
-        window.modelRenderer.defaultEnvironmentIntensity = 0.3
+        window.modelRenderer.defaultEnvironmentIntensity =
+          DEFAULT_LIGHTING.environmentIntensity
         window.modelRenderer.lights = {
-          ambient: ambientLight,
-          directional: directionalLight,
-          point: pointLight,
-          spot: spotLight,
+          ambient: lights.ambient,
+          directional: lights.directional,
+          point: lights.point,
+          spot: lights.spot,
         }
 
         return true
@@ -274,10 +267,10 @@
 
         const lights = window.modelRenderer.lights
         if (lights) {
-          lights.ambient.intensity = 0.35
-          lights.directional.intensity = 0.45
-          lights.point.intensity = 0.2
-          lights.spot.intensity = 0.25
+          lights.ambient.intensity = DEFAULT_LIGHTING.ambient.intensity
+          lights.directional.intensity = DEFAULT_LIGHTING.directional.intensity
+          lights.point.intensity = DEFAULT_LIGHTING.point.intensity
+          lights.spot.intensity = DEFAULT_LIGHTING.spot.intensity
         }
       }
 
@@ -285,10 +278,10 @@
         const lights = window.modelRenderer.lights
         if (!lights) return
 
-        lights.ambient.intensity = 0.06
-        lights.directional.intensity = 0.12
-        lights.point.intensity = 0.05
-        lights.spot.intensity = 0.08
+        lights.ambient.intensity = ENVIRONMENT_PREVIEW_LIGHTING.ambient
+        lights.directional.intensity = ENVIRONMENT_PREVIEW_LIGHTING.directional
+        lights.point.intensity = ENVIRONMENT_PREVIEW_LIGHTING.point
+        lights.spot.intensity = ENVIRONMENT_PREVIEW_LIGHTING.spot
       }
 
       function createEnvironmentSphere(options = {}) {

--- a/src/asset-processor/render-template.html
+++ b/src/asset-processor/render-template.html
@@ -64,11 +64,13 @@
         ENVIRONMENT_PREVIEW_LIGHTING,
         buildSceneLights,
       } from './lib/sceneLighting.js'
-      // Loaded for its window.modelibrTextureMaterial side-effect: the
-      // applyTextures page.evaluate (puppeteerRenderer.js) runs as a classic
-      // script and can't import, so it reaches the shared texture-material rules
-      // through the window global. Single source of truth with the viewer.
+      // Loaded for their window side-effects: the applyTextures page.evaluate
+      // (puppeteerRenderer.js) runs as a classic script and can't import, so it
+      // reaches these shared rules through window globals
+      // (window.modelibrTextureMaterial / window.modelibrDispNormal). Single
+      // source of truth with the viewer.
       import './lib/textureMaterial.js'
+      import './lib/displacementNormal.js'
 
       // Global state for external control
       window.modelRenderer = {

--- a/src/asset-processor/render-template.html
+++ b/src/asset-processor/render-template.html
@@ -67,10 +67,11 @@
       // Loaded for their window side-effects: the applyTextures page.evaluate
       // (puppeteerRenderer.js) runs as a classic script and can't import, so it
       // reaches these shared rules through window globals
-      // (window.modelibrTextureMaterial / window.modelibrDispNormal). Single
-      // source of truth with the viewer.
+      // (window.modelibrTextureMaterial / window.modelibrDispNormal /
+      // window.modelibrTextureChannels). Single source of truth with the viewer.
       import './lib/textureMaterial.js'
       import './lib/displacementNormal.js'
+      import './lib/textureChannels.js'
 
       // Global state for external control
       window.modelRenderer = {

--- a/src/frontend/src/features/model-viewer/__tests__/sceneLighting.test.ts
+++ b/src/frontend/src/features/model-viewer/__tests__/sceneLighting.test.ts
@@ -1,0 +1,143 @@
+import * as THREE from 'three'
+
+import {
+  buildSceneLights,
+  DEFAULT_LIGHTING,
+  resolveSceneLighting,
+} from '../../../../../asset-processor/lib/sceneLighting.js'
+
+/**
+ * Tests for the shared cross-runtime light rig (asset-processor/lib).
+ *
+ * The bug these guard against: the viewer used to stack drei <Stage>'s lights
+ * on top of a manual rig, so the ambient/directional/environment controls were
+ * swamped and "did nothing". The fix routes every control through this single
+ * rig. So the meaningful contract is: turning a control up must put more light
+ * into the scene (a lighter surface), and the values must reach the actual
+ * THREE light objects the renderer shades with.
+ *
+ * We assert on intensities rather than rendered pixels because THREE's lighting
+ * is monotonic in these values: every term is a non-negative additive light
+ * contribution, so a strictly larger total is a strictly brighter (lighter)
+ * result for any material — without needing a GPU/WebGL in jsdom.
+ */
+
+/**
+ * Sum of every additive light contribution in a resolved rig. A faithful,
+ * deliberately simple proxy for "how bright is the scene": THREE adds ambient,
+ * each direct light's contribution, and the IBL (environmentIntensity) together,
+ * so more total here == a lighter pixel.
+ */
+function totalSceneLight(descriptor: ReturnType<typeof resolveSceneLighting>) {
+  return (
+    descriptor.ambient.intensity +
+    descriptor.directional.intensity +
+    descriptor.point.intensity +
+    descriptor.spot.intensity +
+    descriptor.environmentIntensity
+  )
+}
+
+describe('resolveSceneLighting', () => {
+  it('returns the canonical rig when no settings are given (viewer default == thumbnail)', () => {
+    const rig = resolveSceneLighting()
+
+    expect(rig.ambient.intensity).toBe(DEFAULT_LIGHTING.ambient.intensity)
+    expect(rig.directional.intensity).toBe(
+      DEFAULT_LIGHTING.directional.intensity
+    )
+    expect(rig.point.intensity).toBe(DEFAULT_LIGHTING.point.intensity)
+    expect(rig.spot.intensity).toBe(DEFAULT_LIGHTING.spot.intensity)
+    expect(rig.environmentIntensity).toBe(DEFAULT_LIGHTING.environmentIntensity)
+  })
+
+  it('treats ambientIntensity as an absolute value and makes the scene lighter when raised', () => {
+    const dim = resolveSceneLighting({ ambientIntensity: 0.2 })
+    const bright = resolveSceneLighting({ ambientIntensity: 0.8 })
+
+    expect(bright.ambient.intensity).toBeGreaterThan(dim.ambient.intensity)
+    expect(bright.ambient.intensity).toBe(0.8)
+    // The whole scene gets lighter, and only the ambient term changed.
+    expect(totalSceneLight(bright)).toBeGreaterThan(totalSceneLight(dim))
+  })
+
+  it('treats environmentIntensity as an absolute value and makes the scene lighter when raised', () => {
+    const dim = resolveSceneLighting({ environmentIntensity: 0.1 })
+    const bright = resolveSceneLighting({ environmentIntensity: 1.5 })
+
+    expect(bright.environmentIntensity).toBeGreaterThan(
+      dim.environmentIntensity
+    )
+    expect(bright.environmentIntensity).toBe(1.5)
+    expect(totalSceneLight(bright)).toBeGreaterThan(totalSceneLight(dim))
+  })
+
+  it('treats directionalIntensity as a multiplier scaling the whole directional triplet', () => {
+    const base = resolveSceneLighting({ directionalIntensity: 1 })
+    const doubled = resolveSceneLighting({ directionalIntensity: 2 })
+
+    expect(doubled.directional.intensity).toBeCloseTo(
+      base.directional.intensity * 2
+    )
+    expect(doubled.point.intensity).toBeCloseTo(base.point.intensity * 2)
+    expect(doubled.spot.intensity).toBeCloseTo(base.spot.intensity * 2)
+    // Ambient and environment are independent of the directional control.
+    expect(doubled.ambient.intensity).toBe(base.ambient.intensity)
+    expect(doubled.environmentIntensity).toBe(base.environmentIntensity)
+    expect(totalSceneLight(doubled)).toBeGreaterThan(totalSceneLight(base))
+  })
+
+  it('turning every control to zero produces a fully dark rig (no hidden baked-in light)', () => {
+    const dark = resolveSceneLighting({
+      ambientIntensity: 0,
+      directionalIntensity: 0,
+      environmentIntensity: 0,
+    })
+
+    expect(totalSceneLight(dark)).toBe(0)
+  })
+})
+
+describe('buildSceneLights', () => {
+  it('builds exactly the four canonical lights — no extras (guards against re-stacking a second rig)', () => {
+    const rig = buildSceneLights(THREE, DEFAULT_LIGHTING)
+
+    expect(rig.lights).toHaveLength(4)
+    expect(rig.ambient).toBeInstanceOf(THREE.AmbientLight)
+    expect(rig.directional).toBeInstanceOf(THREE.DirectionalLight)
+    expect(rig.point).toBeInstanceOf(THREE.PointLight)
+    expect(rig.spot).toBeInstanceOf(THREE.SpotLight)
+  })
+
+  it('passes the resolved intensities through to the real THREE light objects the renderer shades with', () => {
+    const resolved = resolveSceneLighting({
+      ambientIntensity: 0.9,
+      directionalIntensity: 2,
+    })
+    const rig = buildSceneLights(THREE, resolved)
+
+    // What the user dialed in is exactly what reaches the renderer.
+    expect(rig.ambient.intensity).toBe(0.9)
+    expect(rig.directional.intensity).toBeCloseTo(
+      DEFAULT_LIGHTING.directional.intensity * 2
+    )
+  })
+
+  it('configures positions, shadows and spot cone from the descriptor', () => {
+    const rig = buildSceneLights(THREE, DEFAULT_LIGHTING)
+
+    expect(rig.directional.position.toArray()).toEqual(
+      DEFAULT_LIGHTING.directional.position
+    )
+    expect(rig.directional.castShadow).toBe(true)
+    expect(rig.directional.shadow.mapSize.width).toBe(
+      DEFAULT_LIGHTING.directional.shadowMapSize
+    )
+    expect(rig.spot.angle).toBe(DEFAULT_LIGHTING.spot.angle)
+    expect(rig.spot.penumbra).toBe(DEFAULT_LIGHTING.spot.penumbra)
+    expect(rig.spot.castShadow).toBe(true)
+    expect(rig.point.position.toArray()).toEqual(
+      DEFAULT_LIGHTING.point.position
+    )
+  })
+})

--- a/src/frontend/src/features/model-viewer/__tests__/textureChannels.test.ts
+++ b/src/frontend/src/features/model-viewer/__tests__/textureChannels.test.ts
@@ -29,6 +29,7 @@ describe('shared TextureType enum mirror', () => {
   // frontend TextureType) ever renumbers, this fails instead of silently
   // mis-routing textures across runtimes.
   it('matches the frontend TextureType enum value-for-value', () => {
+    expect(TEXTURE_TYPE.SplitChannel).toBe(TextureType.SplitChannel)
     expect(TEXTURE_TYPE.Albedo).toBe(TextureType.Albedo)
     expect(TEXTURE_TYPE.Normal).toBe(TextureType.Normal)
     expect(TEXTURE_TYPE.Height).toBe(TextureType.Height)

--- a/src/frontend/src/features/model-viewer/__tests__/textureChannels.test.ts
+++ b/src/frontend/src/features/model-viewer/__tests__/textureChannels.test.ts
@@ -1,0 +1,151 @@
+import { TextureChannel, TextureType } from '@/types'
+
+import {
+  CHANNEL_EXTRACT_FRAGMENT_SHADER,
+  CHANNEL_VERTEX_SHADER,
+  channelNeedsExtraction,
+  getChannelUniformIndex,
+  MATERIAL_SLOT_BY_TEXTURE_TYPE,
+  resolveMaterialSlot,
+  RGB_INVERT_FRAGMENT_SHADER,
+  slotIsColorData,
+  TEXTURE_TYPE,
+  textureTypeNeedsInvert,
+} from '../../../../../asset-processor/lib/textureChannels.js'
+
+/**
+ * Locks the shared texture-type → material-slot map and channel-extraction
+ * contract that the frontend viewer and the worker thumbnail both consume.
+ *
+ * Two real drifts this guards against:
+ *  - the worker slot map had no Glossiness entry, so a Glossiness map (inverted
+ *    roughness) was silently dropped in the thumbnail while the viewer applied
+ *    it as an inverted roughnessMap;
+ *  - the two channel-extraction shaders used different channel numbering
+ *    (frontend 0-based `uChannel`, worker 1-based `channel`).
+ */
+describe('shared TextureType enum mirror', () => {
+  // If the API enum (Domain/ValueObjects/TextureType.cs, mirrored in the
+  // frontend TextureType) ever renumbers, this fails instead of silently
+  // mis-routing textures across runtimes.
+  it('matches the frontend TextureType enum value-for-value', () => {
+    expect(TEXTURE_TYPE.Albedo).toBe(TextureType.Albedo)
+    expect(TEXTURE_TYPE.Normal).toBe(TextureType.Normal)
+    expect(TEXTURE_TYPE.Height).toBe(TextureType.Height)
+    expect(TEXTURE_TYPE.AO).toBe(TextureType.AO)
+    expect(TEXTURE_TYPE.Roughness).toBe(TextureType.Roughness)
+    expect(TEXTURE_TYPE.Metallic).toBe(TextureType.Metallic)
+    expect(TEXTURE_TYPE.Specular).toBe(TextureType.Specular)
+    expect(TEXTURE_TYPE.Emissive).toBe(TextureType.Emissive)
+    expect(TEXTURE_TYPE.Bump).toBe(TextureType.Bump)
+    expect(TEXTURE_TYPE.Alpha).toBe(TextureType.Alpha)
+    expect(TEXTURE_TYPE.Displacement).toBe(TextureType.Displacement)
+    expect(TEXTURE_TYPE.Glossiness).toBe(TextureType.Glossiness)
+  })
+})
+
+describe('MATERIAL_SLOT_BY_TEXTURE_TYPE / resolveMaterialSlot', () => {
+  it('routes each texture type to the expected MeshPhysicalMaterial slot', () => {
+    expect(resolveMaterialSlot(TextureType.Albedo)).toBe('map')
+    expect(resolveMaterialSlot(TextureType.Normal)).toBe('normalMap')
+    expect(resolveMaterialSlot(TextureType.AO)).toBe('aoMap')
+    expect(resolveMaterialSlot(TextureType.Roughness)).toBe('roughnessMap')
+    expect(resolveMaterialSlot(TextureType.Metallic)).toBe('metalnessMap')
+    expect(resolveMaterialSlot(TextureType.Specular)).toBe('specularColorMap')
+    expect(resolveMaterialSlot(TextureType.Emissive)).toBe('emissiveMap')
+    expect(resolveMaterialSlot(TextureType.Bump)).toBe('bumpMap')
+    expect(resolveMaterialSlot(TextureType.Alpha)).toBe('alphaMap')
+  })
+
+  it('feeds both Height and Displacement into displacementMap', () => {
+    expect(resolveMaterialSlot(TextureType.Height)).toBe('displacementMap')
+    expect(resolveMaterialSlot(TextureType.Displacement)).toBe(
+      'displacementMap'
+    )
+  })
+
+  it('feeds both Roughness and Glossiness into roughnessMap (the dropped-glossiness drift)', () => {
+    expect(resolveMaterialSlot(TextureType.Roughness)).toBe('roughnessMap')
+    expect(resolveMaterialSlot(TextureType.Glossiness)).toBe('roughnessMap')
+  })
+
+  it('has no slot for the SplitChannel source placeholder or unknown types', () => {
+    expect(resolveMaterialSlot(TextureType.SplitChannel)).toBeNull()
+    expect(resolveMaterialSlot(999)).toBeNull()
+  })
+})
+
+describe('textureTypeNeedsInvert', () => {
+  it('inverts Glossiness (it is inverted roughness) and nothing else', () => {
+    expect(textureTypeNeedsInvert(TextureType.Glossiness)).toBe(true)
+    expect(textureTypeNeedsInvert(TextureType.Roughness)).toBe(false)
+    expect(textureTypeNeedsInvert(TextureType.Albedo)).toBe(false)
+    expect(textureTypeNeedsInvert(TextureType.Height)).toBe(false)
+  })
+})
+
+describe('slotIsColorData', () => {
+  it('treats only the color slots as sRGB; data maps stay linear', () => {
+    expect(slotIsColorData('map')).toBe(true)
+    expect(slotIsColorData('emissiveMap')).toBe(true)
+    expect(slotIsColorData('specularColorMap')).toBe(true)
+    expect(slotIsColorData('normalMap')).toBe(false)
+    expect(slotIsColorData('roughnessMap')).toBe(false)
+    expect(slotIsColorData('aoMap')).toBe(false)
+    expect(slotIsColorData('displacementMap')).toBe(false)
+  })
+})
+
+describe('getChannelUniformIndex', () => {
+  it('maps the TextureChannel enum to the 0-based shader index', () => {
+    expect(getChannelUniformIndex(TextureChannel.R)).toBe(0)
+    expect(getChannelUniformIndex(TextureChannel.G)).toBe(1)
+    expect(getChannelUniformIndex(TextureChannel.B)).toBe(2)
+    expect(getChannelUniformIndex(TextureChannel.A)).toBe(3)
+  })
+
+  it('falls back to 0 for RGB / non-channel values (the caller should not extract)', () => {
+    expect(getChannelUniformIndex(TextureChannel.RGB)).toBe(0)
+    expect(getChannelUniformIndex(0)).toBe(0)
+  })
+})
+
+describe('channelNeedsExtraction', () => {
+  it('is true only for the single channels R/G/B/A', () => {
+    expect(channelNeedsExtraction(TextureChannel.R)).toBe(true)
+    expect(channelNeedsExtraction(TextureChannel.G)).toBe(true)
+    expect(channelNeedsExtraction(TextureChannel.B)).toBe(true)
+    expect(channelNeedsExtraction(TextureChannel.A)).toBe(true)
+  })
+
+  it('is false for RGB and the legacy 0 (no extraction)', () => {
+    expect(channelNeedsExtraction(TextureChannel.RGB)).toBe(false)
+    expect(channelNeedsExtraction(0)).toBe(false)
+  })
+})
+
+describe('channel-extraction shaders', () => {
+  // The frontend hook and the worker page.evaluate bind these exact uniform
+  // names; a rename here without updating both call sites would silently break
+  // extraction, so pin the contract.
+  it('the extraction fragment shader exposes uTexture / uChannel / uInvert', () => {
+    expect(CHANNEL_EXTRACT_FRAGMENT_SHADER).toContain(
+      'uniform sampler2D uTexture'
+    )
+    expect(CHANNEL_EXTRACT_FRAGMENT_SHADER).toContain('uniform int uChannel')
+    expect(CHANNEL_EXTRACT_FRAGMENT_SHADER).toContain('uniform int uInvert')
+  })
+
+  it('the RGB-invert fragment shader inverts rgb and keeps alpha', () => {
+    expect(RGB_INVERT_FRAGMENT_SHADER).toContain('1.0 - texColor.rgb')
+  })
+
+  it('the vertex shader is a fullscreen-quad passthrough (camera-independent)', () => {
+    expect(CHANNEL_VERTEX_SHADER).toContain('gl_Position = vec4(position, 1.0)')
+    expect(CHANNEL_VERTEX_SHADER).toContain('vUv = uv')
+  })
+
+  it('keeps the slot map frozen against accidental mutation', () => {
+    expect(Object.isFrozen(MATERIAL_SLOT_BY_TEXTURE_TYPE)).toBe(true)
+  })
+})

--- a/src/frontend/src/features/model-viewer/__tests__/textureMaterial.test.ts
+++ b/src/frontend/src/features/model-viewer/__tests__/textureMaterial.test.ts
@@ -1,0 +1,125 @@
+import {
+  ensureAoMapUv2,
+  resolveTextureMaterialConfig,
+} from '../../../../../asset-processor/lib/textureMaterial.js'
+
+/** Minimal geometry stub exposing the get/setAttribute surface the helper uses. */
+function fakeGeometry(initial: Record<string, { clone: () => unknown }> = {}) {
+  const attrs: Record<string, unknown> = { ...initial }
+  return {
+    attrs,
+    setCalls: [] as string[],
+    getAttribute(name: string) {
+      return attrs[name] ?? undefined
+    },
+    setAttribute(name: string, value: unknown) {
+      attrs[name] = value
+      this.setCalls.push(name)
+    },
+  }
+}
+
+/**
+ * Locks the texture-set → material gating rule shared by the worker thumbnail
+ * and the frontend viewer.
+ *
+ * The regression this guards against: the viewer once gated metalness on the
+ * base-color map, so a textured surface with no metalness map became fully
+ * metallic — a black mirror lit only by the environment, while the worker
+ * thumbnail rendered it correctly as a dielectric. The first test below is the
+ * direct guard.
+ */
+describe('resolveTextureMaterialConfig', () => {
+  it('a base-color map alone does NOT make the material metallic (the drift bug)', () => {
+    const cfg = resolveTextureMaterialConfig({ baseColorMap: {} })
+
+    expect(cfg.hasBaseColorMap).toBe(true)
+    // Dielectric — responds to ambient/direct/IBL like the thumbnail does.
+    expect(cfg.metalness).toBe(0)
+    expect(cfg.roughness).toBe(0.8)
+  })
+
+  it('is fully dielectric and matte with no maps present', () => {
+    const cfg = resolveTextureMaterialConfig()
+
+    expect(cfg.hasBaseColorMap).toBe(false)
+    expect(cfg.metalness).toBe(0)
+    expect(cfg.roughness).toBe(0.8)
+    expect(cfg.specularIntensity).toBe(0)
+    expect(cfg.envMapIntensity).toBe(1.0)
+  })
+
+  it('becomes metallic only when a metalness map is present', () => {
+    expect(resolveTextureMaterialConfig({ metalnessMap: {} }).metalness).toBe(1)
+    expect(
+      resolveTextureMaterialConfig({ baseColorMap: {}, metalnessMap: {} })
+        .metalness
+    ).toBe(1)
+  })
+
+  it('lets a roughness map drive roughness (1), else stays matte (0.8)', () => {
+    expect(resolveTextureMaterialConfig({ roughnessMap: {} }).roughness).toBe(1)
+    expect(resolveTextureMaterialConfig({ baseColorMap: {} }).roughness).toBe(
+      0.8
+    )
+  })
+
+  it('enables the specular channel only with a specular-color map', () => {
+    expect(resolveTextureMaterialConfig().specularIntensity).toBe(0)
+    expect(
+      resolveTextureMaterialConfig({ specularColorMap: {} }).specularIntensity
+    ).toBe(1)
+  })
+
+  it('treats null/undefined map slots as absent', () => {
+    const cfg = resolveTextureMaterialConfig({
+      baseColorMap: null,
+      metalnessMap: undefined,
+      roughnessMap: null,
+    })
+
+    expect(cfg.hasBaseColorMap).toBe(false)
+    expect(cfg.metalness).toBe(0)
+    expect(cfg.roughness).toBe(0.8)
+  })
+})
+
+/**
+ * Locks the AO → uv2 setup. Without it an AO map collapses all indirect light
+ * (ambient + environment IBL) in the viewer, so those controls looked inert
+ * while directional still worked.
+ */
+describe('ensureAoMapUv2', () => {
+  it('copies uv -> uv2 when a geometry only has uv (so AO samples correctly)', () => {
+    const cloned = { cloned: true }
+    const geometry = fakeGeometry({ uv: { clone: () => cloned } })
+
+    ensureAoMapUv2(geometry as never)
+
+    expect(geometry.attrs.uv2).toBe(cloned)
+  })
+
+  it('is idempotent — does not overwrite an existing uv2', () => {
+    const geometry = fakeGeometry({
+      uv: { clone: () => ({}) },
+      uv2: { clone: () => ({}) },
+    })
+
+    ensureAoMapUv2(geometry as never)
+
+    expect(geometry.setCalls).toHaveLength(0)
+  })
+
+  it('is a no-op when there is no uv to copy', () => {
+    const geometry = fakeGeometry()
+
+    ensureAoMapUv2(geometry as never)
+
+    expect(geometry.attrs.uv2).toBeUndefined()
+    expect(geometry.setCalls).toHaveLength(0)
+  })
+
+  it('safely ignores a null geometry', () => {
+    expect(() => ensureAoMapUv2(null as never)).not.toThrow()
+  })
+})

--- a/src/frontend/src/features/model-viewer/__tests__/texturedModelMaterial.test.ts
+++ b/src/frontend/src/features/model-viewer/__tests__/texturedModelMaterial.test.ts
@@ -1,0 +1,113 @@
+import * as THREE from 'three'
+
+import type { TextureSetDto } from '@/types'
+
+import {
+  applyMaterialTextures,
+  buildMaterialFromTextures,
+} from '../components/materialTextures'
+
+/**
+ * Integration tests for the viewer's REAL texture → material apply path
+ * (`applyMaterialTextures` → `buildMaterialFromTextures` → the shared
+ * resolveTextureMaterialConfig / ensureAoMapUv2). Uses real THREE objects — the
+ * material/geometry construction is GPU-free, so this runs in jsdom without a
+ * WebGL context.
+ *
+ * These guard the two viewer↔worker drifts that made model 6 dark:
+ *   1. metalness gated on the base-color map → textured non-metal = black mirror
+ *   2. AO map applied without a uv2 set → AO killed all indirect light
+ * They assert the actual material/geometry the viewer produces, so they catch a
+ * regression even if someone re-inlines a buggy copy and bypasses the helpers.
+ */
+
+const SEP = '::'
+
+function texturedMesh(materialName = 'Mat') {
+  const geometry = new THREE.BufferGeometry()
+  geometry.setAttribute(
+    'position',
+    new THREE.BufferAttribute(new Float32Array(9), 3)
+  )
+  geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(6), 2))
+  const mesh = new THREE.Mesh(
+    geometry,
+    new THREE.MeshStandardMaterial({ name: materialName })
+  )
+  const group = new THREE.Group()
+  group.add(mesh)
+  return { group, mesh }
+}
+
+/** Build the namespaced loaded-textures record the apply path expects. */
+function loadedTextures(matName: string, slots: string[]) {
+  const out: Record<string, THREE.Texture> = {}
+  for (const slot of slots) out[`${matName}${SEP}${slot}`] = new THREE.Texture()
+  return out
+}
+
+/** Only the keys are read from the texture-set map; contents are stubbed. */
+const matSet = (name: string): Record<string, TextureSetDto> => ({
+  [name]: {} as unknown as TextureSetDto,
+})
+
+describe('viewer texture → material apply path', () => {
+  it('base-color + AO (no metalness map) → lit dielectric with uv2, NOT a black mirror', () => {
+    const { group, mesh } = texturedMesh('Mat')
+
+    applyMaterialTextures(
+      group,
+      matSet('Mat'),
+      loadedTextures('Mat', ['map', 'aoMap']),
+      true
+    )
+
+    const mat = mesh.material as THREE.MeshPhysicalMaterial
+    // Dielectric → responds to ambient / direct / IBL (the metalness-drift fix).
+    expect(mat.metalness).toBe(0)
+    expect(mat.aoMap).not.toBeNull()
+    // Second UV set present so AO doesn't collapse indirect light (the uv2 fix).
+    expect(mesh.geometry.getAttribute('uv2')).toBeDefined()
+  })
+
+  it('a metalness map is what makes it metallic', () => {
+    const { group, mesh } = texturedMesh('Mat')
+
+    applyMaterialTextures(
+      group,
+      matSet('Mat'),
+      loadedTextures('Mat', ['map', 'metalnessMap']),
+      true
+    )
+
+    expect((mesh.material as THREE.MeshPhysicalMaterial).metalness).toBe(1)
+  })
+
+  it('does not add a uv2 set when there is no AO map (no needless attribute)', () => {
+    const { group, mesh } = texturedMesh('Mat')
+
+    applyMaterialTextures(
+      group,
+      matSet('Mat'),
+      loadedTextures('Mat', ['map']),
+      true
+    )
+
+    expect(mesh.geometry.getAttribute('uv2')).toBeUndefined()
+  })
+
+  it('buildMaterialFromTextures: specular channel gated on the specular map', () => {
+    const base = buildMaterialFromTextures(
+      loadedTextures('Mat', ['map']),
+      'Mat'
+    )
+    expect(base.specularIntensity).toBe(0)
+    expect(base.roughness).toBe(0.8)
+
+    const withSpec = buildMaterialFromTextures(
+      loadedTextures('Mat', ['map', 'specularColorMap']),
+      'Mat'
+    )
+    expect(withSpec.specularIntensity).toBe(1)
+  })
+})

--- a/src/frontend/src/features/model-viewer/components/ModelPreviewScene.tsx
+++ b/src/frontend/src/features/model-viewer/components/ModelPreviewScene.tsx
@@ -8,48 +8,72 @@ import { useEnvironmentPresets } from '@/features/model-viewer/hooks/useEnvironm
 import { getFileUrl } from '@/features/models/api/modelApi'
 import { type Model as ModelType } from '@/utils/fileUtils'
 
+import {
+  resolveSceneLighting,
+  type SceneLightingDescriptor,
+} from '../../../../../asset-processor/lib/sceneLighting.js'
 import { MeshHighlighter } from './MeshHighlighter'
 import { Model } from './Model'
 import { type MaterialTextureSets, TexturedModel } from './TexturedModel'
 import { type ViewerSettingsType } from './ViewerSettings'
 
-// Directional light with visual helper indicator
-function FillLightWithHelper({
-  position,
-  intensity,
-  color,
-  helperColor,
+/**
+ * The shared cross-runtime light rig (lib/sceneLighting.js — also used by the
+ * worker thumbnail render) mapped to React-Three-Fiber primitives. This is the
+ * ONLY lighting in the scene: drei's <Stage> runs at intensity 0 so its own
+ * lights don't stack on top and swamp these (the bug that made the ambient /
+ * environment sliders look inert). Optional drei helpers visualise each light
+ * when "Show Light Helpers" is on.
+ */
+function SceneLights({
+  descriptor,
+  showHelpers,
 }: {
-  position: [number, number, number]
-  intensity: number
-  color: string
-  helperColor: string
-}) {
-  const lightRef = useRef<THREE.DirectionalLight>(null)
-  useHelper(lightRef, THREE.DirectionalLightHelper, 1, helperColor)
+  descriptor: SceneLightingDescriptor
+  showHelpers: boolean
+}): JSX.Element {
+  const directionalRef = useRef<THREE.DirectionalLight>(null)
+  const pointRef = useRef<THREE.PointLight>(null)
+  const spotRef = useRef<THREE.SpotLight>(null)
 
-  return (
-    <directionalLight
-      ref={lightRef}
-      position={position}
-      intensity={intensity}
-      color={color}
-    />
+  useHelper(
+    showHelpers ? directionalRef : null,
+    THREE.DirectionalLightHelper,
+    1,
+    '#ff8800'
   )
-}
+  useHelper(showHelpers ? pointRef : null, THREE.PointLightHelper, 1, '#00ccff')
+  useHelper(showHelpers ? spotRef : null, THREE.SpotLightHelper, '#ff00ff')
 
-// Directional light without helper
-function FillLight({
-  position,
-  intensity,
-  color,
-}: {
-  position: [number, number, number]
-  intensity: number
-  color: string
-}) {
   return (
-    <directionalLight position={position} intensity={intensity} color={color} />
+    <>
+      <ambientLight
+        intensity={descriptor.ambient.intensity}
+        color={descriptor.ambient.color}
+      />
+      <directionalLight
+        ref={directionalRef}
+        position={descriptor.directional.position}
+        intensity={descriptor.directional.intensity}
+        color={descriptor.directional.color}
+        castShadow={descriptor.directional.castShadow}
+      />
+      <pointLight
+        ref={pointRef}
+        position={descriptor.point.position}
+        intensity={descriptor.point.intensity}
+        color={descriptor.point.color}
+      />
+      <spotLight
+        ref={spotRef}
+        position={descriptor.spot.position}
+        intensity={descriptor.spot.intensity}
+        angle={descriptor.spot.angle}
+        penumbra={descriptor.spot.penumbra}
+        color={descriptor.spot.color}
+        castShadow={descriptor.spot.castShadow}
+      />
+    </>
   )
 }
 
@@ -105,14 +129,25 @@ export function Scene({
   const panSpeed = settings?.panSpeed ?? 1
   const modelRotationSpeed = settings?.modelRotationSpeed ?? 0.002
   const showShadows = settings?.showShadows ?? true
-  const ambientIntensity = settings?.ambientIntensity ?? 0.3
+  // Defaults mirror the shared rig (lib/sceneLighting.js DEFAULT_LIGHTING) so an
+  // unconfigured viewer matches the thumbnail render. ambient/environment are
+  // absolute intensities; directional is a multiplier on the directional triplet.
+  const ambientIntensity = settings?.ambientIntensity ?? 0.35
   const directionalIntensity = settings?.directionalIntensity ?? 1.0
   const showLightHelpers = settings?.showLightHelpers ?? false
   const environmentPreset = settings?.environmentPreset ?? 'city'
   const showEnvironmentBackground = settings?.showEnvironmentBackground ?? false
   const backgroundIntensity = settings?.backgroundIntensity ?? 1.0
-  const environmentIntensity = settings?.environmentIntensity ?? 1.0
+  const environmentIntensity = settings?.environmentIntensity ?? 0.3
   const { envMap } = useEnvironmentPresets(environmentPreset)
+
+  // Resolve the single balanced rig from the user settings. This is what makes
+  // the ambient/directional/environment controls actually move the image.
+  const lighting = resolveSceneLighting({
+    ambientIntensity,
+    directionalIntensity,
+    environmentIntensity,
+  })
 
   useEffect(() => {
     if (!cameraState) {
@@ -167,10 +202,13 @@ export function Scene({
 
   return (
     <>
-      {/* Stage provides automatic lighting, shadows, and environment */}
+      {/* Stage centres the model and casts the contact shadow. Its own lights
+          are disabled (intensity 0) — the shared SceneLights rig below is the
+          single light source, so the viewer matches the thumbnail render and
+          the ambient/environment controls aren't swamped. */}
       <Stage
         key={`stage-${modelUrl}`}
-        intensity={directionalIntensity}
+        intensity={0}
         environment={null}
         shadows={
           showShadows ? { type: 'contact', opacity: 0.4, blur: 2 } : false
@@ -202,72 +240,20 @@ export function Scene({
         </Suspense>
       </Stage>
 
-      {/* Environment map for reflections and optional background */}
+      {/* Environment map for reflections and optional background. The IBL
+          contribution (environmentIntensity) is the resolved value, so the
+          environment slider visibly changes reflections. */}
       {envMap && (
         <Environment
           map={envMap}
           background={showEnvironmentBackground}
           backgroundIntensity={backgroundIntensity}
-          environmentIntensity={environmentIntensity}
+          environmentIntensity={lighting.environmentIntensity}
         />
       )}
 
-      {/* 
-        Three-Point Lighting System
-        Models are normalized to fit in ~2x2x2 bounds (see TexturedModel.tsx)
-        Lights positioned at 3x model radius for consistent illumination
-      */}
-
-      {/* Ambient fill - base illumination */}
-      <ambientLight intensity={ambientIntensity} />
-
-      {/* KEY LIGHT: Main light, warm, from front-right-above (45° azimuth, 45° elevation) */}
-      {showLightHelpers ? (
-        <FillLightWithHelper
-          position={[4, 4, 4]}
-          intensity={1.2 * directionalIntensity}
-          color="#fff5e6"
-          helperColor="#ff8800"
-        />
-      ) : (
-        <FillLight
-          position={[4, 4, 4]}
-          intensity={1.2 * directionalIntensity}
-          color="#fff5e6"
-        />
-      )}
-
-      {/* FILL LIGHT: Softer, cool, from front-left (opposite key) */}
-      {showLightHelpers ? (
-        <FillLightWithHelper
-          position={[-4, 2, 4]}
-          intensity={0.6 * directionalIntensity}
-          color="#e6f0ff"
-          helperColor="#00ccff"
-        />
-      ) : (
-        <FillLight
-          position={[-4, 2, 4]}
-          intensity={0.6 * directionalIntensity}
-          color="#e6f0ff"
-        />
-      )}
-
-      {/* RIM/BACK LIGHT: Edge separation, from behind */}
-      {showLightHelpers ? (
-        <FillLightWithHelper
-          position={[0, 3, -5]}
-          intensity={0.8 * directionalIntensity}
-          color="#ffffff"
-          helperColor="#ff00ff"
-        />
-      ) : (
-        <FillLight
-          position={[0, 3, -5]}
-          intensity={0.8 * directionalIntensity}
-          color="#ffffff"
-        />
-      )}
+      {/* Shared cross-runtime light rig — the single source of illumination. */}
+      <SceneLights descriptor={lighting} showHelpers={showLightHelpers} />
 
       {/* Mesh highlighting from hierarchy panel */}
       <MeshHighlighter />

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -14,16 +14,16 @@ import {
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
 import { getFileUrl } from '@/features/models/api/modelApi'
 import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
-import {
-  addSharedDisplacementNormal,
-  applyDispNormalDisplacement,
-} from '@/shared/three/sharedDisplacementNormal'
-import { TextureChannel, type TextureSetDto, TextureType } from '@/types'
+import { TextureChannel, TextureType } from '@/types'
 
 import { buildStlModel } from '../../../../../asset-processor/lib/stlMesh.js'
+import {
+  applyMaterialTextures,
+  KEY_SEP,
+  type MaterialTextureSets,
+} from './materialTextures'
 
-/** Map of material names to their texture sets. Key "" means apply to all meshes. */
-export type MaterialTextureSets = Record<string, TextureSetDto>
+export type { MaterialTextureSets } from './materialTextures'
 
 interface TexturedModelProps {
   modelUrl: string
@@ -63,8 +63,6 @@ const TEXTURE_SLOTS: Array<{
   },
 ]
 
-const KEY_SEP = '::'
-
 /**
  * Build a combined texture config map for all material→textureSet mappings.
  * Keys are namespaced as "materialName::slotName" so the hook loads everything in one pass.
@@ -98,143 +96,6 @@ function buildCombinedTextureConfigs(
   }
 
   return configs
-}
-
-/** Get the material names from a mesh (handles arrays). */
-function getMeshMaterialNames(mesh: THREE.Mesh): string[] {
-  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
-  return mats.map(m => m?.name ?? '').filter(Boolean)
-}
-
-/**
- * Build a MeshPhysicalMaterial from loaded textures for a given material key prefix.
- */
-function buildMaterialFromTextures(
-  loadedTextures: Record<string, THREE.Texture | null>,
-  materialPrefix: string
-): THREE.MeshPhysicalMaterial {
-  const get = (slot: string) =>
-    loadedTextures[`${materialPrefix}${KEY_SEP}${slot}`] ?? null
-  const hasMap = get('map') !== null
-
-  const material = new THREE.MeshPhysicalMaterial({
-    color: hasMap ? 0xffffff : new THREE.Color(0.7, 0.7, 0.9),
-    metalness: hasMap ? 1 : 0.3,
-    roughness: hasMap ? 1 : 0.4,
-    envMapIntensity: 1.0,
-    // MeshPhysicalMaterial enables a dielectric specular channel by default
-    // (intensity=1, color=white). Without an explicit Specular texture we
-    // want MeshStandardMaterial-equivalent behavior, otherwise the channel
-    // adds a sheen that washes the albedo toward white.
-    specularIntensity: get('specularColorMap') ? 1 : 0,
-  })
-
-  if (get('map')) material.map = get('map')
-  if (get('normalMap')) material.normalMap = get('normalMap')
-  if (get('roughnessMap')) material.roughnessMap = get('roughnessMap')
-  if (get('metalnessMap')) material.metalnessMap = get('metalnessMap')
-  if (get('specularColorMap')) {
-    material.specularColorMap = get('specularColorMap')
-  }
-  if (get('aoMap')) material.aoMap = get('aoMap')
-  if (get('emissiveMap')) {
-    material.emissiveMap = get('emissiveMap')
-    material.emissive = new THREE.Color(0xffffff)
-  }
-  if (get('bumpMap')) material.bumpMap = get('bumpMap')
-  if (get('alphaMap')) {
-    material.alphaMap = get('alphaMap')
-    material.transparent = true
-  }
-  if (get('displacementMap')) {
-    material.displacementMap = get('displacementMap')
-    // Bias by -scale/2 so heightmap mid-grey means "no displacement".
-    material.displacementScale = 0.02
-    material.displacementBias = -0.01
-    // Sample displacement direction from an averaged-by-position normal
-    // attribute rather than the face-aligned objectNormal — so hard-edged
-    // meshes (game-asset cubes etc.) stay watertight under displacement
-    // while keeping their original per-face UVs intact for color sampling.
-    applyDispNormalDisplacement(material)
-  }
-
-  return material
-}
-
-/**
- * Apply per-material textures to a cloned model.
- * If a material name matches a key in materialTextureSets, that mesh gets textured.
- * A key of "" is a wildcard that applies to meshes with no specific mapping.
- */
-function applyMaterialTextures(
-  clonedModel: THREE.Group | THREE.Object3D,
-  materialTextureSets: MaterialTextureSets,
-  loadedTextures: Record<string, THREE.Texture | null>,
-  texturesReady: boolean
-) {
-  const materialNames = Object.keys(materialTextureSets)
-  const hasWildcard = materialNames.includes('')
-
-  // Pre-build materials for each material name that has textures
-  const builtMaterials: Record<string, THREE.MeshPhysicalMaterial> = {}
-  if (texturesReady) {
-    for (const matName of materialNames) {
-      builtMaterials[matName] = buildMaterialFromTextures(
-        loadedTextures,
-        matName
-      )
-    }
-  }
-
-  // Shared fallback material for unmatched meshes (avoids per-mesh allocation)
-  const fallbackMaterial = new THREE.MeshPhysicalMaterial({
-    color: new THREE.Color(0.7, 0.7, 0.9),
-    metalness: 0.3,
-    roughness: 0.4,
-    envMapIntensity: 1.0,
-    specularIntensity: 0,
-  })
-
-  clonedModel.traverse(child => {
-    if (!child.isMesh) return
-    const mesh = child as THREE.Mesh
-    mesh.castShadow = true
-    mesh.receiveShadow = true
-
-    const meshMatNames = getMeshMaterialNames(mesh)
-
-    // Find matching material: check mesh material names against our map
-    let matched = false
-    let appliedMaterial: THREE.MeshPhysicalMaterial | null = null
-    for (const meshMatName of meshMatNames) {
-      if (meshMatName in builtMaterials) {
-        appliedMaterial = builtMaterials[meshMatName]
-        mesh.material = appliedMaterial
-        matched = true
-        break
-      }
-    }
-
-    // Fallback: use wildcard "" material (applies to all unmatched meshes)
-    if (!matched && hasWildcard && texturesReady) {
-      appliedMaterial = builtMaterials['']
-      mesh.material = appliedMaterial
-    }
-
-    // Strip embedded materials from unmatched meshes to match worker behavior
-    if (!matched && !hasWildcard) {
-      mesh.material = fallbackMaterial
-    }
-
-    // Add the shared-displacement-normal attribute when this mesh is about
-    // to be displaced. The shader uses this attribute as the push direction
-    // so hard-edged meshes (game-asset cubes etc.) stay watertight along
-    // seams while keeping their original per-face UVs / normals intact for
-    // color shading. Idempotent: skipped if the attribute already exists.
-    if (appliedMaterial?.displacementMap) {
-      addSharedDisplacementNormal(mesh.geometry)
-    }
-  })
 }
 
 // Shared props for per-format components

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -18,6 +18,10 @@ import { TextureChannel, TextureType } from '@/types'
 
 import { buildStlModel } from '../../../../../asset-processor/lib/stlMesh.js'
 import {
+  MATERIAL_SLOT_BY_TEXTURE_TYPE,
+  textureTypeNeedsInvert,
+} from '../../../../../asset-processor/lib/textureChannels.js'
+import {
   applyMaterialTextures,
   KEY_SEP,
   type MaterialTextureSets,
@@ -32,35 +36,26 @@ interface TexturedModelProps {
   materialTextureSets: MaterialTextureSets
 }
 
-// Material property slot names used by MeshPhysicalMaterial.
-// `fallback` is used when the primary type is absent (mutually-exclusive groups).
-// `invertFallback` means the fallback texture must be channel-inverted at load
-// time (e.g. Glossiness fed through the roughnessMap slot).
+// Texture types in apply order, each with its fallback when the primary is
+// absent (mutually-exclusive groups: Roughness←Glossiness, Displacement←Height).
+// The MeshPhysicalMaterial slot each type feeds and whether it must be inverted
+// at load come from the shared cross-runtime map
+// (asset-processor/lib/textureChannels.js) — the same source the worker
+// thumbnail uses, so the viewer and the thumbnail route textures identically.
 const TEXTURE_SLOTS: Array<{
-  slot: string
   type: TextureType
   fallback?: TextureType
-  invertFallback?: boolean
 }> = [
-  { slot: 'map', type: TextureType.Albedo },
-  { slot: 'normalMap', type: TextureType.Normal },
-  {
-    slot: 'roughnessMap',
-    type: TextureType.Roughness,
-    fallback: TextureType.Glossiness,
-    invertFallback: true,
-  },
-  { slot: 'metalnessMap', type: TextureType.Metallic },
-  { slot: 'specularColorMap', type: TextureType.Specular },
-  { slot: 'aoMap', type: TextureType.AO },
-  { slot: 'emissiveMap', type: TextureType.Emissive },
-  { slot: 'bumpMap', type: TextureType.Bump },
-  { slot: 'alphaMap', type: TextureType.Alpha },
-  {
-    slot: 'displacementMap',
-    type: TextureType.Displacement,
-    fallback: TextureType.Height,
-  },
+  { type: TextureType.Albedo },
+  { type: TextureType.Normal },
+  { type: TextureType.Roughness, fallback: TextureType.Glossiness },
+  { type: TextureType.Metallic },
+  { type: TextureType.Specular },
+  { type: TextureType.AO },
+  { type: TextureType.Emissive },
+  { type: TextureType.Bump },
+  { type: TextureType.Alpha },
+  { type: TextureType.Displacement, fallback: TextureType.Height },
 ]
 
 /**
@@ -77,19 +72,26 @@ function buildCombinedTextureConfigs(
     materialTextureSets
   )) {
     if (!textureSet?.textures) continue
-    for (const { slot, type, fallback, invertFallback } of TEXTURE_SLOTS) {
+    for (const { type, fallback } of TEXTURE_SLOTS) {
+      const slot = MATERIAL_SLOT_BY_TEXTURE_TYPE[type]
       let tex = textureSet.textures.find(t => t.textureType === type)
-      let invert = false
+      let chosenType = type
       if (!tex && fallback) {
-        tex = textureSet.textures.find(t => t.textureType === fallback)
-        if (tex && invertFallback) invert = true
+        const fallbackTex = textureSet.textures.find(
+          t => t.textureType === fallback
+        )
+        if (fallbackTex) {
+          tex = fallbackTex
+          chosenType = fallback
+        }
       }
       if (tex) {
         configs[`${materialName}${KEY_SEP}${slot}`] = {
           url: getFileUrl(tex.fileId.toString()),
           sourceChannel: tex.sourceChannel ?? TextureChannel.RGB,
           fileName: tex.fileName,
-          invert,
+          // Glossiness feeds roughnessMap inverted (shared rule).
+          invert: textureTypeNeedsInvert(chosenType),
         }
       }
     }

--- a/src/frontend/src/features/model-viewer/components/ViewerSettings.stories.tsx
+++ b/src/frontend/src/features/model-viewer/components/ViewerSettings.stories.tsx
@@ -9,13 +9,13 @@ const defaultSettings: ViewerSettingsType = {
   modelRotationSpeed: 0,
   showShadows: true,
   showStats: false,
-  ambientIntensity: 0.3,
+  ambientIntensity: 0.35,
   directionalIntensity: 1.0,
   showLightHelpers: false,
   environmentPreset: 'city',
   showEnvironmentBackground: false,
   backgroundIntensity: 1.0,
-  environmentIntensity: 1.0,
+  environmentIntensity: 0.3,
 }
 
 const meta: Meta<typeof ViewerSettings> = {

--- a/src/frontend/src/features/model-viewer/components/materialTextures.ts
+++ b/src/frontend/src/features/model-viewer/components/materialTextures.ts
@@ -1,0 +1,171 @@
+import * as THREE from 'three'
+
+import {
+  addSharedDisplacementNormal,
+  applyDispNormalDisplacement,
+} from '@/shared/three/sharedDisplacementNormal'
+import { type TextureSetDto } from '@/types'
+
+import {
+  ensureAoMapUv2,
+  resolveTextureMaterialConfig,
+} from '../../../../../asset-processor/lib/textureMaterial.js'
+
+/** Map of material names to their texture sets. Key "" means apply to all meshes. */
+export type MaterialTextureSets = Record<string, TextureSetDto>
+
+/** Separator for the namespaced "materialName::slot" loaded-texture keys. */
+export const KEY_SEP = '::'
+
+/** Get the material names from a mesh (handles arrays). */
+function getMeshMaterialNames(mesh: THREE.Mesh): string[] {
+  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
+  return mats.map(m => m?.name ?? '').filter(Boolean)
+}
+
+/**
+ * Build a MeshPhysicalMaterial from loaded textures for a given material key
+ * prefix. Exported for the material-pipeline regression tests.
+ */
+export function buildMaterialFromTextures(
+  loadedTextures: Record<string, THREE.Texture | null>,
+  materialPrefix: string
+): THREE.MeshPhysicalMaterial {
+  const get = (slot: string) =>
+    loadedTextures[`${materialPrefix}${KEY_SEP}${slot}`] ?? null
+
+  // Shared gating rule (asset-processor/lib/textureMaterial.js — the same rule
+  // the worker thumbnail uses). Gating metalness/roughness on their OWN maps,
+  // not on the base-color map, is what stops a textured-but-not-metal surface
+  // from rendering as a black mirror in the viewer.
+  const cfg = resolveTextureMaterialConfig({
+    baseColorMap: get('map'),
+    metalnessMap: get('metalnessMap'),
+    roughnessMap: get('roughnessMap'),
+    specularColorMap: get('specularColorMap'),
+  })
+
+  const material = new THREE.MeshPhysicalMaterial({
+    color: cfg.hasBaseColorMap ? 0xffffff : new THREE.Color(0.7, 0.7, 0.9),
+    metalness: cfg.metalness,
+    roughness: cfg.roughness,
+    envMapIntensity: cfg.envMapIntensity,
+    specularIntensity: cfg.specularIntensity,
+  })
+
+  if (get('map')) material.map = get('map')
+  if (get('normalMap')) material.normalMap = get('normalMap')
+  if (get('roughnessMap')) material.roughnessMap = get('roughnessMap')
+  if (get('metalnessMap')) material.metalnessMap = get('metalnessMap')
+  if (get('specularColorMap')) {
+    material.specularColorMap = get('specularColorMap')
+  }
+  if (get('aoMap')) material.aoMap = get('aoMap')
+  if (get('emissiveMap')) {
+    material.emissiveMap = get('emissiveMap')
+    material.emissive = new THREE.Color(0xffffff)
+  }
+  if (get('bumpMap')) material.bumpMap = get('bumpMap')
+  if (get('alphaMap')) {
+    material.alphaMap = get('alphaMap')
+    material.transparent = true
+  }
+  if (get('displacementMap')) {
+    material.displacementMap = get('displacementMap')
+    // Bias by -scale/2 so heightmap mid-grey means "no displacement".
+    material.displacementScale = 0.02
+    material.displacementBias = -0.01
+    // Sample displacement direction from an averaged-by-position normal
+    // attribute rather than the face-aligned objectNormal — so hard-edged
+    // meshes (game-asset cubes etc.) stay watertight under displacement
+    // while keeping their original per-face UVs intact for color sampling.
+    applyDispNormalDisplacement(material)
+  }
+
+  return material
+}
+
+/**
+ * Apply per-material textures to a cloned model.
+ * If a material name matches a key in materialTextureSets, that mesh gets textured.
+ * A key of "" is a wildcard that applies to meshes with no specific mapping.
+ * Exported for the material-pipeline regression tests.
+ */
+export function applyMaterialTextures(
+  clonedModel: THREE.Group | THREE.Object3D,
+  materialTextureSets: MaterialTextureSets,
+  loadedTextures: Record<string, THREE.Texture | null>,
+  texturesReady: boolean
+) {
+  const materialNames = Object.keys(materialTextureSets)
+  const hasWildcard = materialNames.includes('')
+
+  // Pre-build materials for each material name that has textures
+  const builtMaterials: Record<string, THREE.MeshPhysicalMaterial> = {}
+  if (texturesReady) {
+    for (const matName of materialNames) {
+      builtMaterials[matName] = buildMaterialFromTextures(
+        loadedTextures,
+        matName
+      )
+    }
+  }
+
+  // Shared fallback material for unmatched meshes (avoids per-mesh allocation)
+  const fallbackMaterial = new THREE.MeshPhysicalMaterial({
+    color: new THREE.Color(0.7, 0.7, 0.9),
+    metalness: 0.3,
+    roughness: 0.4,
+    envMapIntensity: 1.0,
+    specularIntensity: 0,
+  })
+
+  clonedModel.traverse(child => {
+    if (!child.isMesh) return
+    const mesh = child as THREE.Mesh
+    mesh.castShadow = true
+    mesh.receiveShadow = true
+
+    const meshMatNames = getMeshMaterialNames(mesh)
+
+    // Find matching material: check mesh material names against our map
+    let matched = false
+    let appliedMaterial: THREE.MeshPhysicalMaterial | null = null
+    for (const meshMatName of meshMatNames) {
+      if (meshMatName in builtMaterials) {
+        appliedMaterial = builtMaterials[meshMatName]
+        mesh.material = appliedMaterial
+        matched = true
+        break
+      }
+    }
+
+    // Fallback: use wildcard "" material (applies to all unmatched meshes)
+    if (!matched && hasWildcard && texturesReady) {
+      appliedMaterial = builtMaterials['']
+      mesh.material = appliedMaterial
+    }
+
+    // Strip embedded materials from unmatched meshes to match worker behavior
+    if (!matched && !hasWildcard) {
+      mesh.material = fallbackMaterial
+    }
+
+    // AO maps sample the second UV set. Without uv2 the AO term collapses to
+    // ~0 and kills ALL indirect light (ambient + environment IBL) while direct
+    // lights still work — which made the ambient/environment controls look
+    // inert. Copy uv -> uv2 like the worker thumbnail does.
+    if (appliedMaterial?.aoMap) {
+      ensureAoMapUv2(mesh.geometry)
+    }
+
+    // Add the shared-displacement-normal attribute when this mesh is about
+    // to be displaced. The shader uses this attribute as the push direction
+    // so hard-edged meshes (game-asset cubes etc.) stay watertight along
+    // seams while keeping their original per-face UVs / normals intact for
+    // color shading. Idempotent: skipped if the attribute already exists.
+    if (appliedMaterial?.displacementMap) {
+      addSharedDisplacementNormal(mesh.geometry)
+    }
+  })
+}

--- a/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
+++ b/src/frontend/src/features/model-viewer/hooks/useChannelExtractedTextures.ts
@@ -5,72 +5,12 @@ import { TextureChannel } from '@/types'
 import { isTiffFile } from '@/utils/fileUtils'
 import { loadTiffTextureFromUrl } from '@/utils/tiffTextureLoader'
 
-/**
- * Vertex shader - simple passthrough
- */
-const vertexShader = `
-  varying vec2 vUv;
-  void main() {
-    vUv = uv;
-    gl_Position = vec4(position, 1.0);
-  }
-`
-
-/**
- * Fragment shader - extracts a single channel and converts to grayscale.
- * Optionally inverts the value (used for Glossiness → Roughness conversion).
- */
-const fragmentShader = `
-  uniform sampler2D uTexture;
-  uniform int uChannel; // 0=R, 1=G, 2=B, 3=A
-  uniform int uInvert; // 0=no, 1=output 1.0 - value
-  varying vec2 vUv;
-
-  void main() {
-    vec4 texColor = texture2D(uTexture, vUv);
-    float channelValue;
-
-    if (uChannel == 0) channelValue = texColor.r;
-    else if (uChannel == 1) channelValue = texColor.g;
-    else if (uChannel == 2) channelValue = texColor.b;
-    else channelValue = texColor.a;
-
-    float v = uInvert == 1 ? 1.0 - channelValue : channelValue;
-    gl_FragColor = vec4(v, v, v, 1.0);
-  }
-`
-
-/**
- * Fragment shader - inverts RGB channels (255-based). Used when a Glossiness
- * texture is sourced as full-RGB grayscale and no channel extraction is needed.
- */
-const invertFragmentShader = `
-  uniform sampler2D uTexture;
-  varying vec2 vUv;
-
-  void main() {
-    vec4 texColor = texture2D(uTexture, vUv);
-    gl_FragColor = vec4(1.0 - texColor.rgb, texColor.a);
-  }
-`
-
-/**
- * Get channel index for shader uniform
- */
-function getChannelIndex(channel: TextureChannel): number {
-  switch (channel) {
-    case TextureChannel.R:
-      return 0
-    case TextureChannel.G:
-      return 1
-    case TextureChannel.B:
-      return 2
-    case TextureChannel.A:
-      return 3
-    default:
-      return 0
-  }
-}
+import {
+  CHANNEL_EXTRACT_FRAGMENT_SHADER,
+  CHANNEL_VERTEX_SHADER,
+  getChannelUniformIndex,
+  RGB_INVERT_FRAGMENT_SHADER,
+} from '../../../../../asset-processor/lib/textureChannels.js'
 
 /**
  * Extract a single channel from a texture using WebGL rendering.
@@ -100,11 +40,11 @@ function extractChannel(
 
   const geometry = new THREE.PlaneGeometry(2, 2)
   const material = new THREE.ShaderMaterial({
-    vertexShader,
-    fragmentShader,
+    vertexShader: CHANNEL_VERTEX_SHADER,
+    fragmentShader: CHANNEL_EXTRACT_FRAGMENT_SHADER,
     uniforms: {
       uTexture: { value: sourceTexture },
-      uChannel: { value: getChannelIndex(channel) },
+      uChannel: { value: getChannelUniformIndex(channel) },
       uInvert: { value: invert ? 1 : 0 },
     },
   })
@@ -156,8 +96,8 @@ function invertTexture(
   const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
   const geometry = new THREE.PlaneGeometry(2, 2)
   const material = new THREE.ShaderMaterial({
-    vertexShader,
-    fragmentShader: invertFragmentShader,
+    vertexShader: CHANNEL_VERTEX_SHADER,
+    fragmentShader: RGB_INVERT_FRAGMENT_SHADER,
     uniforms: { uTexture: { value: sourceTexture } },
   })
 
@@ -333,6 +273,7 @@ export function useChannelExtractedTextures(
 }
 
 /**
- * Utility to get channel index for external use (e.g., testing)
+ * Re-exported from the shared cross-runtime module (the worker thumbnail uses the
+ * same channel numbering). Kept under the original name for external use/tests.
  */
-export { getChannelIndex }
+export { getChannelUniformIndex as getChannelIndex }

--- a/src/frontend/src/mocks/services/browserAssetProcessor.ts
+++ b/src/frontend/src/mocks/services/browserAssetProcessor.ts
@@ -22,19 +22,30 @@ import {
   type Object3D,
   PerspectiveCamera,
   PMREMGenerator,
+  PointLight,
   Scene,
   SphereGeometry,
+  SpotLight,
   type Texture,
   Vector3,
   WebGLRenderer,
 } from 'three'
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js'
 import { ThreeMFLoader } from 'three/addons/loaders/3MFLoader.js'
 import { FBXLoader } from 'three/addons/loaders/FBXLoader.js'
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
 import { OBJLoader } from 'three/addons/loaders/OBJLoader.js'
 import { STLLoader } from 'three/addons/loaders/STLLoader.js'
 
+import {
+  buildSceneLights,
+  DEFAULT_LIGHTING,
+} from '../../../../asset-processor/lib/sceneLighting.js'
 import { buildStlModel } from '../../../../asset-processor/lib/stlMesh.js'
+import {
+  ensureAoMapUv2,
+  resolveTextureMaterialConfig,
+} from '../../../../asset-processor/lib/textureMaterial.js'
 
 // ─── Model Thumbnails ───────────────────────────────────────────────────
 
@@ -56,6 +67,33 @@ function applyStandardMaterial(model: Object3D) {
   })
 }
 
+// The four light constructors the shared rig builder needs (demo imports named
+// exports from three rather than a namespace).
+const DEMO_LIGHT_CTORS = {
+  AmbientLight,
+  DirectionalLight,
+  PointLight,
+  SpotLight,
+}
+
+/**
+ * Light a demo render scene with the shared cross-runtime rig
+ * (asset-processor/lib/sceneLighting.js) plus the same neutral RoomEnvironment
+ * IBL the worker thumbnail uses — so demo thumbnails match the real worker's
+ * output instead of using a divergent ad-hoc rig.
+ */
+function setupSceneLighting(scene: Scene, renderer: WebGLRenderer): void {
+  const { lights } = buildSceneLights(DEMO_LIGHT_CTORS, DEFAULT_LIGHTING)
+  scene.add(...lights)
+
+  const pmrem = new PMREMGenerator(renderer)
+  const roomEnv = new RoomEnvironment()
+  scene.environment = pmrem.fromScene(roomEnv).texture
+  scene.environmentIntensity = DEFAULT_LIGHTING.environmentIntensity
+  roomEnv.dispose()
+  pmrem.dispose()
+}
+
 /**
  * Normalize a model to fit within a unit box centred at the origin.
  * Matches the real worker's normalizeModel() approach.
@@ -66,7 +104,10 @@ function normalizeModel(model: Object3D, targetScale = 2.0) {
   const maxDim = Math.max(size.x, size.y, size.z)
   if (maxDim > 0) {
     const scaleFactor = targetScale / maxDim
-    model.scale.setScalar(scaleFactor)
+    // Multiply, don't replace: FBX (and some glTF) loaders bake a non-1
+    // unit-conversion scale into the root. setScalar would drop it and shrink
+    // the model to ~1/100 of intended size. Matches the worker's normalizeModel.
+    model.scale.multiplyScalar(scaleFactor)
   }
   // Recalculate after scaling
   const scaledBox = new Box3().setFromObject(model)
@@ -321,6 +362,7 @@ async function applyTextureMaps(
 ): Promise<void> {
   const albedoTex = textures.find(t => t.textureType === 1)
   const normalTex = textures.find(t => t.textureType === 2)
+  const aoTex = textures.find(t => t.textureType === 4)
   const roughnessTex = textures.find(t => t.textureType === 5)
   const metallicTex = textures.find(t => t.textureType === 6)
 
@@ -329,24 +371,40 @@ async function applyTextureMaps(
     return new CanvasTexture(bitmap as unknown as HTMLCanvasElement)
   }
 
-  const [albedoMap, normalMap, roughnessMap, metalnessMap] = await Promise.all([
-    albedoTex ? loadTexture(albedoTex.blob) : Promise.resolve(null),
-    normalTex ? loadTexture(normalTex.blob) : Promise.resolve(null),
-    roughnessTex ? loadTexture(roughnessTex.blob) : Promise.resolve(null),
-    metallicTex ? loadTexture(metallicTex.blob) : Promise.resolve(null),
-  ])
+  const [albedoMap, normalMap, aoMap, roughnessMap, metalnessMap] =
+    await Promise.all([
+      albedoTex ? loadTexture(albedoTex.blob) : Promise.resolve(null),
+      normalTex ? loadTexture(normalTex.blob) : Promise.resolve(null),
+      aoTex ? loadTexture(aoTex.blob) : Promise.resolve(null),
+      roughnessTex ? loadTexture(roughnessTex.blob) : Promise.resolve(null),
+      metallicTex ? loadTexture(metallicTex.blob) : Promise.resolve(null),
+    ])
+
+  // Same gating rule as the viewer and the worker thumbnail (metalness/
+  // roughness keyed on their own maps, not the base-color map).
+  const cfg = resolveTextureMaterialConfig({
+    baseColorMap: albedoMap,
+    metalnessMap,
+    roughnessMap,
+  })
 
   model.traverse(child => {
     if (child instanceof Mesh) {
       child.material = new MeshStandardMaterial({
-        color: albedoMap ? new Color(1, 1, 1) : new Color(0.7, 0.7, 0.9),
+        color: cfg.hasBaseColorMap
+          ? new Color(1, 1, 1)
+          : new Color(0.7, 0.7, 0.9),
         map: albedoMap,
-        normalMap: normalMap,
-        roughnessMap: roughnessMap,
-        metalnessMap: metalnessMap,
-        metalness: metalnessMap ? 1.0 : 0.3,
-        roughness: roughnessMap ? 1.0 : 0.4,
+        normalMap,
+        aoMap,
+        roughnessMap,
+        metalnessMap,
+        metalness: cfg.metalness,
+        roughness: cfg.roughness,
+        envMapIntensity: cfg.envMapIntensity,
       })
+      // AO needs the second UV set or it collapses indirect light (shared helper).
+      if (aoMap) ensureAoMapUv2(child.geometry)
       child.castShadow = true
       child.receiveShadow = true
     }
@@ -405,10 +463,7 @@ async function renderModelWithTextures(
   const scene = new Scene()
   const camera = new PerspectiveCamera(45, width / height, 0.01, 1000)
 
-  scene.add(new AmbientLight(0xffffff, 0.6))
-  const dirLight = new DirectionalLight(0xffffff, 0.8)
-  dirLight.position.set(5, 10, 7)
-  scene.add(dirLight)
+  setupSceneLighting(scene, renderer)
 
   let model: Group
   if (ext === 'fbx') {
@@ -490,10 +545,7 @@ async function renderGltfThumbnail(
   const camera = new PerspectiveCamera(45, width / height, 0.01, 1000)
 
   // Lighting
-  scene.add(new AmbientLight(0xffffff, 0.6))
-  const dirLight = new DirectionalLight(0xffffff, 0.8)
-  dirLight.position.set(5, 10, 7)
-  scene.add(dirLight)
+  setupSceneLighting(scene, renderer)
 
   // Load model
   const loader = new GLTFLoader()
@@ -543,10 +595,7 @@ async function renderFbxThumbnail(
   const scene = new Scene()
   const camera = new PerspectiveCamera(45, width / height, 0.01, 1000)
 
-  scene.add(new AmbientLight(0xffffff, 0.6))
-  const dirLight = new DirectionalLight(0xffffff, 0.8)
-  dirLight.position.set(5, 10, 7)
-  scene.add(dirLight)
+  setupSceneLighting(scene, renderer)
 
   const loader = new FBXLoader()
   const fbxScene = await new Promise<Group>((resolve, reject) => {
@@ -595,10 +644,7 @@ async function renderObjThumbnail(
   const scene = new Scene()
   const camera = new PerspectiveCamera(45, width / height, 0.01, 1000)
 
-  scene.add(new AmbientLight(0xffffff, 0.6))
-  const dirLight = new DirectionalLight(0xffffff, 0.8)
-  dirLight.position.set(5, 10, 7)
-  scene.add(dirLight)
+  setupSceneLighting(scene, renderer)
 
   const loader = new OBJLoader()
   const objScene = await new Promise<Group>((resolve, reject) => {
@@ -704,10 +750,7 @@ export async function generateTextureSetThumbnail(
     camera.position.set(0, 0, 3)
     camera.lookAt(0, 0, 0)
 
-    scene.add(new AmbientLight(0xffffff, 0.6))
-    const dl = new DirectionalLight(0xffffff, 0.8)
-    dl.position.set(3, 5, 4)
-    scene.add(dl)
+    setupSceneLighting(scene, renderer)
 
     // Load albedo as texture
     const imageBitmap = await createImageBitmap(albedoBlob)

--- a/src/frontend/src/mocks/services/browserAssetProcessor.ts
+++ b/src/frontend/src/mocks/services/browserAssetProcessor.ts
@@ -42,6 +42,7 @@ import {
   DEFAULT_LIGHTING,
 } from '../../../../asset-processor/lib/sceneLighting.js'
 import { buildStlModel } from '../../../../asset-processor/lib/stlMesh.js'
+import { TEXTURE_TYPE } from '../../../../asset-processor/lib/textureChannels.js'
 import {
   ensureAoMapUv2,
   resolveTextureMaterialConfig,
@@ -344,8 +345,8 @@ export async function generateModelThumbnail(
 }
 
 /**
- * Texture map data for applying textures to model thumbnails.
- * TextureType: 1=Albedo, 2=Normal, 5=Roughness, 6=Metallic
+ * Texture map data for applying textures to model thumbnails. `textureType` is
+ * the shared TextureType enum value (see asset-processor/lib/textureChannels.js).
  */
 export interface TextureMapData {
   textureType: number
@@ -355,16 +356,21 @@ export interface TextureMapData {
 /**
  * Apply texture maps to all meshes in model.
  * Uses albedo for map, normal for normalMap, roughness for roughnessMap, metallic for metalnessMap.
+ * Texture-type numbers come from the shared enum so demo, viewer, and worker agree.
  */
 async function applyTextureMaps(
   model: Object3D,
   textures: TextureMapData[]
 ): Promise<void> {
-  const albedoTex = textures.find(t => t.textureType === 1)
-  const normalTex = textures.find(t => t.textureType === 2)
-  const aoTex = textures.find(t => t.textureType === 4)
-  const roughnessTex = textures.find(t => t.textureType === 5)
-  const metallicTex = textures.find(t => t.textureType === 6)
+  const albedoTex = textures.find(t => t.textureType === TEXTURE_TYPE.Albedo)
+  const normalTex = textures.find(t => t.textureType === TEXTURE_TYPE.Normal)
+  const aoTex = textures.find(t => t.textureType === TEXTURE_TYPE.AO)
+  const roughnessTex = textures.find(
+    t => t.textureType === TEXTURE_TYPE.Roughness
+  )
+  const metallicTex = textures.find(
+    t => t.textureType === TEXTURE_TYPE.Metallic
+  )
 
   const loadTexture = async (blob: Blob) => {
     const bitmap = await createImageBitmap(blob)

--- a/src/frontend/src/shared/three/sharedDisplacementNormal.ts
+++ b/src/frontend/src/shared/three/sharedDisplacementNormal.ts
@@ -1,146 +1,37 @@
 import * as THREE from 'three'
 
-/**
- * Make per-vertex displacement *direction* consistent across coincident-position
- * vertex duplicates, without merging their UVs/normals (which would smear the
- * surface texture at edges).
- *
- * The problem this solves: three.js's BoxGeometry and many user-uploaded
- * hard-edged meshes carry duplicated vertices at every shared edge — each
- * copy holds the same position but a face-aligned normal and a face-local
- * UV island. Under per-vertex displacement, those copies push along their
- * own face normal and tear the seam open. Merging the vertices (the welding
- * fix) closes the tear but also collapses the UVs to a single "first occurrence
- * wins" value, leaving a one-triangle-wide texture-smear band along every edge.
- *
- * The clean alternative is to keep both copies (so each face's UV island stays
- * intact and color sampling is unaffected) but make their *displacement*
- * direction identical: the average of the normals at that shared position.
- *
- * Pipeline:
- *   1. `addSharedDisplacementNormal(geom)` writes the averaged direction into a
- *      custom `aDispNormal` attribute (falls back to the per-vertex normal where
- *      a position has no duplicates).
- *   2. `applyDispNormalDisplacement(mat)` injects an `onBeforeCompile` hook that
- *      replaces three's stock displacement vertex chunk with one that pushes
- *      along `aDispNormal` instead of `objectNormal`.
- *
- * Trade-off: heights at duplicates can still differ if their face-local UVs
- * sample different texels. With `RepeatWrapping`, adjacent face UVs at cube
- * corners wrap to the same texel (`u = 0` and `u = 1` are identical samples);
- * only *mid-edges* can show a height mismatch. The worst-case mismatch is
- * `(maxHeight − minHeight) × displacementScale` along the averaged normal —
- * up to one percent of mesh size at the 0.02 displacement scale we use for
- * previews. Still far less perceptible than the smear band welding produced.
- */
+import {
+  addSharedDisplacementNormal as addSharedImpl,
+  applyDispNormalDisplacement as applyDispNormalImpl,
+} from '../../../../asset-processor/lib/displacementNormal.js'
 
-const DISP_NORMAL_ATTR = 'aDispNormal'
+/**
+ * Frontend wrapper over the shared cross-runtime displacement-normal helpers
+ * (`asset-processor/lib/displacementNormal.js`) — the same source the worker
+ * thumbnail uses, so hard-edged displaced meshes shade identically in both.
+ *
+ * The shared module injects THREE; this wrapper passes the bundler's instance so
+ * every existing call site keeps the original no-THREE signature. See the shared
+ * module for the full rationale (averaging the displacement direction across
+ * coincident-position vertex duplicates instead of welding, to keep per-face UV
+ * islands intact and avoid the one-triangle texture-smear band along edges).
+ */
 
 /**
  * Compute averaged-by-position normals and store them on the geometry as
- * `aDispNormal`. Returns the same geometry for chaining. Idempotent — if the
- * attribute already exists, leaves it alone.
+ * `aDispNormal`. Returns the same geometry. Idempotent; a no-op without
+ * position/normal attributes.
  */
 export function addSharedDisplacementNormal(
   geometry: THREE.BufferGeometry,
   tolerance = 1e-4
 ): THREE.BufferGeometry {
-  if (geometry.getAttribute(DISP_NORMAL_ATTR)) return geometry
-
-  const position = geometry.getAttribute('position') as
-    | THREE.BufferAttribute
-    | THREE.InterleavedBufferAttribute
-    | undefined
-  const normal = geometry.getAttribute('normal') as
-    | THREE.BufferAttribute
-    | THREE.InterleavedBufferAttribute
-    | undefined
-  if (!position || !normal) return geometry
-
-  const count = position.count
-  const mult = 1 / tolerance
-
-  // Bucket vertices by quantized position.
-  const groups = new Map<string, number[]>()
-  for (let i = 0; i < count; i++) {
-    const x = Math.round(position.getX(i) * mult)
-    const y = Math.round(position.getY(i) * mult)
-    const z = Math.round(position.getZ(i) * mult)
-    const key = `${x},${y},${z}`
-    let bucket = groups.get(key)
-    if (!bucket) {
-      bucket = []
-      groups.set(key, bucket)
-    }
-    bucket.push(i)
-  }
-
-  const dispNormals = new Float32Array(count * 3)
-  for (const indices of groups.values()) {
-    let nx = 0
-    let ny = 0
-    let nz = 0
-    for (const idx of indices) {
-      nx += normal.getX(idx)
-      ny += normal.getY(idx)
-      nz += normal.getZ(idx)
-    }
-    const len = Math.hypot(nx, ny, nz)
-    if (len > 0) {
-      nx /= len
-      ny /= len
-      nz /= len
-    }
-    for (const idx of indices) {
-      dispNormals[idx * 3] = nx
-      dispNormals[idx * 3 + 1] = ny
-      dispNormals[idx * 3 + 2] = nz
-    }
-  }
-
-  geometry.setAttribute(
-    DISP_NORMAL_ATTR,
-    new THREE.BufferAttribute(dispNormals, 3)
-  )
-  return geometry
+  return addSharedImpl(THREE, geometry, tolerance)
 }
-
-const VERTEX_PARS_INJECTION = `
-#include <displacementmap_pars_vertex>
-attribute vec3 aDispNormal;
-`
-
-const VERTEX_DISPLACEMENT_INJECTION = `
-#ifdef USE_DISPLACEMENTMAP
-	transformed += normalize( aDispNormal ) * ( texture2D( displacementMap, vDisplacementMapUv ).x * displacementScale + displacementBias );
-#endif
-`
 
 /**
  * Swap the displacement direction from `objectNormal` to the `aDispNormal`
- * attribute. Idempotent on the same material (caches via `userData`).
+ * attribute via an `onBeforeCompile` hook. Idempotent on the same material.
  */
-export function applyDispNormalDisplacement(material: THREE.Material): void {
-  if (material.userData.dispNormalShaderApplied) return
-  material.userData.dispNormalShaderApplied = true
-
-  const previousOnBeforeCompile = material.onBeforeCompile
-  material.onBeforeCompile = (shader, renderer) => {
-    previousOnBeforeCompile?.call(material, shader, renderer)
-
-    shader.vertexShader = shader.vertexShader.replace(
-      '#include <displacementmap_pars_vertex>',
-      VERTEX_PARS_INJECTION.trim()
-    )
-    shader.vertexShader = shader.vertexShader.replace(
-      '#include <displacementmap_vertex>',
-      VERTEX_DISPLACEMENT_INJECTION.trim()
-    )
-  }
-
-  const previousCacheKey = material.customProgramCacheKey
-  material.customProgramCacheKey = () => {
-    const prev = previousCacheKey ? previousCacheKey.call(material) : ''
-    return prev ? `disp-normal|${prev}` : 'disp-normal'
-  }
-}
+export const applyDispNormalDisplacement: (material: THREE.Material) => void =
+  applyDispNormalImpl

--- a/src/frontend/src/stores/viewerSettingsStore.ts
+++ b/src/frontend/src/stores/viewerSettingsStore.ts
@@ -36,13 +36,16 @@ const DEFAULT_SETTINGS: ViewerSettingsState = {
   modelRotationSpeed: 0.002,
   showShadows: true,
   showStats: false,
-  ambientIntensity: 0.3,
+  // Defaults mirror the shared rig (asset-processor/lib/sceneLighting.js
+  // DEFAULT_LIGHTING) so an unconfigured viewer matches the thumbnail render.
+  // ambient/environment are absolute intensities; directional is a multiplier.
+  ambientIntensity: 0.35,
   directionalIntensity: 1.0,
   showLightHelpers: false,
   environmentPreset: 'city',
   showEnvironmentBackground: false,
   backgroundIntensity: 1.0,
-  environmentIntensity: 1.0,
+  environmentIntensity: 0.3,
 }
 
 export const useViewerSettingsStore = create<ViewerSettingsStore>()(


### PR DESCRIPTION
## Why

The model-preview viewer's **ambient** and **environment** intensity sliders did nothing — drei's `<Stage>` was injecting its own light rig that swamped the controls — and textured models could render dark/wrong because the viewer and the worker thumbnail had **drifted** copies of the same lighting/material/texture logic. This branch fixes the controls and collapses that duplicated logic into `src/asset-processor/lib/` so the **viewer, the worker thumbnail, and demo mode** share one source of truth (prompt-16, fully done).

## What's now shared (`src/asset-processor/lib/`)

| Module | Single source for |
|---|---|
| `sceneLighting.js` | the ambient/directional/point/spot rig + IBL `environmentIntensity` |
| `textureMaterial.js` | metalness/roughness/specular gating (keyed on each map, not the base-color map) + AO `uv2` |
| `displacementNormal.js` | averaged-by-position displacement normals + the two displacement GLSL chunks |
| `textureChannels.js` | texture-type → material-slot map, `TextureType`/`TextureChannel` enum mirrors, Glossiness-invert rule, channel-extraction GLSL |

The frontend imports these directly (Vite); the worker `page.evaluate` reaches them through `window.modelibr*` side-effects; demo mode builds its rig + textures from them too.

## Drifts fixed along the way

- **Inert ambient/environment controls** — `<Stage intensity={0}>` + a real `SceneLights` rig mapped from the shared descriptor, so the controls land on one rig.
- **Textured non-metal → black mirror** — viewer gated metalness on the base-color map; now keyed on the metalness map (shared rule).
- **AO collapsing all indirect light** — viewer didn't copy `uv → uv2`; shared `ensureAoMapUv2` now does.
- **Worker silently dropping Glossiness** — the worker slot map had no Glossiness entry; it now routes Glossiness → `roughnessMap` and inverts it, matching the viewer.
- **Channel-extraction shader drift** — frontend used 0-based `uChannel`, worker used 1-based `channel`; now one shared shader.
- **Demo model scaling** — `setScalar` (dropped FBX/glTF baked unit-scale) → `multiplyScalar`; demo thumbnails now light via the shared rig + a neutral RoomEnvironment IBL.

## Tests

New contract tests (meaningful, not render-label): the shared light rig responds to intensity changes, the material gating rule, AO `uv2`, displacement-normal averaging, and the texture-type→slot map / invert rule / channel index / shader uniform names. Full suites green: frontend **424** Jest + worker **79** Vitest, lint clean, `build` + `build:demo` ✓.

## Not done here (out of scope)

- A worker thumbnail and demo thumbnails want a visual spot-check (no Chromium/WebGL in this dev env). Demo lighting now includes IBL, so its thumbnails will look closer to the real worker.
- `mocks/dynamic-demo/shared.ts` `parseTextureType` keeps its own drifted name→number map, but only the consumed entries (albedo/normal/roughness/metallic) are correct; the rest are inert.