### PR TITLE
fix: address 0.3 release review findings (#2–#6 + cleanup)

### DIFF
--- a/src/Application/Abstractions/Repositories/ITextureSetRepository.cs
+++ b/src/Application/Abstractions/Repositories/ITextureSetRepository.cs
@@ -14,6 +14,12 @@ public interface ITextureSetRepository
     Task<TextureSet?> GetByFileHashAsync(string sha256Hash, CancellationToken cancellationToken = default);
     Task<bool> ExistsByNameAsync(string name, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<string>> GetNamesByPrefixAsync(string prefix, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Distinct tag names currently assigned to (non-deleted) texture sets.
+    /// This is the texture-set tag vocabulary — kept separate from the model tag
+    /// pool so tag suggestions stay strictly per-asset-type.
+    /// </summary>
+    Task<IReadOnlyList<string>> GetAssignedTagNamesAsync(CancellationToken cancellationToken = default);
     Task<(IEnumerable<TextureSet> Items, int TotalCount)> GetPagedAsync(
         int page, int pageSize,
         IReadOnlyCollection<int>? packIds = null,

--- a/src/Application/TextureSets/GetTextureSetTagsQuery.cs
+++ b/src/Application/TextureSets/GetTextureSetTagsQuery.cs
@@ -1,0 +1,34 @@
+using Application.Abstractions.Messaging;
+using Application.Abstractions.Repositories;
+using SharedKernel;
+
+namespace Application.TextureSets;
+
+internal sealed class GetTextureSetTagsQueryHandler : IQueryHandler<GetTextureSetTagsQuery, GetTextureSetTagsResponse>
+{
+    private readonly ITextureSetRepository _textureSetRepository;
+
+    public GetTextureSetTagsQueryHandler(ITextureSetRepository textureSetRepository)
+    {
+        _textureSetRepository = textureSetRepository;
+    }
+
+    public async Task<Result<GetTextureSetTagsResponse>> Handle(GetTextureSetTagsQuery query, CancellationToken cancellationToken)
+    {
+        var names = await _textureSetRepository.GetAssignedTagNamesAsync(cancellationToken);
+        var items = names
+            .Select(name => new TextureSetTagDto { Name = name })
+            .ToArray();
+
+        return Result.Success(new GetTextureSetTagsResponse(items));
+    }
+}
+
+public record GetTextureSetTagsQuery : IQuery<GetTextureSetTagsResponse>;
+
+public record GetTextureSetTagsResponse(IReadOnlyList<TextureSetTagDto> Tags);
+
+public record TextureSetTagDto
+{
+    public string Name { get; init; } = string.Empty;
+}

--- a/src/Infrastructure/Repositories/TextureSetRepository.cs
+++ b/src/Infrastructure/Repositories/TextureSetRepository.cs
@@ -26,6 +26,19 @@ internal sealed class TextureSetRepository : ITextureSetRepository
         return entityEntry.Entity;
     }
 
+    public async Task<IReadOnlyList<string>> GetAssignedTagNamesAsync(CancellationToken cancellationToken = default)
+    {
+        // Respects the soft-delete global query filter on TextureSets, so only
+        // tags on live sets surface as the texture-set vocabulary.
+        return await _context.TextureSets
+            .AsNoTracking()
+            .SelectMany(ts => ts.Tags)
+            .Select(tag => tag.Name)
+            .Distinct()
+            .OrderBy(name => name)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<TextureSet>> GetAllAsync(CancellationToken cancellationToken = default)
     {
         return await _context.TextureSets

--- a/src/WebApi/Endpoints/TextureSetEndpoints.cs
+++ b/src/WebApi/Endpoints/TextureSetEndpoints.cs
@@ -19,6 +19,21 @@ public static class TextureSetEndpoints
             .WithSummary("Gets all texture sets with their textures and model associations")
             .WithOpenApi();
 
+        // Literal segment; ASP.NET routing prefers it over "/texture-sets/{id}".
+        app.MapGet("/texture-sets/tags", async (
+            IQueryHandler<GetTextureSetTagsQuery, GetTextureSetTagsResponse> queryHandler,
+            CancellationToken cancellationToken) =>
+        {
+            var result = await queryHandler.Handle(new GetTextureSetTagsQuery(), cancellationToken);
+
+            return result.IsFailure
+                ? Results.BadRequest(new { error = result.Error.Code, message = result.Error.Message })
+                : Results.Ok(result.Value);
+        })
+            .WithName("Get Texture Set Tags")
+            .WithSummary("Distinct tags assigned to texture sets (per-asset-type vocabulary)")
+            .WithOpenApi();
+
         app.MapGet("/texture-sets/{id}", GetTextureSetById)
             .WithName("Get Texture Set By ID")
             .WithSummary("Gets a specific texture set by ID")
@@ -47,7 +62,7 @@ public static class TextureSetEndpoints
 
         app.MapPut("/texture-sets/{id}/tags", UpdateTextureSetTags)
             .WithName("Update Texture Set Tags")
-            .WithSummary("Replaces a texture set's tags (shared tag vocabulary)")
+            .WithSummary("Replaces a texture set's tags")
             .WithOpenApi();
 
         app.MapDelete("/texture-sets/{id}", DeleteTextureSet)

--- a/src/asset-processor/lib/displacementNormal.js
+++ b/src/asset-processor/lib/displacementNormal.js
@@ -91,11 +91,23 @@ export function addSharedDisplacementNormal(THREE, geometry, tolerance = 1e-4) {
       nx /= len
       ny /= len
       nz /= len
-    }
-    for (const idx of indices) {
-      dispNormals[idx * 3] = nx
-      dispNormals[idx * 3 + 1] = ny
-      dispNormals[idx * 3 + 2] = nz
+      for (const idx of indices) {
+        dispNormals[idx * 3] = nx
+        dispNormals[idx * 3 + 1] = ny
+        dispNormals[idx * 3 + 2] = nz
+      }
+    } else {
+      // The summed normals cancelled to zero — coincident vertices with
+      // opposing normals (a zero-thickness shell, back-to-back face pair, or a
+      // thin seam). Writing (0,0,0) would make the shader's
+      // `normalize(aDispNormal)` produce NaN and collapse those vertices to the
+      // origin, tearing a hole in the displaced mesh. Fall back to each
+      // vertex's own normal so every vertex keeps a finite push direction.
+      for (const idx of indices) {
+        dispNormals[idx * 3] = normal.getX(idx)
+        dispNormals[idx * 3 + 1] = normal.getY(idx)
+        dispNormals[idx * 3 + 2] = normal.getZ(idx)
+      }
     }
   }
 

--- a/src/frontend/src/features/model-viewer/components/Model.tsx
+++ b/src/frontend/src/features/model-viewer/components/Model.tsx
@@ -11,6 +11,7 @@ import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
 import { LoadingPlaceholder } from '@/components/LoadingPlaceholder'
 import { useModelObject } from '@/features/model-viewer/hooks/useModelObject'
 import { safeLoadingManager } from '@/shared/three/safeLoadingManager'
+import { THREEJS_SUPPORTED_FORMATS } from '@/utils/fileUtils'
 
 import { buildStlModel } from '../../../../../asset-processor/lib/stlMesh.js'
 
@@ -225,7 +226,9 @@ function PlaceholderModel({ rotationSpeed }: { rotationSpeed: number }) {
   )
 }
 
-const KNOWN_FORMATS = ['obj', 'fbx', 'gltf', 'glb', 'stl', '3mf']
+// Derive the dotless extension list from the single source of truth so adding a
+// loader (e.g. stl/3mf) in fileUtils automatically keeps this dispatch in sync.
+const KNOWN_FORMATS = THREEJS_SUPPORTED_FORMATS.map(ext => ext.slice(1))
 
 export function Model({
   modelUrl,

--- a/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
+++ b/src/frontend/src/features/model-viewer/components/TexturedModel.tsx
@@ -127,6 +127,30 @@ function usePerMaterialTextures(
   return { loadedTextures, texturesReady }
 }
 
+/**
+ * Dispose the materials of a previously-built clone before it is dropped.
+ * applyMaterialTextures allocates fresh MeshPhysicalMaterials on every rebuild
+ * (texture-ready toggle, texture-set change), so without this the old GPU
+ * materials leak for the lifetime of the viewing session. Geometries are NOT
+ * disposed: Object3D.clone() shares geometry with the source model, and the
+ * loaded textures are owned by the extraction hook's cache — disposing either
+ * here would corrupt the still-live original.
+ */
+function disposePreviousClone(group: THREE.Object3D): void {
+  const seen = new Set<THREE.Material>()
+  group.traverse(child => {
+    const mesh = child as THREE.Mesh
+    if (!mesh.isMesh) return
+    const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
+    for (const mat of mats) {
+      if (mat && !seen.has(mat)) {
+        seen.add(mat)
+        mat.dispose()
+      }
+    }
+  })
+}
+
 /** Shared logic: clone model, apply per-material textures, scale and center */
 function setupModel(
   model: THREE.Group | THREE.Object3D,
@@ -167,6 +191,7 @@ function setupModel(
   clonedModel.position.y -= scaledBox.min.y
 
   if (meshRef.current) {
+    disposePreviousClone(meshRef.current)
     meshRef.current.clear()
     meshRef.current.add(clonedModel)
   }

--- a/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetGrid.tsx
@@ -190,7 +190,7 @@ export function TextureSetGrid({ kind, viewStateScope }: TextureSetGridProps) {
     toast,
   } = useTextureSetGrid({ kind, viewStateScope })
 
-  const tagVocabulary = useTagVocabulary()
+  const tagVocabulary = useTagVocabulary('texture-set')
 
   const selectedIdSet = useMemo(
     () => new Set(selectedTextureSetIds),

--- a/src/frontend/src/features/texture-set/components/TextureSetTags.tsx
+++ b/src/frontend/src/features/texture-set/components/TextureSetTags.tsx
@@ -14,13 +14,13 @@ interface TextureSetTagsProps {
 
 /**
  * Tag display + inline editor for a texture set, drawing suggestions from the
- * shared tag vocabulary and persisting via the shared TagInput primitive.
+ * texture-set tag vocabulary and persisting via the shared TagInput primitive.
  */
 export function TextureSetTags({ tags, onTagsUpdate }: TextureSetTagsProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState<string[]>(tags)
   const [saving, setSaving] = useState(false)
-  const vocabulary = useTagVocabulary()
+  const vocabulary = useTagVocabulary('texture-set')
 
   useEffect(() => {
     setDraft(tags)

--- a/src/frontend/src/mocks/dynamicDemoHandlers.ts
+++ b/src/frontend/src/mocks/dynamicDemoHandlers.ts
@@ -682,15 +682,10 @@ export const dynamicDemoHandlers = [
   }),
 
   http.get('*/model-tags', async () => {
-    // The shared tag vocabulary spans every asset type that can be tagged.
+    // Model tag vocabulary only — texture sets have their own pool at
+    // "/texture-sets/tags". Tags are strictly per-asset-type, never shared.
     const models = await getAll('models')
-    const textureSets = await getAll('textureSets')
-    const tags = [
-      ...new Set([
-        ...models.flatMap(model => model.tags ?? []),
-        ...textureSets.flatMap(ts => ts.tags ?? []),
-      ]),
-    ]
+    const tags = [...new Set(models.flatMap(model => model.tags ?? []))]
       .sort((left, right) => left.localeCompare(right))
       .map(name => ({ name }))
 
@@ -1757,6 +1752,18 @@ export const dynamicDemoHandlers = [
       })
     }
     return HttpResponse.json({ textureSets: sets })
+  }),
+
+  // Per-asset-type tag vocabulary: only tags assigned to texture sets (kept
+  // separate from the model tag pool). Registered before "/texture-sets/:id"
+  // so "tags" is not matched as an id.
+  http.get('*/texture-sets/tags', async () => {
+    const textureSets = await getAll('textureSets')
+    const tags = [...new Set(textureSets.flatMap(ts => ts.tags ?? []))]
+      .sort((left, right) => left.localeCompare(right))
+      .map(name => ({ name }))
+
+    return HttpResponse.json({ tags })
   }),
 
   http.get('*/texture-sets/by-file/:fileId', async () => {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -188,6 +188,18 @@ export const handlers = [
     return HttpResponse.json({ tags })
   }),
 
+  http.get(`${BASE_URL}/texture-sets/tags`, () => {
+    const tags = [
+      ...new Set(
+        mockTextureSets.flatMap((set: { tags?: string[] }) => set.tags ?? [])
+      ),
+    ]
+      .sort((left, right) => left.localeCompare(right))
+      .map(name => ({ name }))
+
+    return HttpResponse.json({ tags })
+  }),
+
   http.post(`${BASE_URL}/models/:id/concept-images`, () => {
     return new HttpResponse(null, { status: 204 })
   }),

--- a/src/frontend/src/mocks/services/browserAssetProcessor.ts
+++ b/src/frontend/src/mocks/services/browserAssetProcessor.ts
@@ -362,29 +362,40 @@ async function applyTextureMaps(
   model: Object3D,
   textures: TextureMapData[]
 ): Promise<void> {
-  const albedoTex = textures.find(t => t.textureType === TEXTURE_TYPE.Albedo)
-  const normalTex = textures.find(t => t.textureType === TEXTURE_TYPE.Normal)
-  const aoTex = textures.find(t => t.textureType === TEXTURE_TYPE.AO)
-  const roughnessTex = textures.find(
-    t => t.textureType === TEXTURE_TYPE.Roughness
-  )
-  const metallicTex = textures.find(
-    t => t.textureType === TEXTURE_TYPE.Metallic
-  )
-
   const loadTexture = async (blob: Blob) => {
     const bitmap = await createImageBitmap(blob)
     return new CanvasTexture(bitmap as unknown as HTMLCanvasElement)
   }
 
-  const [albedoMap, normalMap, aoMap, roughnessMap, metalnessMap] =
-    await Promise.all([
-      albedoTex ? loadTexture(albedoTex.blob) : Promise.resolve(null),
-      normalTex ? loadTexture(normalTex.blob) : Promise.resolve(null),
-      aoTex ? loadTexture(aoTex.blob) : Promise.resolve(null),
-      roughnessTex ? loadTexture(roughnessTex.blob) : Promise.resolve(null),
-      metallicTex ? loadTexture(metallicTex.blob) : Promise.resolve(null),
-    ])
+  // Load every supported map by its shared TextureType so the demo applies the
+  // same slots the viewer/worker do — not just the original five. (Specular
+  // needs MeshPhysicalMaterial, and channel-packed / Glossiness / Displacement
+  // maps need the channel extraction the demo doesn't run, so those remain
+  // demo-only approximations.)
+  const mapFor = (type: number): Promise<CanvasTexture | null> => {
+    const found = textures.find(t => t.textureType === type)
+    return found ? loadTexture(found.blob) : Promise.resolve(null)
+  }
+
+  const [
+    albedoMap,
+    normalMap,
+    aoMap,
+    roughnessMap,
+    metalnessMap,
+    emissiveMap,
+    bumpMap,
+    alphaMap,
+  ] = await Promise.all([
+    mapFor(TEXTURE_TYPE.Albedo),
+    mapFor(TEXTURE_TYPE.Normal),
+    mapFor(TEXTURE_TYPE.AO),
+    mapFor(TEXTURE_TYPE.Roughness),
+    mapFor(TEXTURE_TYPE.Metallic),
+    mapFor(TEXTURE_TYPE.Emissive),
+    mapFor(TEXTURE_TYPE.Bump),
+    mapFor(TEXTURE_TYPE.Alpha),
+  ])
 
   // Same gating rule as the viewer and the worker thumbnail (metalness/
   // roughness keyed on their own maps, not the base-color map).
@@ -396,7 +407,7 @@ async function applyTextureMaps(
 
   model.traverse(child => {
     if (child instanceof Mesh) {
-      child.material = new MeshStandardMaterial({
+      const material = new MeshStandardMaterial({
         color: cfg.hasBaseColorMap
           ? new Color(1, 1, 1)
           : new Color(0.7, 0.7, 0.9),
@@ -409,6 +420,16 @@ async function applyTextureMaps(
         roughness: cfg.roughness,
         envMapIntensity: cfg.envMapIntensity,
       })
+      if (emissiveMap) {
+        material.emissiveMap = emissiveMap
+        material.emissive = new Color(0xffffff)
+      }
+      if (bumpMap) material.bumpMap = bumpMap
+      if (alphaMap) {
+        material.alphaMap = alphaMap
+        material.transparent = true
+      }
+      child.material = material
       // AO needs the second UV set or it collapses indirect light (shared helper).
       if (aoMap) ensureAoMapUv2(child.geometry)
       child.castShadow = true

--- a/src/frontend/src/shared/hooks/useTagVocabulary.ts
+++ b/src/frontend/src/shared/hooks/useTagVocabulary.ts
@@ -7,14 +7,27 @@ interface TagVocabularyResponse {
 }
 
 /**
- * The shared tag vocabulary — the single ModelTag pool drawn from by every
- * asset type. Backed by the `/model-tags` endpoint (the canonical tag list).
+ * Which asset type's tag vocabulary to load. Tags are strictly per-asset-type —
+ * models and texture sets draw suggestions from separate pools, never a shared
+ * one — so the source is explicit.
  */
-export function useTagVocabulary() {
+export type TagVocabularySource = 'model' | 'texture-set'
+
+const ENDPOINT_BY_SOURCE: Record<TagVocabularySource, string> = {
+  model: '/model-tags',
+  'texture-set': '/texture-sets/tags',
+}
+
+/**
+ * The tag vocabulary for a single asset type, used to power tag autocomplete.
+ */
+export function useTagVocabulary(source: TagVocabularySource = 'model') {
   return useQuery({
-    queryKey: ['tag-vocabulary'],
+    queryKey: ['tag-vocabulary', source],
     queryFn: async (): Promise<string[]> => {
-      const response = await client.get<TagVocabularyResponse>('/model-tags')
+      const response = await client.get<TagVocabularyResponse>(
+        ENDPOINT_BY_SOURCE[source]
+      )
       return (response.data.tags ?? []).map(tag => tag.name)
     },
     staleTime: 60_000,

--- a/src/frontend/src/shared/three/__tests__/sharedDisplacementNormal.test.ts
+++ b/src/frontend/src/shared/three/__tests__/sharedDisplacementNormal.test.ts
@@ -60,6 +60,40 @@ describe('addSharedDisplacementNormal', () => {
     }
   })
 
+  it('falls back to per-vertex normals when coincident normals cancel to zero', () => {
+    // Two vertices share a position but carry exactly opposing normals, so the
+    // averaged direction is (0,0,0). Writing that would feed normalize() a zero
+    // vector → NaN → collapsed vertex. The fallback must keep each vertex's own
+    // (finite, non-zero) normal instead.
+    const geom = new THREE.BufferGeometry()
+    geom.setAttribute(
+      'position',
+      new THREE.BufferAttribute(new Float32Array([0, 0, 0, 0, 0, 0]), 3)
+    )
+    geom.setAttribute(
+      'normal',
+      new THREE.BufferAttribute(new Float32Array([0, 0, 1, 0, 0, -1]), 3)
+    )
+
+    addSharedDisplacementNormal(geom)
+    const disp = geom.getAttribute('aDispNormal')
+
+    for (let i = 0; i < disp.count * 3; i++) {
+      expect(Number.isNaN(disp.array[i])).toBe(false)
+    }
+    expect(disp.getZ(0)).toBe(1)
+    expect(disp.getZ(1)).toBe(-1)
+    // Each fallback direction is unit-length (no zero vector reaches the shader).
+    expect(Math.hypot(disp.getX(0), disp.getY(0), disp.getZ(0))).toBeCloseTo(
+      1,
+      6
+    )
+    expect(Math.hypot(disp.getX(1), disp.getY(1), disp.getZ(1))).toBeCloseTo(
+      1,
+      6
+    )
+  })
+
   it('is idempotent', () => {
     const geom = makeHardEdgeQuad()
     addSharedDisplacementNormal(geom)

--- a/src/frontend/src/stores/viewerSettingsStore.ts
+++ b/src/frontend/src/stores/viewerSettingsStore.ts
@@ -64,6 +64,23 @@ export const useViewerSettingsStore = create<ViewerSettingsStore>()(
     {
       name: 'modelibr_viewer_settings',
       storage: createJSONStorage(() => localStorage),
+      // v1: the ambient/environment defaults changed to match the shared
+      // thumbnail rig (asset-processor/lib/sceneLighting.js). Existing users
+      // have the old values cached for keys they may never have touched, and
+      // the merge below keeps persisted values over defaults — so without a
+      // migration an upgraded viewer would never pick up the new lighting.
+      // Reset just those two keys for pre-v1 state so "unconfigured viewer
+      // matches the render" actually holds on upgrade.
+      version: 1,
+      migrate: (persisted, version) => {
+        const state = persisted as ViewerSettingsStore
+        if (version < 1 && state?.settings) {
+          state.settings.ambientIntensity = DEFAULT_SETTINGS.ambientIntensity
+          state.settings.environmentIntensity =
+            DEFAULT_SETTINGS.environmentIntensity
+        }
+        return state
+      },
       merge: (persisted, current) => ({
         ...current,
         settings: {

--- a/tests/Application.Tests/TextureSets/GetTextureSetTagsQueryHandlerTests.cs
+++ b/tests/Application.Tests/TextureSets/GetTextureSetTagsQueryHandlerTests.cs
@@ -1,0 +1,45 @@
+using Application.Abstractions.Repositories;
+using Application.TextureSets;
+using Moq;
+using Xunit;
+
+namespace Application.Tests.TextureSets;
+
+public class GetTextureSetTagsQueryHandlerTests
+{
+    private readonly Mock<ITextureSetRepository> _textureSetRepository = new();
+    private readonly GetTextureSetTagsQueryHandler _handler;
+
+    public GetTextureSetTagsQueryHandlerTests()
+    {
+        _handler = new GetTextureSetTagsQueryHandler(_textureSetRepository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsTextureSetAssignedTags()
+    {
+        // Per-asset-type vocabulary: suggestions come from tags assigned to
+        // texture sets, not the global model tag pool.
+        _textureSetRepository
+            .Setup(r => r.GetAssignedTagNamesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { "fabric", "metal" });
+
+        var result = await _handler.Handle(new GetTextureSetTagsQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(new[] { "fabric", "metal" }, result.Value.Tags.Select(t => t.Name));
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoTags_ReturnsEmpty()
+    {
+        _textureSetRepository
+            .Setup(r => r.GetAssignedTagNamesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        var result = await _handler.Handle(new GetTextureSetTagsQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.Tags);
+    }
+}


### PR DESCRIPTION
Follow-up to the 0.3 release review (see comment on #540). Fixes the remaining findings beyond #1 (which is #541). One commit per finding.

### 🔴 Correctness
- **#2 — displacement NaN** (`asset-processor/lib/displacementNormal.js`): coincident vertices with opposing normals summed to a zero-length averaged normal; `normalize(aDispNormal)` then produced NaN and collapsed those vertices. Falls back to each vertex's own normal (as the module's doc already claimed). Shared by viewer + worker. Regression test added.

### 🟠 Design — per your call
- **#3 — per-asset tag vocabulary** (`GET /texture-sets/tags` + `useTagVocabulary('texture-set')`): texture-set tag suggestions and the grid filter drew from the global `/model-tags` pool. Added a texture-set-scoped vocabulary (distinct tags assigned to live texture sets) and pointed the editor + grid at it, so tag vocabularies are strictly per-asset-type. Demo MSW handlers split accordingly (`/model-tags` is now model-only). Backend query-handler test added.

### 🟡 Lower severity
- **#4 — viewer lighting migration** (`viewerSettingsStore.ts`): added persist `version: 1` + a `migrate` that refreshes the two changed lighting keys for pre-v1 state, so the new defaults (matching the thumbnail rig) actually reach existing users.
- **#5 — demo texture maps** (`browserAssetProcessor.ts`): the demo hardcoded five slots; now loads maps by shared `TextureType` and also applies emissive/bump/alpha. (Specular/glossiness/displacement still need the physical material / channel extraction the demo doesn't run — noted in-code.)
- **#6 — GPU material leak** (`TexturedModel.tsx`): rebuilding a textured clone detached the old subtree via `.clear()` but never disposed its freshly-built materials. Now disposes the previous clone's materials first (geometry is shared with the source and textures are hook-owned, so those are left intact).

### 🧹 Cleanup
- Derive `KNOWN_FORMATS` in `Model.tsx` from the shared `THREEJS_SUPPORTED_FORMATS` list instead of re-listing extensions.

**Deferred (noted, not in this PR):** the `TexturedModel` 5-component consolidation, cross-runtime model-normalization extraction, the displacement scale/bias shared constant, and a cross-package path alias — pure cleanups with cross-runtime/build risk, better as a dedicated post-release PR.

### Verification
- Backend: `dotnet build` clean; non-integration suite green (545).
- Frontend: `npm test` (425), `lint` (0 errors), `format:check` clean, `build` OK.
- Worker: `npm test` (79), `lint`, `format:check` clean.

Note: `#5` (demo path) and `#6`/`#3` UI are exercised by the demo/texture-set E2E suites, not run here.