### PR TITLE
test(e2e): route GPU-render flaky scenarios to the local @serial lane

### DIFF
--- a/tests/e2e/demo-tests/demo-mode.spec.ts
+++ b/tests/e2e/demo-tests/demo-mode.spec.ts
@@ -132,8 +132,18 @@ async function addModelToOpenPack(page, modelName, modelId) {
     });
 }
 
+// Some demo scenarios open 3D canvases / render-heavy views. On GitHub's
+// GPU-less runners these fall back to SwiftShader software WebGL and time out at
+// the drained-runner tail (they pass 15/15 locally on a real GPU — see the note
+// in playwright.demo.config.ts). Such scenarios are tagged `@serial` so they run
+// on the local GPU lane only and are excluded from the GPU-less CI fast lane
+// (run-e2e-fast.js passes --grep-invert=@serial to the demo phase). The tagged
+// three below all flaked on the v0.3.0 main push. See CLAUDE.md testing rule 3.
 test.describe("demo mode e2e", () => {
-    test("shows seeded demo libraries across tabs", async ({ page }) => {
+    // @serial: demo SPA boot times out under software WebGL at the CI tail.
+    test("shows seeded demo libraries across tabs", { tag: "@serial" }, async ({
+        page,
+    }) => {
         const modelListPage = new ModelListPage(page);
         const environmentMapsPage = new EnvironmentMapsPage(page);
         const textureSetsPage = new TextureSetsPage(page);
@@ -231,7 +241,8 @@ test.describe("demo mode e2e", () => {
         ).toContainText("Basic Texture Set");
     });
 
-    test("uploads a model and records it in upload history", async ({
+    // @serial: asserts the model-viewer <canvas> is visible — GPU render flake.
+    test("uploads a model and records it in upload history", { tag: "@serial" }, async ({
         page,
     }) => {
         const upload = await createUploadCopy(
@@ -260,7 +271,10 @@ test.describe("demo mode e2e", () => {
         }
     });
 
-    test("creates, recycles, and restores a texture set", async ({ page }) => {
+    // @serial: texture-set preview render waits time out under software WebGL.
+    test("creates, recycles, and restores a texture set", { tag: "@serial" }, async ({
+        page,
+    }) => {
         const textureSetsPage = new TextureSetsPage(page);
         const recycledFilesPage = new RecycledFilesPage(page);
         const textureSetName = `Demo Runtime Texture Set ${Date.now()}`;

--- a/tests/e2e/features/01-model-viewer/01-viewer-rendering.feature
+++ b/tests/e2e/features/01-model-viewer/01-viewer-rendering.feature
@@ -15,7 +15,12 @@ Feature: Model 3D Viewer Rendering
     And the viewer controls should be visible
     And I take a screenshot of the 3D model rendering
 
-  @ui @controls
+  # @serial: opening the viewer page waits for the 3D canvas to become ready.
+  # On GitHub's GPU-less runners the SwiftShader software render times out at
+  # the drained-runner tail (this scenario flaked on the v0.3.0 main push);
+  # it passes on a real GPU, so it runs on the local GPU lane only. See
+  # CLAUDE.md testing rule 3.
+  @ui @controls @serial
   Scenario: Menubar controls are accessible
     Given I am on the model viewer page for "multi-version-model"
     Then the following control buttons should be visible:

--- a/tests/e2e/run-e2e-fast.js
+++ b/tests/e2e/run-e2e-fast.js
@@ -171,7 +171,12 @@ async function main() {
     console.log("\n📋 Demo tests: skipped (SKIP_DEMO_PHASE=1)\n");
   } else {
     console.log(`\n📋 Phase ${fastOnly ? 3 : 5}: Demo tests (workers=1)\n`);
-    demoResult = run(`node run-demo-e2e.js ${args}`, {
+    // In the fast lane (CI), exclude @serial demo scenarios: they open 3D
+    // canvases / render-heavy views that flake on GitHub's GPU-less runners
+    // (SwiftShader software WebGL). They still run on the local GPU lane via
+    // the full runner (run-e2e.js), which does not pass this filter.
+    const demoArgs = fastOnly ? `${args} --grep-invert=@serial` : args;
+    demoResult = run(`node run-demo-e2e.js ${demoArgs}`, {
       env: testEnv,
     });
     preserveBlobs("demo");


### PR DESCRIPTION
On the v0.3.0 main push, E2E flaked on scenarios that open 3D canvases / render-heavy views: they fall back to SwiftShader software WebGL on GitHub's GPU-less runners and time out at the drained-runner tail (they pass on a real GPU). Per CLAUDE.md testing rule 3, tag them `@serial` so they run on the local GPU lane only and no longer flake the GPU-less CI fast lane:

- `01-viewer-rendering.feature`: `Menubar controls are accessible` (opening the viewer waits on canvas readiness).
- `demo-mode.spec.ts`: `shows seeded demo libraries across tabs`, `uploads a model and records it in upload history`, `creates, recycles, and restores a texture set` (tagged via Playwright's `{ tag }` option).
- `run-e2e-fast.js`: pass `--grep-invert=@serial` to the demo phase in the fast lane so `@serial` demo scenarios are excluded on CI; the full runner (`run-e2e.js`, local GPU lane) still runs them.

Each tag carries a root-cause comment naming the GPU-less flake.

> Note: the docs-feature-videos changes originally in this PR were dropped — videos stay **autogenerated on main-push in CI** (not committed) to avoid repo bloat. See the follow-up on making that generation flake-resilient.