### PR TITLE
fix(texture-sets): surface tags on the texture-set detail DTO

### DIFF
--- a/src/Application/TextureSets/GetTextureSetByIdQuery.cs
+++ b/src/Application/TextureSets/GetTextureSetByIdQuery.cs
@@ -50,6 +50,7 @@ internal class GetTextureSetByIdQueryHandler : IQueryHandler<GetTextureSetByIdQu
             IsEmpty = textureSet.IsEmpty,
             ThumbnailPath = textureSet.ThumbnailPath,
             PngThumbnailPath = textureSet.PngThumbnailPath,
+            Tags = textureSet.Tags.Select(t => t.Name).OrderBy(name => name).ToList(),
             Textures = textureSet.Textures.Select(t => new TextureDto
             {
                 Id = t.Id,
@@ -112,6 +113,7 @@ public record TextureSetDetailDto
     public bool IsEmpty { get; init; }
     public string? ThumbnailPath { get; init; }
     public string? PngThumbnailPath { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
     public ICollection<TextureDto> Textures { get; init; } = new List<TextureDto>();
     public ICollection<ModelSummaryDto> AssociatedModels { get; init; } = new List<ModelSummaryDto>();
     public ICollection<PackSummaryDto> Packs { get; init; } = new List<PackSummaryDto>();

--- a/tests/Application.Tests/TextureSets/GetTextureSetByIdQueryHandlerTests.cs
+++ b/tests/Application.Tests/TextureSets/GetTextureSetByIdQueryHandlerTests.cs
@@ -1,0 +1,78 @@
+using Application.Abstractions.Repositories;
+using Application.TextureSets;
+using Domain.Models;
+using Moq;
+using Xunit;
+
+namespace Application.Tests.TextureSets;
+
+public class GetTextureSetByIdQueryHandlerTests
+{
+    private readonly Mock<ITextureSetRepository> _textureSetRepository = new();
+    private readonly Mock<ITextureSetCategoryRepository> _categoryRepository = new();
+    private readonly GetTextureSetByIdQueryHandler _handler;
+
+    public GetTextureSetByIdQueryHandlerTests()
+    {
+        _categoryRepository
+            .Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TextureSetCategory>());
+        _handler = new GetTextureSetByIdQueryHandler(
+            _textureSetRepository.Object,
+            _categoryRepository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTextureSetNotFound_ReturnsFailure()
+    {
+        _textureSetRepository
+            .Setup(r => r.GetByIdAsync(99, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TextureSet?)null);
+
+        var result = await _handler.Handle(
+            new GetTextureSetByIdQuery(99), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("TextureSetNotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_MapsTagsOntoDetailDto_SortedByName()
+    {
+        // Regression: the detail DTO previously omitted Tags, so the viewer's
+        // tag editor always showed "no tags" against the real backend even
+        // though GetByIdAsync eager-loads them.
+        var textureSet = TextureSet.Create("Rust", DateTime.UtcNow);
+        textureSet.SetTags(
+            new[]
+            {
+                ModelTag.Create("metal", DateTime.UtcNow),
+                ModelTag.Create("aged", DateTime.UtcNow),
+            },
+            DateTime.UtcNow);
+        _textureSetRepository
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(textureSet);
+
+        var result = await _handler.Handle(
+            new GetTextureSetByIdQuery(1), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(new[] { "aged", "metal" }, result.Value.TextureSet.Tags);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoTags_ReturnsEmptyTagList()
+    {
+        var textureSet = TextureSet.Create("Rust", DateTime.UtcNow);
+        _textureSetRepository
+            .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(textureSet);
+
+        var result = await _handler.Handle(
+            new GetTextureSetByIdQuery(1), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.TextureSet.Tags);
+    }
+}


### PR DESCRIPTION
## Problem

The tags-all-types feature (#523) added `Tags` to the **grid** DTO (`TextureSetListDto`), the `PUT /texture-sets/{id}/tags` endpoint, and the viewer header — but **not** to the **detail** DTO. `GetTextureSetByIdQueryHandler` mapped textures, models, packs and projects but silently dropped the eager-loaded `Tags`.

The viewer's tag editor reads `textureSet.tags` from this detail endpoint (`TextureSetViewerHeader` → `useTextureSetViewerData` → `GET /texture-sets/{id}`), so against the real backend:

- opening a texture set that has tags shows **"No tags"**, and
- after saving, the refetch still returns none, so the chips never appear (tags *are* persisted to the DB, they just never round-trip into the viewer).

This was **masked entirely by demo mode**, where the MSW `getById` handler returns the raw demo object that carries `tags` — exactly the demo-vs-real divergence CLAUDE.md warns about. The repository's `GetByIdAsync` already `.Include(tp => tp.Tags)`, so the data was loaded all along; only the projection was missing.

## Fix

- Map `Tags` onto `TextureSetDetailDto`, mirroring `TextureSetListDto` (`textureSet.Tags.Select(t => t.Name).OrderBy(...)`, `IReadOnlyList<string>` defaulting to empty).
- Frontend type already declares `tags?: string[]`, so no frontend change needed.

## Tests

New `GetTextureSetByIdQueryHandlerTests`: tags are surfaced sorted by name, an empty set returns `[]`, and not-found still fails. `dotnet build` clean; full non-integration backend suite green (546 passed).

Found during the 0.3 release review. Worth landing on `version/0.3` before the `→ main` release cut.