### PR TITLE
docs(agents): refresh all skills from full-codebase review session

### DIFF
--- a/.claude/skills/asset-processor-patterns/SKILL.md
+++ b/.claude/skills/asset-processor-patterns/SKILL.md
@@ -1,59 +1,103 @@
 ---
 name: asset-processor-patterns
-description: Modelibr asset-processor (Node.js worker) conventions — config.js discipline, ProcessorRegistry/BaseProcessor lifecycle, service boundaries, worker↔backend API contracts, offline-safe rendering. Use when creating or editing code under src/asset-processor.
+description: Modelibr asset-processor (Node.js worker) conventions — config.js discipline, ProcessorRegistry/BaseProcessor lifecycle, job queue/timeout traps, RendererPool/Puppeteer rules, unified API-client usage, shared cross-runtime lib, offline-safe rendering, Vitest. Use when creating or editing code under src/asset-processor.
 ---
 
 # Asset processor patterns (Node.js worker)
 
+ESM (`"type": "module"`), Vitest (NOT Jest — the frontend is the inverse),
+structured winston `logger` + `withJobContext(jobId)` — never `console.log`.
+Known debt + planned refactors: prompts 24 (folder grouping), 41 (dead code +
+timeout cancellation), 42 (client factory + hygiene) in `.claude/prompts/`.
+
 ## Configuration
-- ALL runtime config lives in `src/asset-processor/config.js` (75+ env vars:
-  rendering, orbit, encoding, thumbnail storage, blender, …). Don't scatter
-  `process.env` reads through processors/services — extend the config surface.
+- ALL runtime config lives in `config.js` (rendering, orbit, encoding,
+  thumbnail storage, blender, …). Never read `process.env` elsewhere — known
+  violations (`POLL_INTERVAL_MS` in jobProcessor, Chrome paths in
+  puppeteerRenderer) are slated for prompt 42; don't add more. New env vars
+  also go in root `.env.example`.
+- Blender + thumbnail-render settings are refreshed FROM the backend API
+  (`refreshBlenderConfigFromApi` etc.) — user-editable settings flow through
+  the DB, not env.
+- ESLint enforces an architectural boundary: `config.js` must not import
+  business logic.
 
 ## Processor architecture
-- `ProcessorRegistry` (Strategy) maps `job.assetType` → processor. Registered:
-  `Model`, `Sound`, `TextureSet`, `MeshAnalysis`.
-- `BaseProcessor` is the template method: `execute()` wraps your `process()` with
-  error handling, `withJobContext()` logging, and `JobApiClient` callbacks.
-- New processor = extend `BaseProcessor`, implement `get processorType()` +
-  `async process(job, jobLogger)`, register in the `ProcessorRegistry` constructor.
+- `ProcessorRegistry` (Strategy) maps `job.assetType` → processor.
+  Registered: `Model`, `Sound`, `TextureSet`, `EnvironmentMap`,
+  `MeshAnalysis` (stub — logs not-implemented; `meshProcessor.js` documents
+  the planned shape).
+- `BaseProcessor` is the template method: `execute()` wraps your `process()`
+  with error handling, `withJobContext` logging, and `JobApiClient`
+  callbacks. New processor = extend it, implement `get processorType()` +
+  `async process(job, jobLogger)`, register in the registry constructor.
+- TRAP — `jobProcessor.js` still contains a full LEGACY inline pipeline
+  (`processModelJobAsync`/`processSoundJobAsync`/`processModel`/
+  `processSound`, ~580 lines) that nothing calls; dispatch goes through the
+  registry. Don't fix or extend the legacy path — prompt 41 deletes it.
 
-## Service boundaries
-- Reuse `JobApiClient`, `JobEventService`, `BaseProcessor`, structured `logger` —
-  no ad-hoc job lifecycle code or duplicate axios clients.
-- Per-job logic in `processors/`; transport concerns in service/client files.
+## Job lifecycle (how work arrives and runs)
+- Delivery is belt-and-braces: SignalR push notification → worker CLAIMS via
+  `POST /thumbnail-jobs/dequeue` (backend arbitrates racing workers) →
+  local queue (cap 50; full = drop notification, fallback polling sweeps
+  later) → up to `config.maxConcurrentJobs` (default 3) run concurrently.
+- TRAP — the job timeout is a `Promise.race`: it marks the job failed but
+  does NOT cancel the work; a hung render keeps its pool renderer (slot
+  starvation). Prompt 41 fixes this — until then never rely on the timeout
+  to free resources; make your processor's awaits fail rather than hang.
+- Retry/dead-letter logic is backend-side (`FinishThumbnailJobCommand`) —
+  the worker just reports finish/fail honestly.
 
-## Worker ↔ backend contract
-Worker calls: `POST /thumbnail-jobs/dequeue`, `POST /thumbnail-jobs/{id}/finish`,
-`POST /thumbnail-jobs/sounds/{id}/finish`, `POST /thumbnail-jobs/texture-sets/{id}/finish`.
-If backend endpoint shapes change, update `JobApiClient` to match (and vice versa).
+## Puppeteer / RendererPool rules
+- One shared browser, one page per pool renderer (= isolated WebGL context
+  per concurrent job). Always `acquire()` / `release()` in try/finally.
+- Pages crash (frame detach, OOM on 4K textures). `PuppeteerRenderer` has
+  `isPageUsable()` + `reinitialize()` — check/recover instead of assuming
+  the page survived; reuse this machinery, don't invent recovery.
+- The odd launch flags (`--disable-crashpad`, `--crash-dumps-dir=/tmp`, …)
+  are load-bearing container fixes — don't remove; macOS uses Metal
+  (swiftshader has no WebGL there).
+- External processes (Blender) via `execFile` with arg arrays — never
+  `exec`/shell strings.
+
+## API clients (worker → backend)
+- TRAP — six hand-rolled axios clients exist and have drifted:
+  `jobEventService` sends NO `X-Api-Key`; coverage is inconsistent. Prompt
+  42 introduces one `createWorkerApiClient` factory. Until then: never
+  create another bare `axios.create` — reuse an existing keyed client, and
+  any new request surface must attach `X-Api-Key` from
+  `config.workerApiKey`.
+- Contract endpoints: `POST /thumbnail-jobs/dequeue`, `POST
+  /thumbnail-jobs/{id}/finish` (+ sound/texture-set/environment-map finish
+  variants). If backend endpoint shapes change, update the client to match
+  (and vice versa).
 
 ## Shared cross-runtime code (single source of truth)
-Logic that must behave **identically** in more than one runtime — the frontend
-viewer, this worker's Puppeteer thumbnail render (`render-template.html` +
-`page.evaluate`), and demo mode — lives **once** in `src/asset-processor/lib/`,
-never hand-copied into each. The failure this prevents: the viewer and the
-generated thumbnail drift because the same algorithm was maintained in two
-places. Rule of thumb: writing viewer/render code whose output another runtime
-must match? It's shared code — put it here.
-- **Shape:** a dependency-light ESM that **injects its heavy deps as arguments**
-  (e.g. `THREE`, `UTIF`) so the one file runs in both the Vite bundle and the
-  classic-script `page.evaluate` context; add a `window.modelibr*` side-effect
-  for the page, and a `.d.ts` sibling for the TS frontend.
-- **Consumers:** frontend imports by relative path
-  (`../../../asset-processor/lib/x.js`, allowed via Vite `server.fs.allow`); the
-  render template loads it as `<script type="module">` / `import`.
-- **Examples:** `lib/tiffDecode.js` (TIFF→RGBA, UTIF injected), `lib/stlMesh.js`
-  (STL geometry→mesh, THREE injected). See `lib/README.md`.
-- **Known not-yet-migrated:** the displacement-normal shader is hand-copied
-  between `frontend/src/shared/three/sharedDisplacementNormal.ts` and
-  `puppeteerRenderer.js` — migrate it here when you next touch either.
+Logic that must behave **identically** in more than one runtime — the
+frontend viewer, this worker's Puppeteer render (`render-template.html` +
+`page.evaluate`), demo mode — lives ONCE in `lib/`, never hand-copied.
+- **Shape:** dependency-light ESM that injects heavy deps as arguments
+  (`THREE`, `UTIF`) so one file runs in the Vite bundle AND the
+  classic-script page context; `window.modelibr*` side-effect for the page;
+  `.d.ts` sibling for the TS frontend.
+- **Modules:** `tiffDecode`, `stlMesh`, `sceneLighting`, `textureMaterial`,
+  `displacementNormal`, `textureChannels`. See `lib/README.md`.
+- `lib/` stays FLAT — frontend/demo import it by relative path; moving files
+  breaks cross-runtime consumers (prompt 24 explicitly excludes it).
+- Rule of thumb: writing render code whose output another runtime must
+  match? It's shared code — put it here first.
 
 ## Offline-safe (product invariant)
-Rendering/processing must work with no external network: Puppeteer + Three.js use
-local assets; Blender CLI uses a local install. No CDN imports, external APIs, or
-hosted inference in pipelines. (macOS note: rendering uses Metal — swiftshader has
-no WebGL there.)
+Rendering/processing must work with no external network: local Three.js
+assets, local Blender install, no CDN imports or hosted inference.
 
-## Testing & verify
-Vitest. Verify: `cd src/asset-processor && npm test && npm run lint`
+## Testing
+- Vitest in `tests/*.test.js`. Meaningful tests: services, processors, queue
+  mechanics — not render pixels (visual parity is covered by other suites).
+- `tests/test-crashpad-fix.js`, `test-puppeteer.js`, `test-scene-cleanup.js`
+  are MANUAL debug scripts, not Vitest suites (prompt 42 relocates them) —
+  don't pattern-match new tests on them.
+
+## Verify
+`cd src/asset-processor && npm test && npm run lint && npm run format:check`
+(format:check is a required CI gate not covered by lint.)

--- a/.claude/skills/backend-patterns/SKILL.md
+++ b/.claude/skills/backend-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-patterns
-description: Modelibr backend conventions — Clean Architecture boundaries, Result/Error, CQRS handlers, domain events, validation, DI, repositories, minimal API endpoints, xUnit naming. Use when creating or editing code under src/WebApi, src/Application, src/Domain, src/Infrastructure, or src/SharedKernel.
+description: Modelibr backend conventions — Clean Architecture boundaries, Result/Error, CQRS handlers, domain events, validation, DI, repositories, minimal API endpoints, known traps, xUnit naming. Use when creating or editing code under src/WebApi, src/Application, src/Domain, src/Infrastructure, or src/SharedKernel.
 ---
 
 # Backend patterns (.NET 9, Clean Architecture + DDD)
@@ -10,11 +10,15 @@ description: Modelibr backend conventions — Clean Architecture boundaries, Res
   SharedKernel stay free of EF Core attributes, HTTP concerns, and infrastructure refs.
 - One command/query handler per operation; business rules live on entities and value
   objects; repositories stay thin.
+- Known debt + planned refactors live in `.claude/prompts/` (15, 25–29). Before
+  reworking error mapping, transactions, event dispatch, or FileType, read the
+  matching prompt — don't half-implement it as a side effect.
 
 ## Result/Error
 - Handlers return `Task<Result>` / `Task<Result<T>>` (`SharedKernel/Result.cs`, `Error.cs`).
 - Check `IsSuccess`/`IsFailure`; access `.Value` only on success.
-- Domain errors: `new Error("Code", "Message")`.
+- Domain errors: `new Error("Code", "Message")`. `Error` has no type/category field
+  (yet — prompt 26), so HTTP status can't be derived from it.
 
 ## CQRS
 - Commands: `ICommand`/`ICommand<TResponse>` + `ICommandHandler<...>`.
@@ -22,10 +26,20 @@ description: Modelibr backend conventions — Clean Architecture boundaries, Res
 - Interfaces live in `Application/Abstractions/Messaging/`.
 
 ## Domain events
-- Extend `DomainEvent` (SharedKernel), defined in `Domain/Events/`.
-- Handlers implement `IDomainEventHandler<TEvent>` in `Application/EventHandlers/`.
-- Raised on aggregates; published via `IDomainEventDispatcher.PublishAsync()` in the
-  command handler AFTER persistence.
+- Extend `DomainEvent` (SharedKernel), defined in `Domain/Events/`; handlers implement
+  `IDomainEventHandler<TEvent>` in `Application/EventHandlers/`.
+- TRAP — dispatch is manual and easy to forget: after persisting, the command handler
+  itself must call `IDomainEventDispatcher.PublishAsync(aggregate.DomainEvents)` then
+  `aggregate.ClearDomainEvents()`. If you mutate an aggregate that raises events and
+  skip this, the events are silently dropped. (Prompt 25 moves this into the save
+  pipeline; until then, copy the pattern from `CreateModelVersionCommandHandler`.)
+
+## Transactions — there is NO unit of work
+- Every repository commits internally (`SaveChangesAsync` inside repo methods). A
+  handler calling two mutating repo methods = two independent commits; if the second
+  fails, the first is already durable. Until prompt 25: keep multi-entity writes
+  inside ONE repository method (single SaveChanges), and say so in the PR if you
+  can't. `ThumbnailJobRepository` shows the explicit-transaction escape hatch.
 
 ## Validation
 - No FluentValidation. Handler-level: validate early, return `Result.Failure(error)`.
@@ -38,15 +52,44 @@ description: Modelibr backend conventions — Clean Architecture boundaries, Res
 - Repositories/services/DbContext are registered explicitly in
   `Infrastructure/DependencyInjection.cs`.
 
-## Entities, repositories, endpoints
+## Entities, repositories, EF
 - `int` IDs (db-assigned); aggregates extend `AggregateRoot`; static `Create()`
   factories; private `List<T>` backing fields behind `ICollection<T>` properties.
 - Repo interfaces in `Application/Abstractions/Repositories/`, impls in
-  `Infrastructure/Repositories/`. Reads use `AsNoTracking()`; paged queries return
+  `Infrastructure/Repositories/`. Reads use `AsNoTracking()`; add `AsSplitQuery()`
+  when includes span multiple collections. Paged queries return
   `Task<(IEnumerable<T> Items, int TotalCount)>`.
-- Endpoints: static classes in `WebApi/Endpoints/` with `Map*Endpoints()` extensions;
-  handlers injected as endpoint parameters. Result→HTTP: success `Ok()`, not found
-  `NotFound()`, validation/domain failure `BadRequest(new { error, message })`.
+- All EF configuration lives inline in `ApplicationDbContext.OnModelCreating` —
+  new entity = config block there + migration.
+- Soft-deletable entities need the full trio: `IsDeleted`/`DeletedAt` props,
+  `HasQueryFilter(e => !e.IsDeleted)`, and filtered unique indexes
+  (`.HasFilter("\"IsDeleted\" = false")`) — copy an existing block.
+
+## Endpoints
+- Static classes in `WebApi/Endpoints/` with `Map*Endpoints()` extensions; handlers
+  injected as endpoint parameters; always forward the `CancellationToken`.
+- Failure body shape is `new { error = result.Error.Code, message = result.Error.Message }`
+  — never a bare string. Status mapping is currently ad-hoc per endpoint (mostly 400
+  for every failure, some 404) because `Error` is untyped; match the file you're
+  editing for consistency. Prompt 26 replaces this with one typed mapping — don't
+  invent a third convention.
+- Worker-facing upload endpoints (thumbnails, previews, waveforms) must add
+  `WorkerApiKeyFilter` (validates `X-Api-Key`; fails closed outside Development).
+
+## Known traps
+- **FileType registry**: a new type in `Domain/ValueObjects/FileType.cs` must be
+  added to the `AllTypes` registry in the same file — `FileType.FromValue` (the DB
+  read side) resolves through it, and `FileTypeRegistryTests` fails the build if a
+  static field is missing from the list. Never reintroduce a hand-maintained
+  value↔type mapping elsewhere (the old `MapFromDatabaseValue` switch silently
+  degraded 19 script types to `Unknown`).
+- **Two FileTypes exist**: `Domain.ValueObjects.FileType` (rich VO, 44 values) vs
+  `Domain.Files.FileType` (4-value storage-bucket enum used only at upload). Don't
+  conflate them.
+- **Time**: inject `IDateTimeProvider`; never `DateTime.UtcNow` in new code. Entities
+  receive `now` as a method/factory parameter — never inject services into entities.
+- **Config**: new settings flow through root `.env` + `.env.example` (env-style key
+  names), read via `builder.Configuration` — no hardcoded consts in `Program.cs`.
 
 ## Testing
 - xUnit + Moq, Arrange-Act-Assert, names `Method_When_Condition_Returns_Expected`.

--- a/.claude/skills/e2e-authoring/SKILL.md
+++ b/.claude/skills/e2e-authoring/SKILL.md
@@ -30,8 +30,12 @@ folders are numbered (`00-texture-sets/` …) to control ordering.
   `npx bddgen && npx playwright test --grep "<scenario name>" --no-deps`
   (seed first with `PW_WORKERS=1 npx playwright test --project=setup`).
 - Artifact env knobs: `PW_VIDEO`, `PW_TRACE`, `PW_SCREENSHOT`, `PW_RETRIES`,
-  `PW_HEADED`, `PW_WORKERS`. Default trace is `on-first-retry`; force capture on a
-  single run with `PW_TRACE=on` (or `retain-on-failure`).
+  `PW_HEADED`, `PW_WORKERS`, `PW_TEST_TIMEOUT` (per-test ms, default 90s to
+  absorb Puppeteer cold-start). Default trace is `on-first-retry`; force
+  capture on a single run with `PW_TRACE=on` (or `retain-on-failure`).
+- Phase worker counts are set by `run-e2e.js` (chromium currently 3 local AND
+  CI — 4 caused asset-processor contention); trust run-e2e.js over the stale
+  comment in `playwright.config.ts`.
 
 ## Results & traces (read your own run output)
 A machine-readable **JSON report** (`status`, `error.message`, `attachments[]`)
@@ -76,18 +80,48 @@ For deeper triage (history, regression-vs-long-broken, infra signatures) use the
 
 ## Page objects & selectors
 - Page objects live in `tests/e2e/pages/` (fluent Playwright API, explicit
-  stability waits for React hydration and SignalR events). Extend these rather
-  than putting locators in steps.
-- Selector priority: `getByRole` → `data-testid` → `#id`; avoid CSS classes.
-  `data-testid` format: `{component}-{element}-{variant?}`.
+  stability waits for React hydration and SignalR events — page-object
+  `expect()` calls as stability waits are a deliberate convention here).
+  Extend these rather than putting locators in steps.
+- **Contract for NEW selectors:** `data-testid` (format
+  `{component}-{element}-{variant?}`; add the attribute to the frontend
+  component if missing) or `getByRole` where semantics fit. Reality check:
+  ~950 legacy CSS-class locators exist (`.model-card`, `.p-dialog`, …) —
+  they are **grandfathered, do not add more**. Prompt 46 adds a CI
+  drift-audit + a central PrimeReact selector module; until then, `.p-*`
+  classes are the accepted exception for PrimeReact body-mounted overlays
+  (dialogs, dropdown panels, toasts).
 - Grids are virtualized — wait for the specific card/locator, never assume all
   items are rendered (see past `fix(e2e)` commits for hardened wait patterns).
+
+## Waits & control flow (the flake rules)
+- **Web-first assertions are the default idiom**: `await
+  expect(locator).toBeVisible()/toHaveText()/toHaveCount()` — they retry.
+  `waitForSelector` is the legacy pattern (prompt 47 migrates it); don't
+  write new ones.
+- **No `waitForTimeout`** (CLAUDE.md rule 4). A "let React settle" sleep
+  means the NEXT assertion should be a retrying web-first one — write that
+  instead. Fixed intervals inside an explicit bounded poll loop are the one
+  exception; any surviving sleep needs a comment naming the race it absorbs.
+- **No branching on app state** (`if (await x.isVisible())` deciding the
+  test path) — the Given must produce ONE known state; fix provisioning
+  instead. Idempotent cleanup is fine but must be a named helper
+  (`dismissToastIfPresent`), not inline conditionals.
+- For endpoint-coupled actions, scope the wait to the exact request
+  (`waitForResponse` matched to method+path — see ModelViewerPage's
+  create-version pattern), not to generic loading states.
 
 ## Reload policy
 Avoid `page.reload()` when the UI updates reactively (SignalR, query
 invalidation); when unavoidable use `{ waitUntil: "domcontentloaded" }`.
 
 ## Quality bar
-One behavior per scenario; no placeholder assertions; verify full-stack flows at
-every relevant layer (UI + API + DB), not just one. Scenario names are grep keys
-and history identity — keep them stable.
+One behavior per scenario; no placeholder assertions (a `Then` must assert the
+behavior the scenario names — data/content, not just that a container
+rendered); verify full-stack flows at every relevant layer (UI + API + DB —
+`helpers/api-helper.ts` has the methods), not just one. Scenario names are
+grep keys and history identity — keep them stable.
+
+Planned hardening lives in `.claude/prompts/`: 46 (selector contract + CI
+drift audit), 47 (sleep/conditional cleanup, web-first migration, @serial
+reclamation after 41/42). Don't half-implement those as side effects.

--- a/.claude/skills/frontend-patterns/SKILL.md
+++ b/.claude/skills/frontend-patterns/SKILL.md
@@ -1,67 +1,102 @@
 ---
 name: frontend-patterns
-description: Modelibr frontend conventions — feature modules, apiBase/axios routing, React Query vs Zustand state split, forms, demo mode (MSW), SignalR, tab system, Jest testing. Use when creating or editing code under src/frontend.
+description: Modelibr frontend conventions — feature modules, apiBase/axios routing, React Query keys/invalidation, Zustand state split, code placement rules, styling tokens, demo mode (MSW), SignalR, tab system, Jest testing, known traps. Use when creating or editing code under src/frontend.
 ---
 
-# Frontend patterns (React + TypeScript + Vite)
+# Frontend patterns (React 19 + TypeScript + Vite)
+
+Known debt + planned refactors live in `.claude/prompts/` (13, 18, 20, 26,
+33–38). Before reworking query keys, feature boundaries, Settings, the demo
+handlers, or anything per-asset-type, read the matching prompt — don't
+half-implement it as a side effect.
 
 ## API layer
-- All HTTP goes through feature-local API modules under
-  `src/frontend/src/features/*/api/` using the shared axios client
-  `src/frontend/src/lib/apiBase.ts`.
-- `services/ApiClient.ts` is a backward-compat re-export facade — never add new
-  fetch logic or API methods there. No raw `fetch()`, no hardcoded base URLs.
+- All HTTP goes through feature-local API modules under `features/*/api/`
+  using the shared axios client `src/lib/apiBase.ts`. No raw `fetch()`, no
+  hardcoded base URLs (asset URLs via `resolveApiAssetUrl`).
+- apiBase rejects with a normalized `ApiClientError` (status, code, details,
+  isNetworkError/isTimeout/isOffline) — catch that, not `AxiosError`.
+  Backend statuses are currently unreliable (400-for-everything in places;
+  prompt 26 fixes) — branch on error `code`/`message`, not status, for
+  not-found/conflict semantics.
+- `services/ApiClient.ts` is a deprecated re-export facade slated for
+  deletion (prompt 34) — never add to it.
+- TRAP — file/preview URL helpers (`getFileUrl`, `getFilePreviewUrl`)
+  currently live in `features/models/api/modelApi.ts` and are imported
+  cross-feature. Known wart (prompt 34 moves them to shared) — import them,
+  don't duplicate them.
 
-## Feature module structure
-`src/frontend/src/features/{name}/` contains: `api/` ({feature}Api.ts +
-React Query `queries.ts`), `components/`, `hooks/`, `types/`, `index.ts` (public
-re-exports).
+## Code placement (two trees exist — know the rule)
+- `features/{name}/` — feature-specific code: `api/` ({feature}Api.ts +
+  `queries.ts`), `components/`, `hooks/`, `types/`, `index.ts`.
+- `src/shared/` — anything reusable across features (components, hooks,
+  utils, validation, styles/tokens, three, thumbnail). **New shared code
+  goes here**, never in the legacy root `src/components|hooks|utils` trees
+  (prompt 36 merges those; app shell = `components/layout` + `contexts` +
+  tab system stays put until then).
+- TRAP — the Settings UI is a 1,774-line monolith at
+  `components/tabs/Settings.tsx`, NOT in `features/settings` (which holds
+  only its api/). Prompt 35 fixes; meanwhile extract the section you touch.
 
 ## State split (strict)
-- **Server state** → React Query: `queryOptions()` + `useQuery` hooks in feature
-  `api/queries.ts`; `useMutation` with optimistic updates; invalidate related keys
-  on success.
-- **UI state** → Zustand stores in `src/frontend/src/stores/` (panels, navigation,
-  viewer settings, upload progress, preferences).
-- **Ephemeral component state** → `useState` only.
+- **Server state** → React Query only. **UI state** → Zustand stores in
+  `src/stores/` (small, single-purpose). **Ephemeral** → `useState`.
+- Query keys are inline string arrays with NO factory (prompt 33) and mixed
+  naming (`['models']` vs `['model-tags']`). A mismatched key silently stops
+  invalidating — **grep for the exact existing key before writing any
+  `useQuery`/`invalidateQueries`; reuse it verbatim; never invent a
+  variant.**
+- Mutations invalidate related keys on success; optimistic updates where the
+  neighbors do.
+
+## Styling
+- Design tokens: `src/shared/styles/tokens.css` — use `var(--token)`; no new
+  hardcoded colors (a sweep + lint gate is prompt 20; don't add to the pile).
+- Component CSS files are **global scope** — prefix class names with the
+  component name; check for collisions.
+- Shared UI = small dumb composable primitives, not type-aware
+  mega-components; the Models tab is the design identity other tabs follow.
+- **New asset type? STOP — read prompt 18.** Do not copy an existing
+  `XList.tsx` (650–850 lines each) as a template; that's the six-clone
+  problem being actively dismantled.
 
 ## Forms
 `react-hook-form` + `zodResolver`; composable Zod schemas in
-`src/frontend/src/shared/validation/formSchemas.ts`.
+`src/shared/validation/formSchemas.ts`.
 
 ## Demo mode
-- Activates with `VITE_DEMO_MODE=true` (`src/frontend/.env.demo`); MSW intercepts
-  API calls — static mocks in `src/mocks/handlers.ts`, interactive in
-  `dynamicDemoHandlers.ts`; data persists in IndexedDB (`src/mocks/db/demoDb.ts`).
-- **When backend API shape/endpoints change, check demo handlers for matching
-  updates**, and validate `npm run build:demo` for demo-visible changes.
-- Demo impact surface: `.env.demo`, `vite.config.js`, `vite-env.d.ts`,
-  `package.json` (`build:demo`), `scripts/prepare-demo-assets.js`.
+- `VITE_DEMO_MODE=true` (`.env.demo`); MSW intercepts — static mocks in
+  `src/mocks/handlers.ts`, interactive in `dynamicDemoHandlers.ts` (4k-line
+  monolith; prompt 38 splits it); data persists in IndexedDB
+  (`src/mocks/db/demoDb.ts`).
+- **When backend API shape/endpoints change, update demo handlers to match**
+  and validate `npm run build:demo` for demo-visible changes.
 
 ## SignalR
-- Real-time events via `services/ThumbnailSignalRService.ts` (singleton);
-  events: `ThumbnailStatusChanged`, `ActiveVersionChanged`.
-- Demo mode stubs SignalR endpoints in `dynamicDemoHandlers.ts` (prevents 405s).
+Real-time via `services/ThumbnailSignalRService.ts` (singleton); events:
+`ThumbnailStatusChanged`, `ActiveVersionChanged`. Demo mode stubs the SignalR
+endpoints in `dynamicDemoHandlers.ts` (prevents 405s).
 
 ## Tabs
 New tab type = three places: a case in `TabContent.tsx`, an entry in
 `useTabMenuItems()`, and the `TabType` union in `src/shared/types/ui.ts`.
 
 ## Shared viewer/worker logic (don't duplicate)
-Three.js / geometry / pixel-decode logic you write for the viewer that the
-worker's thumbnail render or demo mode must produce **identically** (STL mesh
-build, TIFF decode, displacement-normal shader, …) is **shared code** — put it
-once in `src/asset-processor/lib/` as an injected-dep ESM and import it by
-relative path, rather than copying it into both viewers. See the
-`asset-processor-patterns` skill, "Shared cross-runtime code".
-
-## Design system
-Build shared UI as small composable primitives, not type-aware mega-components;
-the Models tab is the design identity other asset tabs follow.
+Three.js / geometry / pixel-decode logic that the worker's thumbnail render
+or demo mode must reproduce **identically** (STL mesh build, TIFF decode,
+displacement-normal shader, …) lives once in `src/asset-processor/lib/` as
+injected-dep ESM, imported by relative path. See `asset-processor-patterns`,
+"Shared cross-runtime code".
 
 ## Testing
-- **Jest** (not Vitest) + `@testing-library/react` + `user-event`;
-  files `__tests__/*.test.ts(x)`.
+- **Jest** (not Vitest) + `@testing-library/react` + `user-event`; files
+  `__tests__/*.test.ts(x)`. Full conventions — tiers, mock infrastructure,
+  the "must be able to fail" rule — live in the **`frontend-test-authoring`**
+  skill; read it before writing any test.
+- When editing a 500+ line component, extract + test the section you touch —
+  don't grow it.
 
 ## Verify
-`cd src/frontend && npm test && npm run lint && npm run build`
+`cd src/frontend && npm test && npm run lint && npm run format:check && npm run build`
+(format:check is a required CI gate NOT covered by lint — Markdown/JSON/CSS
+drift passes lint but fails CI; `npm run format` auto-fixes.)

--- a/.claude/skills/frontend-test-authoring/SKILL.md
+++ b/.claude/skills/frontend-test-authoring/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: frontend-test-authoring
+description: Writing Modelibr frontend Jest tests — the can't-fail deletion rule, test tiers (api contract / hook+store / flow), mock infrastructure (global apiBase mock, MSW tier, typed fixtures), regression-comment convention, PrimeReact/virtuoso gotchas. Use when creating or editing any test under src/frontend. For Playwright E2E use e2e-authoring instead.
+---
+
+# Frontend test authoring (Jest + Testing Library)
+
+## The one rule
+**Every test must be able to fail while the feature is broken.** Before
+writing (or keeping) a test, name the regression that would make it go red.
+Forbidden: static text/placeholder assertions with no logic behind them,
+"renders without crashing", asserting a mock was called with what you just
+passed, mocking PrimeReact (or any component library) and asserting on the
+stub. If the only thing that can fail it is a label rename, delete it.
+
+## Convention: name the regression
+Each test (or its describe block) carries a comment saying what real bug it
+catches — see `ScriptList.flow.test.tsx` ("the language options were derived
+from the *filtered* result set…") or `soundApi.test.ts` ("a truthy check here
+would drop 'from 0 seconds'"). If you can't write that comment, see rule one.
+
+## Three tiers — pick by what you're testing
+1. **API contract tests** (`features/*/api/__tests__/`): the mocked axios
+   client (globally mocked in `setupTests.ts`; cast `client.get as
+   jest.Mock`). Assert request construction — URL/params serialization,
+   payload shape (keys omitted vs null), response unwrapping — plus at least
+   one error path. Model: `soundApi.test.ts`.
+2. **Hook/store behavior**: `renderHook` + `createQueryWrapper` /
+   `createTestQueryClient` from `src/test/renderWithProviders.tsx` (fresh
+   QueryClient per test, retries off). Stores: test transitions/persistence,
+   not `set`-wrappers. Model: `useScriptListData.test.ts`,
+   `uploadProgressStore.test.ts`.
+3. **Flow tests** (`X.flow.test.tsx`, one per page): real component tree via
+   `renderWithProviders`, real user-event, network-level mocks. Baseline:
+   load → filter → mutate → **assert the list reflects it after refetch**
+   (the invalidation check) → failure path (error state, no crash, retry
+   recovers). Model: `ScriptList.flow.test.tsx`. These are the layer that
+   catches "app broken, tests green".
+
+## Mock infrastructure (know what's already mocked)
+- `setupTests.ts` **globally mocks `@/lib/apiBase`** — every unconfigured
+  `client.get/post/…` resolves `undefined`. A component test that doesn't
+  set up its API responses is testing a broken data path and must not assert
+  success states. `jest.clearAllMocks()` + explicit `mockImplementation`
+  per file (route by URL, like the flow tests do).
+- **MSW tier** (once prompt 39 lands): flow tests opt in via
+  `src/test/mswServer.ts` to run the REAL apiBase (interceptors +
+  `ApiClientError`) with `onUnhandledRequest: 'error'` — unmocked requests
+  fail loudly. Prefer it for new flow tests; check the helper's header for
+  the opt-out mechanics.
+- **Fixtures**: use the typed builders in `src/test/fixtures/` (once they
+  exist — prompt 39); never hand-roll DTO literals in new tests. Typed
+  fixtures turn backend DTO drift into compile errors.
+- Error paths assert the real `ApiClientError` fields (`status`, `code`,
+  `isOffline`, `isTimeout`) — not just "something threw".
+
+## Gotchas
+- **Jest, not Vitest** (worker uses Vitest — don't cross-pollinate config).
+- `import.meta.env` doesn't exist in Jest — env comes from `process.env`
+  set in `setupTests.ts`; that's why apiBase is module-mocked. Don't import
+  modules that read `import.meta` at module scope without a mock.
+- CSS imports resolve via `identity-obj-proxy` — the CSS moduleNameMapper
+  rule must stay ABOVE the `@/` alias in `jest.config.js` (first-match-wins).
+- PrimeReact overlays render into `document.body` — query panels via
+  `document.querySelector('.p-dropdown-panel')`-style helpers (see
+  ScriptList.flow) and use real PrimeReact, never a stub.
+- react-virtuoso lists may not render rows in jsdom without viewport
+  sizing — use/extend the shared helper in `src/test/`; never fix with
+  timeouts.
+- Tab-context dependencies: stub `@/hooks/useTabContext` per file when a
+  component opens tabs (see ScriptList.flow) — that's an app-shell seam,
+  not over-mocking.
+
+## Where tests live / verify
+`__tests__/*.test.ts(x)` next to the code under test. Run one file while
+iterating: `npx jest path/to/file.test.tsx -t "name"`. Full gate:
+`cd src/frontend && npm test && npm run lint && npm run format:check`.
+Planned work: prompts 37 (prune), 39 (mock infra), 40 (flow rollout).

--- a/.claude/skills/webdav-patterns/SKILL.md
+++ b/.claude/skills/webdav-patterns/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: webdav-patterns
+description: Modelibr WebDAV virtual drive — middleware interception (Blender Safe Save), virtual store/collections, client-compat shims for macOS Finder/Windows Explorer/Blender, temp-file lifecycle, data-safety rules. Use when creating or editing src/WebApi/Infrastructure/WebDavMiddleware.cs, src/WebApi/Services/*WebDav*/RequestHandlerFactory, or anything under src/Infrastructure/WebDav.
+---
+
+# WebDAV patterns (virtual asset drive)
+
+## The cardinal rule
+Every odd-looking branch here is a **client-compat shim debugged against real
+Finder / Windows Explorer / Blender traffic**, and its comment explains which
+client demands it. Never simplify or remove a shim because it looks
+redundant. Any behavior change requires a manual test against at least one
+real client — name the client/OS in the PR (generically; no machine-specific
+details in public content).
+
+## Map
+- `WebApi/Infrastructure/WebDavMiddleware.cs` (~830 lines) — mounted at
+  `/modelibr` (`app.UseWebDav`). Intercepts special flows itself; everything
+  else dispatches to NWebDav (`0.1.36` — dormant package, wrapped
+  deliberately).
+- `WebApi/Services/RequestHandlerFactory` → `MacOsPropFindHandler` (PROPFIND)
+  / `CustomWebDavHandler` (OPTIONS/GET/HEAD).
+- `Infrastructure/WebDav/VirtualAssetStore` (~1,200 lines) — DB-driven
+  virtual tree: `Projects/ Packs/ Models/ TextureSets/ EnvironmentMaps/
+  Sprites/ Sounds/ Selection/`. Per-type `Virtual*Collections` classes
+  (mirrors the six-clone problem — prompt 18 note; don't add a seventh
+  without reading it).
+
+## Intercepted flows (order matters in `InvokeAsync`)
+1. `._*` AppleDouble noise → discarded with per-method status codes.
+2. Blender Safe Save: PUT `*.blend@` (temp) → HEAD/PROPFIND/PROPPATCH
+   verification (Windows MiniRedirector requires these or reports the write
+   failed) → MOVE to `*.blend` = hash-compare + create model version via
+   CQRS. `.blend1` backup ops are silently ignored.
+3. LOCK/UNLOCK: synthetic, **never enforced** (uuid theater; NWebDav's
+   `NoLockingManager` would 403 otherwise). New file = 201, existing = 200.
+   Concurrent editors both "hold" exclusive locks — versioning makes
+   concurrent saves fork versions instead of corrupting; that's the accepted
+   trade-off. OPTIONS advertises `DAV: 1, 2`; changing that or lock behavior
+   is compat-sensitive — test against Windows write flows first.
+4. PUT `/modelibr/Models/{name}.blend` = create model (403 if Blender
+   integration disabled/installing, 409 on name conflict). **0-byte PUT is a
+   client pre-create stub → 201 WITHOUT creating a model** — the real
+   content PUT follows.
+
+## Data-safety rules
+- **Never delete an unprocessed Blender temp file.** Failure paths must
+  quarantine, not destroy (prompt 30 — if not yet landed, its findings still
+  apply: unresolvable-model MOVE currently deletes + 204s, and name-based
+  model resolution has no ambiguity guard; don't extend those paths without
+  fixing them).
+- Missing physical blob must become 404, never an empty stream.
+- Temp files: `{uploads}/webdav-blend-temp/`, keyed by SHA256 of the
+  normalized path (`GetTempFileKey`) — traversal-safe by construction; keep
+  it that way.
+
+## Store rules
+- `VirtualAssetStore` is a **singleton**; all DB access via
+  `_scopeFactory.CreateScope()` per request — never cache a scoped service.
+- Virtual filenames = asset name + original file's extension
+  (`WebDavUtilities.GetVirtualFileName`) so listings show asset names, not
+  upload filenames.
+- Physical paths = hash-based layout `root/aa/bb/{hash}` and MUST match
+  `HashBasedFileStorage` (duplicated knowledge until prompt 30 switches to
+  persisted `File.RelativePath`).
+- Perf: resolvers load full aggregate graphs per request and clients send
+  PROPFIND storms — don't add `Include`s casually (read-model plan:
+  prompt 28).
+
+## NWebDav quirks (why the wrappers exist)
+- Writes responses **synchronously** → middleware opts in
+  `AllowSynchronousIO` per request. Keep that; Kestrel blocks sync IO
+  otherwise.
+- Crashes on empty PROPFIND body → `MacOsPropFindHandler` injects `allprop`
+  (RFC-legal empty body from macOS) and rewrites collection hrefs to end
+  with `/` (Finder requirement).
+
+## Testing
+Coverage is thin (path-resolution unit tests only) until prompt 31's
+client-replay suite lands — sequences per client dance through
+`WebApplicationFactory`, `Category=Integration`. Until then: any middleware/
+handler change = manual client verification (Blender save is the highest-
+value smoke). This surface is unauthenticated by design (prompt 23) — never
+add write endpoints here without checking the threat-model page.
+
+## Verify
+`dotnet build Modelibr.sln && dotnet test Modelibr.sln --no-build --filter
+"Category!=Integration"` + backend-integration suite if integration tests
+were touched + the manual client check above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ locally; core behavior must never depend on hosted services.
 - Orchestration: Docker Compose (root `docker-compose.yml`; e2e has its own).
 
 **Domain-specific conventions live in skills** (auto-loaded when relevant):
-`backend-patterns`, `frontend-patterns`, `asset-processor-patterns`,
-`e2e-authoring`, `test-triage`. Skills are canonical agent docs — there is no
+`backend-patterns`, `frontend-patterns`, `frontend-test-authoring`,
+`asset-processor-patterns`, `webdav-patterns`, `e2e-authoring`, `test-triage`. Skills are canonical agent docs — there is no
 parallel "AI documentation" set. **If a skill claim contradicts the code, trust
 the code and fix the skill in the same session.**
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -28,13 +28,11 @@ export default defineConfig({
     // Retries only re-run failed tests, so they don't weaken anything; raising
     // them via PW_RETRIES helps the flaky-timeout tail on slow runners pass.
     retries: process.env.PW_RETRIES ? parseInt(process.env.PW_RETRIES, 10) : 1,
-    // Workers are controlled per-phase by run-e2e.js:
-    //   setup    → --workers=1  (sequential, avoids asset-processor overload)
-    //   chromium → --workers=2  (local) / --workers=4  (CI)
-    //
-    // 2 workers locally reduces database and asset-processor contention,
-    // eliminating most parallel timing issues while keeping run time reasonable.
-    // When running manually, default to 2.
+    // Workers are controlled per-phase by run-e2e.js (see its comments for the
+    // current counts — chromium runs 3 both locally and on CI; 4 caused
+    // asset-processor contention). This value is only the fallback for manual
+    // `npx playwright test` runs without PW_WORKERS; 2 keeps database and
+    // asset-processor contention low for ad-hoc runs.
     workers: parseInt(process.env.PW_WORKERS || "2", 10),
     // The JSON reporter writes a machine-readable run summary (incl. each
     // failure's message + the path to its trace/screenshot under test-results/)


### PR DESCRIPTION
## What

Documentation-only PR carrying the agent-guide updates from the full-codebase review session (backend, WebDAV, frontend, worker, unit-test and E2E audits). No runtime code changes — the only non-`.claude` file is a comment-only correction in `tests/e2e/playwright.config.ts`.

All skills now follow one contract: **describe the code as it is** (including known warts, marked TRAP with the prompt that fixes them), give the operative instruction, and point at the planned-refactor queue so agents don't half-implement pending work as side effects.

## Changes

**Updated skills**
- `backend-patterns` — transaction trap (no unit of work: repos self-commit), manual domain-event-dispatch trap, honest endpoint error-mapping state, FileType registry rule, `AsSplitQuery`/soft-delete trio, `WorkerApiKeyFilter` requirement, corrected verify chain.
- `frontend-patterns` — code-placement rules (two shared trees), query-key grep-before-writing rule, `ApiClientError` handling, "new asset type? STOP" pointer, token/styling rules, **corrected verify chain** (`format:check` was missing — an agent following the old skill would claim verified and fail CI).
- `asset-processor-patterns` — **two stale claims fixed** (registry was missing `EnvironmentMap`; displacement-normal shader migration was described as pending but shipped), plus job-lifecycle/timeout trap, RendererPool rules, API-client auth trap, `lib/` flatness rule, corrected verify chain.
- `e2e-authoring` — selector reality (testid contract for new code; ~950 legacy CSS locators grandfathered), new "waits & control flow" flake rules (web-first assertions, no sleeps, no state-branching), `PW_TEST_TIMEOUT` knob, worker-count correction, sharpened quality bar.

**New skills**
- `frontend-test-authoring` — the can't-fail rule, three test tiers, global apiBase-mock trap, regression-comment convention, PrimeReact/virtuoso/`import.meta` gotchas.
- `webdav-patterns` — client-compat cardinal rule, intercepted-flow map (Blender Safe Save, AppleDouble, synthetic locks), data-safety rules, NWebDav quirks.

**Other**
- `CLAUDE.md` — registers the two new skills.
- `playwright.config.ts` — stale worker-count comment corrected (run-e2e.js runs 3 workers local *and* CI, not 2/4); config value documented as the manual-run fallback only.

## Notes

- The `backend-patterns` FileType section describes the registry pattern introduced in #552 — the two PRs pair; merge order doesn't matter materially, but #552 first keeps docs strictly trailing code.
- Skill-vs-code contradictions found during the reviews were fixed per the CLAUDE.md rule (trust the code, fix the skill in the same session).