### PR TITLE
test(e2e): GPU-render scenarios to @serial lane; restore E2E on PRs

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -334,11 +334,12 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         needs: [detect-changes]
-        # GPU-dependent Playwright render tests flake on GPU-less GitHub runners
-        # (SwiftShader software GL times out at the drained-runner tail). They run
-        # on the local GPU lane via `npm run test:all`; on GitHub they are
-        # manual-only (workflow_dispatch), so the flake never gates a PR.
-        if: github.event_name == 'workflow_dispatch'
+        # Runs the fast tier on relevant PRs. GPU-render-dependent scenarios are
+        # tagged @serial and excluded from this lane (the chromium project
+        # grep-inverts @serial); they run on the local GPU lane via
+        # `npm run test:all`. Keeps the GPU-less-runner render flake off PRs
+        # without dropping the rest of E2E.
+        if: needs.detect-changes.outputs.e2e-relevant == 'true' || github.event_name == 'workflow_dispatch'
         # Successful E2E runs take ~15-20 minutes. A hard ceiling prevents a
         # single hung step (apt mirror flake, stuck Playwright test) from
         # silently consuming the 6h runner default.

--- a/tests/e2e/features/00-texture-sets/09-shader-channel-extraction.feature
+++ b/tests/e2e/features/00-texture-sets/09-shader-channel-extraction.feature
@@ -32,7 +32,7 @@ Feature: Shader-based Channel Extraction in 3D Viewer
     And the file should have channel "B" set to "Metallic"
     And I take a screenshot named "orm-split-channels-configured"
 
-  @viewer @texture-applied
+  @viewer @texture-applied @serial
   Scenario: Texture set textures are applied to 3D model
     # Create texture set with ALL possible texture types
     Given I am on the texture sets page

--- a/tests/e2e/features/00-texture-sets/11-exr-preview.feature
+++ b/tests/e2e/features/00-texture-sets/11-exr-preview.feature
@@ -5,7 +5,7 @@ Feature: EXR Texture Preview Loading
   using the EXRLoader with proper color space handling.
   Preview tab is only available for Universal (Global Materials) texture sets.
 
-  @timeout:300000
+  @serial @timeout:300000
   Scenario: Preview tab renders without errors when texture set contains EXR textures
     Given I am on the texture sets page
     When I create a universal texture set with EXR textures named "exr_preview_test"
@@ -16,7 +16,7 @@ Feature: EXR Texture Preview Loading
     And no console errors should be present
     And I take a screenshot named "exr-preview-no-crash"
 
-  @timeout:300000
+  @serial @timeout:300000
   Scenario: Preview tab renders with mixed EXR and standard textures
     Given I am on the texture sets page
     When I create a universal texture set with mixed EXR and standard textures named "mixed_exr_test"

--- a/tests/e2e/features/00-texture-sets/17-tiff-preview.feature
+++ b/tests/e2e/features/00-texture-sets/17-tiff-preview.feature
@@ -4,7 +4,7 @@ Feature: TIFF Texture Preview Loading
   in the 3D viewer without errors. Browsers cannot decode TIFF natively;
   textures are routed through utif2 and re-wrapped as Three.js textures.
 
-  @timeout:300000
+  @serial @timeout:300000
   Scenario: Preview tab renders without errors when texture set contains a TIFF texture
     Given I am on the texture sets page
     When I create a universal texture set with a TIFF texture named "tiff_preview_test"
@@ -15,7 +15,7 @@ Feature: TIFF Texture Preview Loading
     And no console errors should be present
     And I take a screenshot named "tiff-preview-no-crash"
 
-  @timeout:300000
+  @serial @timeout:300000
   Scenario: Preview tab renders with mixed TIFF and standard textures
     Given I am on the texture sets page
     When I create a universal texture set with mixed TIFF and standard textures named "mixed_tiff_test"

--- a/tests/e2e/features/01-model-viewer/01-viewer-rendering.feature
+++ b/tests/e2e/features/01-model-viewer/01-viewer-rendering.feature
@@ -7,7 +7,7 @@ Feature: Model 3D Viewer Rendering
       | name                 |
       | multi-version-model  |
 
-  @three-js @rendering @timeout:300000
+  @three-js @rendering @serial @timeout:300000
   Scenario: Model renders in 3D canvas after opening viewer
     Given I am on the model viewer page for "multi-version-model"
     Then the 3D canvas should be visible

--- a/tests/e2e/features/01-model-viewer/02-version-switching.feature
+++ b/tests/e2e/features/01-model-viewer/02-version-switching.feature
@@ -21,6 +21,7 @@ Feature: Version Switching
     And version 2 should have a thumbnail image
     And I capture a screenshot of the version dropdown with thumbnails
 
+  @serial
   Scenario: Switching versions updates the viewer
     Given I am on the model viewer page for "multi-version-model"
     And I am viewing version 2


### PR DESCRIPTION
Corrects the earlier CI trim (#544), which was too blunt: it gated the whole monolithic \`e2e-tests\` job to \`workflow_dispatch\`, dropping **all** E2E from PRs (uploads, CRUD, navigation, settings, error handling) — not just the flaky GPU ones.

## What
- **Restore E2E on PRs**: \`e2e-tests\` runs the fast tier again (\`e2e-relevant || workflow_dispatch\`).
- **Tag the GPU-render scenarios \`@serial\`** so they leave the PR lane (the \`chromium\` fast project grep-inverts \`@serial\`) and run on the local GPU lane via \`npm run test:all\`:
  - `01-viewer-rendering` → "Model renders in 3D canvas"
  - `02-version-switching` → "Switching versions updates the viewer"
  - `09-shader-channel-extraction` → "Texture set textures are applied to 3D model"
  - `11-exr-preview` / `17-tiff-preview` → preview-canvas render scenarios
- **`generate-videos` stays trimmed** (main + dispatch) — it's GPU + only needed to refresh the docs videos on `main`.

## Why `@serial` (not `@slow`)
`@slow` is **not** local-only — `nightly-e2e.yml` runs `--project=slow` on GitHub's GPU-less runner at 3 AM, so `@slow` GPU tests would still flake nightly. `@serial` is excluded from the PR fast lane **and** never run by any GitHub workflow (CLAUDE.md rule 3), so these run only where a real GPU makes them deterministic.

Root cause is the GPU-less render environment, not the tests — so this tags honestly (per rule 3) rather than weakening anything. Non-render scenarios (e.g. the Files-tab channel-config check) stay on PRs.