### PR TITLE
chore(ci): genericize local-test-lane references

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -336,7 +336,7 @@ jobs:
         needs: [detect-changes]
         # GPU-dependent Playwright render tests flake on GPU-less GitHub runners
         # (SwiftShader software GL times out at the drained-runner tail). They run
-        # on the Mac Mini GPU lane via `npm run test:all`; on GitHub they are
+        # on the local GPU lane via `npm run test:all`; on GitHub they are
         # manual-only (workflow_dispatch), so the flake never gates a PR.
         if: github.event_name == 'workflow_dispatch'
         # Successful E2E runs take ~15-20 minutes. A hard ceiling prevents a

--- a/scripts/test-runner/README.md
+++ b/scripts/test-runner/README.md
@@ -1,8 +1,8 @@
 # Local test runner
 
 One command to run as many of the project's test suites as possible on this
-machine (great for the Mac Mini M4, which is far faster than GitHub's shared
-runners) and get a single openable HTML report.
+machine (great for a local machine with a real GPU, which is far faster than
+GitHub's shared runners) and get a single openable HTML report.
 
 It does **not** reimplement any test orchestration — it shells out to each
 suite's existing command (e.g. `tests/e2e`'s Docker runners) and aggregates the


### PR DESCRIPTION
Describe the local GPU test lane generically in the CI workflow comment and the test-runner README, instead of naming a specific machine. What runs locally is separate from the public repository.

Comment-only / docs change — no behaviour change.

Note: #544's already-merged commit message still contains the old wording; rewriting it would require a force-push to the protected `version/0.3`, so it's left as-is (history), while all current file content, docs, and PR descriptions are scrubbed.