### PR TITLE
chore(release): align internal package versions to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.2.1",
+            "version": "0.3.0",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.2.1",
+    "version": "0.3.0",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## What

Bump internal package versions **0.2.1 → 0.3.0** across all five packages, mirroring the prior release-prep PRs (#525 → 0.2.0, #530 → 0.2.1):

- `package.json` + `package-lock.json` (root)
- `src/frontend/package.json` + lockfile
- `src/asset-processor/package.json` + lockfile
- `src/desktop/package.json` + lockfile
- `src/desktop-client/package.json`

13 version-string changes, nothing else. No dependency or lockfile-tree changes.

## Why

Prep step before cutting the **0.3.0** release (`version/0.3 → main`, tag `v0.3.0`). `electron-updater` reads `src/desktop/package.json`, so the desktop host/client versions must be aligned before the release merge.

## What's in 0.3.0

The `version/0.3` changeset over `main` (32 commits) bundles:

- **three.js r185** upgrade + **local-first preview IBL** (procedural, no CDN HDR) + opt-in perf-monitor overlay (#539)
- **Shared cross-runtime render lib** — unified light rig, texture-material rules, displacement-normal shader, and texture-type→slot/channel shaders shared across viewer + worker + demo (#537)
- **STL / 3MF model support** (#536)
- **Tags for all asset types** — shared tag vocabulary + filtering for texture sets (#523)
- backup-restore E2E Settings-nav repair (#535) and stale Blender test-report plumbing removal (#534)

## Verification

- All 9 JSON files parse.
- Diff is exactly 13 `0.2.1 → 0.3.0` version lines (matches the #530 shape).