### PR TITLE
fix(desktop): apply Windows self-update silently (quitAndInstall isSilent)

### DIFF
--- a/src/desktop/src/updateManager.js
+++ b/src/desktop/src/updateManager.js
@@ -132,7 +132,13 @@ export class UpdateManager {
   install() {
     if (this.state.status === 'downloaded') {
       try {
-        this.autoUpdater.quitAndInstall()
+        // isSilent=true: the NSIS installer is assisted (oneClick:false), so a
+        // non-silent update pops the full setup wizard and waits for clicks —
+        // which never come on an unattended/relaunching update, so the update
+        // never applies (the app just relaunches the old version). Silent runs
+        // the update in the background; isForceRunAfter=true relaunches into the
+        // new version afterwards.
+        this.autoUpdater.quitAndInstall(true, true)
         return
       } catch (error) {
         this.log('[ModelibrDesktop][update] quitAndInstall failed', {

--- a/src/desktop/test/updateManager.test.js
+++ b/src/desktop/test/updateManager.test.js
@@ -18,8 +18,9 @@ function makeFakeAutoUpdater(overrides = {}) {
   au.downloadUpdate = async () => {
     au.calls.downloadUpdate++
   }
-  au.quitAndInstall = () => {
+  au.quitAndInstall = (...args) => {
     au.calls.quitAndInstall++
+    au.calls.quitAndInstallArgs = args
   }
   return Object.assign(au, overrides)
 }
@@ -110,6 +111,9 @@ test('install() restarts into a downloaded build', async () => {
 
   mgr.install()
   assert.equal(au.calls.quitAndInstall, 1)
+  // Must install silently: the assisted (oneClick:false) NSIS installer would
+  // otherwise pop the wizard and block an unattended update from applying.
+  assert.deepEqual(au.calls.quitAndInstallArgs, [true, true])
   assert.equal(opened.length, 0, 'should restart, not open a browser')
 })
 


### PR DESCRIPTION
## Root cause (confirmed via captured updater logs)

The nightly Windows self-update has failed for ~a week. Diagnostics added in #549 captured the updater lifecycle on a dispatched run and proved it:

```
[update] Install on explicit quitAndInstall
[update] Install: isSilent: false, isForceRunAfter: true
[update] Executing: ...\modelibr-desktop-updater\pending\Modelibr-0.3.0-windows-x64.exe with args: --updated,--force-run
[worker:1] Process exited with code 0     ← sidecars exited cleanly
[worker:2] Process exited with code 0
[webapi]   Process exited with code 0
[update] Update installer has already been triggered. Quitting application.
```
…and `installdir-after-update.txt`: `ProductVersion=0.1.0.0` (update never applied).

`install()` called `quitAndInstall()` **non-silently** (`isSilent:false`), but the NSIS installer is **assisted** (`build.nsis.oneClick:false`). On update that pops the full setup wizard and waits for clicks — which never come on an unattended/relaunching update, so the update never applies and the app just relaunches the old version. It also means **real users would get the wizard on every update** instead of a seamless background update.

> The earlier sidecar-file-lock hypothesis was **refuted** by the logs — postgres/WebApi exited cleanly (code 0) before the app quit.

## Fix

`quitAndInstall(true, true)` — `isSilent` applies the update in the background (respecting the location chosen at first install), `isForceRunAfter` relaunches into the new version. This is the standard electron-updater pattern for `oneClick:false` apps.

## Verification

- Desktop unit suite green (46/46); the updater test now asserts `quitAndInstall` is called with `[true, true]`.
- **End-to-end caveat:** the upgrade-test self-update runs the **FROM** version's updater code, so it will keep failing from the immutable `v0.1.0` baseline — this fix is validated live only once two post-fix releases exist. Recommend moving the workflow's `from_tag` baseline to the first post-fix release after the next cut (a NOTE for this already exists in `upgrade-test.yml`).

Depends conceptually on #549 (which added the diagnostics that confirmed this).