### PR TITLE
ci: retry docs video generation to absorb the software-WebGL flake

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -471,10 +471,10 @@ jobs:
         # docs-site videos on main, so restrict it to main pushes + manual
         # dispatch — it no longer runs (or flakes) on PRs.
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        # Historically this job completes in ~12 minutes. A hard ceiling prevents
-        # a single hung step (e.g. apt mirror flake during `playwright install
-        # --with-deps`) from silently consuming the 6h runner default.
-        timeout-minutes: 45
+        # A single attempt completes in ~12 minutes; the generate step retries up
+        # to 3x to absorb the software-WebGL flake, so allow headroom (setup +
+        # 3×~12m) while still capping a hung step well below the 6h default.
+        timeout-minutes: 60
 
         steps:
             - name: Checkout code
@@ -518,8 +518,26 @@ jobs:
             - name: Generate videos
               id: generate
               working-directory: docs/videos
-              timeout-minutes: 25
-              run: npm run generate
+              timeout-minutes: 40
+              # Capture uses SwiftShader software WebGL on the GPU-less runner,
+              # which occasionally flakes mid-render — and a single failed clip
+              # fails the whole run, which then blocks the main docs deploy (the
+              # v0.3.0 push flaked once and passed on a plain re-run). Retry a
+              # couple of times to absorb that transient flake instead of
+              # committing the videos to the repo. Each attempt regenerates the
+              # full set; the running stack is reused across attempts.
+              run: |
+                  for attempt in 1 2 3; do
+                    echo "::group::generate videos (attempt $attempt/3)"
+                    if npm run generate; then
+                      echo "::endgroup::"
+                      exit 0
+                    fi
+                    echo "::endgroup::"
+                    echo "video generation attempt $attempt failed"
+                  done
+                  echo "video generation failed after 3 attempts"
+                  exit 1
               env:
                   FRONTEND_URL: http://localhost:3002
                   API_BASE_URL: http://localhost:8090


### PR DESCRIPTION
## Why

Docs feature videos are **autogenerated on main-push** (not committed — keeping them out of the repo avoids bloating every clone). But generation uses SwiftShader **software WebGL** on GitHub's GPU-less runner, which occasionally flakes mid-render. A single failed clip fails the whole `generate-videos` job, which **blocks the main docs deploy** — that's what skipped the 0.3.0 docs deploy until a manual re-run (which passed).

## What

Retry the generate step up to **3×** so a transient software-render flake self-heals instead of blocking the deploy. Each attempt regenerates the full set against the already-running stack; step/job timeouts bumped for the headroom (setup + 3×~12m, still well under the 6h default).

This is the reliability fix that **replaces the rejected commit-the-videos approach** — videos stay CI-generated and uncommitted.

## Verification

Workflow YAML validated. Behavior validated by the job's own main-push/dispatch run.