### PR TITLE
ci: keep GPU-dependent E2E and video jobs off pull requests

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -334,7 +334,11 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         needs: [detect-changes]
-        if: needs.detect-changes.outputs.e2e-relevant == 'true' || github.event_name == 'workflow_dispatch'
+        # GPU-dependent Playwright render tests flake on GPU-less GitHub runners
+        # (SwiftShader software GL times out at the drained-runner tail). They run
+        # on the Mac Mini GPU lane via `npm run test:all`; on GitHub they are
+        # manual-only (workflow_dispatch), so the flake never gates a PR.
+        if: github.event_name == 'workflow_dispatch'
         # Successful E2E runs take ~15-20 minutes. A hard ceiling prevents a
         # single hung step (apt mirror flake, stuck Playwright test) from
         # silently consuming the 6h runner default.
@@ -461,6 +465,11 @@ jobs:
         name: Generate Feature Videos
         runs-on: ubuntu-latest
         needs: [detect-changes]
+        # Video capture drives the same GPU-dependent WebGL render as the E2E
+        # suite and flakes on GPU-less runners. It is only needed to refresh the
+        # docs-site videos on main, so restrict it to main pushes + manual
+        # dispatch — it no longer runs (or flakes) on PRs.
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         # Historically this job completes in ~12 minutes. A hard ceiling prevents
         # a single hung step (e.g. apt mirror flake during `playwright install
         # --with-deps`) from silently consuming the 6h runner default.
@@ -641,18 +650,22 @@ jobs:
                   .github/scripts/fetch-test-reports.sh
 
             - name: Fail if feature video generation did not succeed
-              if: needs.generate-videos.result != 'success'
+              # Only a genuine failure is fatal; a skipped video job (on PRs and
+              # non-main branches, where videos aren't regenerated) is expected.
+              if: needs.generate-videos.result == 'failure'
               run: |
                   echo "Feature video generation must succeed before building documentation."
                   exit 1
 
             - name: Download feature videos
+              if: needs.generate-videos.result == 'success'
               uses: actions/download-artifact@v5
               with:
                   name: feature-videos-${{ github.run_number }}
                   path: docs/static/videos/
 
             - name: Verify feature videos
+              if: needs.generate-videos.result == 'success'
               run: |
                   expected_videos=(
                     model-management.webm
@@ -712,8 +725,8 @@ jobs:
         name: Deploy to GitHub Pages
         runs-on: ubuntu-latest
         needs: [build-docs]
-        # Always deploy after docs are built - environment protection must be configured in repo settings
-        if: always() && needs.build-docs.result == 'success'
+        # Deploy only from main; environment protection is also configured in repo settings.
+        if: always() && needs.build-docs.result == 'success' && github.ref == 'refs/heads/main'
 
         steps:
             - name: Deploy to GitHub Pages


### PR DESCRIPTION
The **CI trim** from the release-review discussion. Implements the `testing_strategy` plan: GitHub runs the fast + required lanes; the GPU-dependent suites move off PRs to the local GPU lane.

## Why

`E2E Tests`, `CI Status`, and `Generate Feature Videos` all drive real WebGL rendering, which is unreliable on GPU-less GitHub runners (SwiftShader software GL times out at the drained-runner tail — see the review thread on #540). Result: **every PR showed red on these checks even though no code change could fix them**, while the required unit gates (`Backend`/`Frontend`/`Asset Processor`) were green. Proven environmental: #540 — a version-string-only bump — failed the identical E2E scenarios.

## What

- **`e2e-tests`** → `workflow_dispatch` only. Runs on the local GPU lane via `npm run test:all`; manual on GitHub. Never gates a PR. (`CI Status` aggregates E2E, and a *skipped* job is not a failure, so it goes green too.)
- **`generate-videos`** → `main` pushes + `workflow_dispatch` only. Still refreshes the docs-site videos on `main`; no longer runs (or flakes) on PRs.
- **`build-docs`** → tolerate a skipped video job: the "Fail if feature video generation did not succeed" gate now fires only on a genuine `failure`, and the video download/verify steps are gated on `generate-videos` success. So docs + **demo build (`build:demo`)** still validate on PRs and stay green.
- **`deploy-docs`** → guarded to `refs/heads/main`, so a video-less PR docs build can never deploy Pages.

**Unchanged:** the required gates (`Backend`/`Frontend`/`Asset Processor` unit) run on every PR exactly as before. On `main`, E2E is manual/dispatch but videos + docs deploy run as before.

## Rollout note

CI config changes apply going forward. The four open 0.3 PRs (#541/#542/#543/#540) are already **mergeable now** on their green required checks — the red E2E/video is non-required. They pick up this trimmed workflow once they include it (merge `version/0.3` after this lands, or just merge them as-is). Future PRs into `version/0.3` won't show the flake red at all.

## Verification
Workflow YAML parses; each edited job has exactly one job-level `if`; conditions verified (`e2e-tests`=dispatch-only, `generate-videos`=main+dispatch, `deploy-docs`=main-guarded, `build-docs` still `always()`).
