### PR TITLE
fix(backend): resolve FileType from a single registry on DB read

### DIFF
--- a/src/Domain/ValueObjects/FileType.cs
+++ b/src/Domain/ValueObjects/FileType.cs
@@ -212,6 +212,37 @@ public sealed class FileType : IEquatable<FileType>
 
     public static IReadOnlyList<FileType> GetScriptTypes() => ScriptTypes;
 
+    // Canonical registry of every predefined FileType. FromValue (the database
+    // read-side lookup) and the drift-guard tests are built from this list — a
+    // new FileType MUST be added here, or it will round-trip from the database
+    // as Unknown (the exact bug this registry exists to prevent; a test asserts
+    // the list matches the static fields above). Lazy so the declaration order
+    // of the static fields can never leave a null in the list.
+    private static readonly Lazy<IReadOnlyList<FileType>> AllTypes = new(() => new[]
+    {
+        Unknown, Obj, Fbx, Gltf, Glb, Stl, ThreeMf,
+        Blend, Max, Maya,
+        Texture, Hdr, Material, Other,
+        Sprite, SpriteSheet, Gif, Apng, WebP,
+        Mp3, Wav, Ogg, Flac, Aac, M4a,
+        JavaScript, TypeScript, Python, CSharp, Cpp, Lua, Java, Go, Rust,
+        Ruby, Php, Shell, Sql, Json, Yaml, Xml, Glsl, Hlsl, GdScript
+    });
+
+    private static readonly Lazy<IReadOnlyDictionary<string, FileType>> ValueMap = new(() =>
+        AllTypes.Value.ToDictionary(t => t.Value, StringComparer.OrdinalIgnoreCase));
+
+    public static IReadOnlyList<FileType> GetAllTypes() => AllTypes.Value;
+
+    /// <summary>
+    /// Resolves a persisted <see cref="Value"/> string back to its FileType.
+    /// Unrecognized values (legacy or corrupt data) fall back to <see cref="Unknown"/>.
+    /// </summary>
+    public static FileType FromValue(string? value)
+        => value is not null && ValueMap.Value.TryGetValue(value, out var fileType)
+            ? fileType
+            : Unknown;
+
     // Canonical extension for each script language id — used when authoring a
     // script in-app (no uploaded file), to synthesize a file name.
     private static readonly Dictionary<string, string> ScriptLanguageExtensions = new(StringComparer.OrdinalIgnoreCase)

--- a/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -343,11 +343,13 @@ namespace Infrastructure.Persistence
                 entity.Property(f => f.IsDeleted).IsRequired();
                 entity.Property(f => f.DeletedAt);
                 
-                // Configure FileType Value Object to be stored as string
+                // Configure FileType Value Object to be stored as string.
+                // Read side resolves through the FileType registry so both
+                // directions share one source of truth (see FileType.FromValue).
                 entity.Property(f => f.FileType)
                     .HasConversion(
                         v => v.Value,
-                        v => MapFromDatabaseValue(v))
+                        v => FileType.FromValue(v))
                     .IsRequired();
 
                 // Add index for efficient soft delete queries
@@ -1106,38 +1108,6 @@ namespace Infrastructure.Persistence
             });
 
             base.OnModelCreating(modelBuilder);
-        }
-
-        private static FileType MapFromDatabaseValue(string value)
-        {
-            return value switch
-            {
-                "obj" => FileType.Obj,
-                "fbx" => FileType.Fbx,
-                "gltf" => FileType.Gltf,
-                "glb" => FileType.Glb,
-                "stl" => FileType.Stl,
-                "3mf" => FileType.ThreeMf,
-                "blend" => FileType.Blend,
-                "max" => FileType.Max,
-                "maya" => FileType.Maya,
-                "texture" => FileType.Texture,
-                "material" => FileType.Material,
-                "sprite" => FileType.Sprite,
-                "spritesheet" => FileType.SpriteSheet,
-                "gif" => FileType.Gif,
-                "apng" => FileType.Apng,
-                "webp" => FileType.WebP,
-                "mp3" => FileType.Mp3,
-                "wav" => FileType.Wav,
-                "ogg" => FileType.Ogg,
-                "flac" => FileType.Flac,
-                "aac" => FileType.Aac,
-                "m4a" => FileType.M4a,
-                "hdr" => FileType.Hdr,
-                "other" => FileType.Other,
-                _ => FileType.Unknown
-            };
         }
     }
 }

--- a/tests/Domain.Tests/ValueObjects/FileTypeRegistryTests.cs
+++ b/tests/Domain.Tests/ValueObjects/FileTypeRegistryTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using Domain.ValueObjects;
+using Xunit;
+
+namespace Domain.Tests.ValueObjects;
+
+/// <summary>
+/// Drift guards for the FileType registry. The database read side
+/// (ApplicationDbContext's FileType converter) resolves persisted strings via
+/// FileType.FromValue, which is built from FileType.GetAllTypes(). These tests
+/// make it impossible to add a FileType that silently round-trips as Unknown —
+/// the bug that shipped for all 19 script types (see prompt 15).
+/// </summary>
+public class FileTypeRegistryTests
+{
+    public static TheoryData<string> AllRegisteredValues()
+    {
+        var data = new TheoryData<string>();
+        foreach (var fileType in FileType.GetAllTypes())
+        {
+            data.Add(fileType.Value);
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllRegisteredValues))]
+    public void FromValue_WithEveryRegisteredValue_RoundTripsToSameValue(string value)
+    {
+        var resolved = FileType.FromValue(value);
+
+        Assert.Equal(value, resolved.Value);
+    }
+
+    [Fact]
+    public void FromValue_WithEveryRegisteredType_ReturnsSameInstance()
+    {
+        Assert.All(FileType.GetAllTypes(), fileType =>
+            Assert.Same(fileType, FileType.FromValue(fileType.Value)));
+    }
+
+    [Fact]
+    public void FromValue_WithUnknownLegacyString_ReturnsUnknown()
+    {
+        Assert.Same(FileType.Unknown, FileType.FromValue("no-such-type"));
+        Assert.Same(FileType.Unknown, FileType.FromValue(""));
+        Assert.Same(FileType.Unknown, FileType.FromValue(null));
+    }
+
+    [Fact]
+    public void GetAllTypes_Values_AreUniqueIgnoringCase()
+    {
+        // FromValue is a dictionary keyed by Value — a duplicate would make one
+        // type unreachable from the database.
+        var values = FileType.GetAllTypes().Select(t => t.Value).ToList();
+
+        Assert.Equal(values.Count, values.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void GetAllTypes_ContainsEveryPredefinedStaticField()
+    {
+        // The registry list is hand-maintained next to the static fields; this
+        // reflection check is what makes forgetting an entry impossible.
+        var staticFields = typeof(FileType)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.FieldType == typeof(FileType))
+            .Select(f => (FileType)f.GetValue(null)!)
+            .ToList();
+
+        var registered = FileType.GetAllTypes();
+
+        Assert.NotEmpty(staticFields);
+        Assert.Equal(staticFields.Count, registered.Count);
+        foreach (var fieldInstance in staticFields)
+        {
+            Assert.Contains(fieldInstance, registered);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/Persistence/FileTypeConverterTests.cs
+++ b/tests/Infrastructure.Tests/Persistence/FileTypeConverterTests.cs
@@ -1,0 +1,61 @@
+using Domain.ValueObjects;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+using DomainFile = Domain.Models.File;
+
+namespace Infrastructure.Tests.Persistence;
+
+/// <summary>
+/// Proves the DbContext's configured FileType converter round-trips every
+/// registered FileType — i.e. that the model is actually wired to
+/// FileType.FromValue and not to a hand-maintained mapping that can drift
+/// (the pre-fix switch silently mapped all 19 script types to Unknown).
+/// InMemory is used ONLY to build the model metadata; no queries run, so no
+/// provider-specific behavior is being trusted here (a real-Postgres
+/// round-trip belongs to prompt 43's integration layer).
+/// </summary>
+public class FileTypeConverterTests
+{
+    private static ValueConverter GetConfiguredFileTypeConverter()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        using var context = new ApplicationDbContext(options);
+
+        var property = context.Model
+            .FindEntityType(typeof(DomainFile))!
+            .FindProperty(nameof(DomainFile.FileType))!;
+
+        var converter = property.GetValueConverter();
+        Assert.NotNull(converter);
+        return converter!;
+    }
+
+    [Fact]
+    public void ConfiguredConverter_RoundTrips_EveryRegisteredFileType()
+    {
+        var converter = GetConfiguredFileTypeConverter();
+
+        Assert.All(FileType.GetAllTypes(), fileType =>
+        {
+            var stored = converter.ConvertToProvider(fileType);
+            var restored = converter.ConvertFromProvider(stored);
+
+            Assert.Equal(fileType.Value, Assert.IsType<string>(stored));
+            Assert.Same(fileType, Assert.IsType<FileType>(restored));
+        });
+    }
+
+    [Fact]
+    public void ConfiguredConverter_UnrecognizedStoredString_FallsBackToUnknown()
+    {
+        var converter = GetConfiguredFileTypeConverter();
+
+        var restored = converter.ConvertFromProvider("legacy-value-never-registered");
+
+        Assert.Same(FileType.Unknown, restored);
+    }
+}


### PR DESCRIPTION
## Problem

The EF value converter for `File.FileType` read persisted strings back through a hand-maintained `MapFromDatabaseValue` switch in `ApplicationDbContext`. The switch had silently drifted from the `FileType` registry: **all 19 script types** (`javascript`, `typescript`, `python`, `csharp`, …) were missing, so every script `File` row read back as `FileType.Unknown` — wrong `Category` (`Other` instead of `Script`) and wrong `GetMimeType()` (`application/octet-stream` instead of `text/plain`). This shipped in v0.3.0.

Impact today is latent (verified: no read path branches on a script file's round-tripped type — `Script.Language` is persisted on the aggregate, and file serving uses the stored `MimeType`), but any future feature branching on a loaded file's type/category would hit it. The same trap previously bit STL/3MF.

## No data repair needed

The write side (`v => v.Value`) always stored correct strings — the database is clean. This is a read-side-only fix; **no migration, no backfill**.

## Fix

- `FileType.FromValue(string)` backed by a canonical `AllTypes` registry in `FileType.cs`, so both conversion directions share one source of truth. `Lazy<>` initialization makes static-field declaration order irrelevant.
- `ApplicationDbContext` converter now calls `FileType.FromValue`; the 31-line drifted switch is deleted. Unrecognized legacy strings still fall back to `Unknown`.

## Drift guards (make the bug class unrepresentable)

- `FileTypeRegistryTests` — round-trip theory over every registered value; value-uniqueness check (dictionary-key precondition); reflection check that `AllTypes` contains every public static `FileType` field → adding a type without registering it fails the build.
- `FileTypeConverterTests` — asserts the converter *actually configured in the model* round-trips every registered type and falls back to `Unknown` for unrecognized strings. Uses InMemory only to build model metadata (no queries, no provider behavior trusted — a real-Postgres round-trip belongs to the planned integration-test layer).

## Verification

- `dotnet build Modelibr.sln` — clean (0 errors; warnings pre-existing)
- `dotnet test --filter "Category!=Integration"` — **598 passed, 0 failed** (Domain 404 / Application 160 / Infrastructure 34), including the 44-case round-trip theory and both converter-wiring tests
- No behavioral change for the 24 types the old switch mapped correctly (same instances returned)