### PR TITLE
ci: harden installer + updater nightly (fast-lane smoke + Windows self-update diagnostics)

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -378,7 +378,7 @@ jobs:
         working-directory: tests/e2e
         run: npx playwright install chromium
 
-      - name: Run full E2E suite against installed app
+      - name: Run E2E smoke against installed app (fast lane, no GPU-render)
         if: github.event_name != 'push'
         working-directory: tests/e2e
         env:
@@ -405,15 +405,22 @@ jobs:
           PW_RETRIES: "2"
           # The hosted Windows runner is far slower for the 3D-heavy UI, so the
           # parallel Chromium phase flakes on timeouts there. Keep it running and
-          # reported, but non-blocking on Windows; setup/serial/slow stay strict
-          # everywhere, and Linux/macOS still gate the full UI sweep.
+          # reported, but non-blocking on Windows; setup stays strict everywhere,
+          # and Linux/macOS still gate the Chromium UI sweep.
           CHROMIUM_PHASE_NONBLOCKING: ${{ runner.os == 'Windows' && '1' || '0' }}
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_PORT: "35432"
           POSTGRES_USER: modelibr
           POSTGRES_PASSWORD: modelibr
           POSTGRES_DB: Modelibr
-        run: node run-e2e-fast.js
+        # --fast-only runs setup + the core Chromium UI flows only. The serial
+        # (@serial) + slow phases are dropped: the @serial scenarios are
+        # GPU-render tests that flake on GitHub's GPU-less runners (SwiftShader
+        # software WebGL) and belong on the local GPU lane, and running the full
+        # ~64-min suite here drained the runner and made even non-render flows
+        # flake at the tail. This keeps a reliable install smoke of the real
+        # native app without the GPU-less flake. Full coverage runs locally.
+        run: node run-e2e-fast.js --fast-only
 
       - name: Upload native E2E report
         if: always()

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -329,13 +329,42 @@ jobs:
           if (-not $old) { throw "FROM installer not found" }
           Start-Process -Wait -FilePath $old.FullName -ArgumentList '/S'
 
+          $logDir = Join-Path $env:GITHUB_WORKSPACE 'upgrade-logs'
+          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          $script:launchId = 0
+
           function Exe { @("$env:LOCALAPPDATA\Programs\Modelibr\Modelibr.exe", "$env:PROGRAMFILES\Modelibr\Modelibr.exe") | Where-Object { Test-Path $_ } | Select-Object -First 1 }
-          function Start-App { $e = Exe; if (-not $e) { throw "Modelibr.exe not found" }; Start-Process -FilePath $e -ArgumentList '--remote-debugging-port=9222' }
+          function Start-App {
+            $e = Exe; if (-not $e) { throw "Modelibr.exe not found" }
+            $script:launchId++
+            # Capture the app console (electron-updater logs via runtimeLog ->
+            # console) so a failed self-update leaves diagnostics behind.
+            Start-Process -FilePath $e -ArgumentList '--remote-debugging-port=9222' `
+              -RedirectStandardOutput "$logDir\app-out-$($script:launchId).log" `
+              -RedirectStandardError  "$logDir\app-err-$($script:launchId).log"
+          }
           function Wait-Ready {
             for ($i = 0; $i -lt 90; $i++) { try { Invoke-WebRequest -UseBasicParsing http://127.0.0.1:3010 -TimeoutSec 5 | Out-Null; return $true } catch { Start-Sleep 3 } }
             return $false
           }
           function HttpCode($u) { try { [int](Invoke-WebRequest -UseBasicParsing $u -TimeoutSec 5).StatusCode } catch { if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 } } }
+          # Diagnostics for the Windows self-update failure (root-cause hypothesis:
+          # bundled sidecars keep the install dir locked so the NSIS in-place
+          # update can't overwrite them). Capture whether postgres/WebApi are
+          # still running after quitAndInstall and whether the install dir was
+          # actually updated (ProductVersion still 0.1.0 == update did not apply).
+          function Dump-Diag($tag) {
+            try {
+              Get-Process -Name Modelibr, postgres, WebApi, node -ErrorAction SilentlyContinue |
+                Select-Object Name, Id, Path | Format-Table -AutoSize | Out-String |
+                Out-File "$logDir\processes-$tag.txt"
+              $e = Exe
+              if ($e) {
+                "installed exe: $e (ProductVersion=$((Get-Item $e).VersionInfo.ProductVersion))" |
+                  Out-File "$logDir\installdir-$tag.txt"
+              }
+            } catch { "diag error: $_" | Out-File -Append "$logDir\diag-errors.txt" }
+          }
 
           Start-App
           if (-not (Wait-Ready)) { throw "FROM app not ready" }
@@ -346,6 +375,7 @@ jobs:
 
           # quitAndInstall runs the NSIS update silently and relaunches the new version.
           Start-Sleep 25
+          Dump-Diag 'after-update'
           if (-not (Wait-Ready)) {
             Write-Host "did not auto-relaunch — starting the (updated) app"
             Start-App
@@ -365,4 +395,5 @@ jobs:
           path: |
             upgrade-manifest.json
             /tmp/modelibr.log
+            upgrade-logs/
           if-no-files-found: ignore


### PR DESCRIPTION
Post-0.3 hardening of the two GPU-less-CI-sensitive installer/updater workflows. The v0.3.0 installers + updater feeds shipped fine (published during the Build jobs); these were red on **post-publish** checks only.

## 1. Installer smoke → fast lane (`native-release.yml`)
The *"Run full E2E suite against installed app"* step ran `run-e2e-fast.js` **without `--fast-only`**, executing the `serial` (`@serial`) + `slow` phases on GitHub's GPU-less runners. The `@serial` scenarios are GPU-render tests that flake on SwiftShader software WebGL, and the ~64-min run drained the runner into tail flakes. → Switch to `--fast-only` (setup + core Chromium flows); GPU-render + slow run on the local GPU lane. Windows keeps its non-blocking Chromium phase.

## 2. Windows self-update diagnostics (`upgrade-test.yml`)
The Windows self-update has failed nightly for ~a week with **no app-side logs** (console-only logging + no `Start-Process` output redirect + a Unix-only artifact path). Root-cause hypothesis: the updater downloads 0.3.0 fine, but `quitAndInstall` runs the NSIS in-place update while the bundled **postgres/WebApi sidecars** are still running and **locking their binaries in the install dir**, so the update can't apply (app stays 0.1.0, `/api/scripts`=404). Linux passes because AppImage swaps the whole file wholesale.

**Confirm-first** (before touching the auto-update flow that ships to installed apps): capture per-launch app console output + dump whether sidecars are still running and the installed exe's ProductVersion after `quitAndInstall`, and upload `upgrade-logs/`. A dispatched run / the next nightly will prove the root cause; the desktop fix (stop sidecars before `quitAndInstall`) follows once confirmed.

## Verification
Both workflow YAMLs validated. Behavior validated by each workflow's own run (installer smoke: release/dispatch; upgrade diagnostics: dispatched now).