### PR TITLE
chore: add videos:generate script for one-command local video checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "test:frontend": "cd src/frontend && npm test",
         "test:e2e": "cd tests/e2e && npm test",
         "test:e2e:demo": "cd tests/e2e && npm run test:demo",
+        "videos:generate": "(cd tests/e2e && npm run test:teardown >/dev/null 2>&1); (cd tests/e2e && npm run test:setup) && (cd docs/videos && ([ -d node_modules ] || npm ci) && npx playwright install chromium && npm run generate); ec=$?; (cd tests/e2e && npm run test:teardown); exit $ec",
         "test:all": "node scripts/test-runner/index.mjs",
         "test:all:fast": "node scripts/test-runner/index.mjs --tier=fast --yes",
         "test:all:full": "node scripts/test-runner/index.mjs --all --yes",


### PR DESCRIPTION
Adds `npm run videos:generate` so the docs feature-video generation can be spot-checked locally with one command — same flow as CI's `generate-videos` job, but on a real GPU.

Self-contained per the repo's suite conventions: leading silent teardown, e2e stack up, `docs/videos` deps installed only if missing, Playwright chromium ensured, generate, always teardown after; exit code reflects the generation result. Output lands in `docs/static/videos/` (gitignored — inspection only; videos stay CI-generated).

**Verified end-to-end locally:** all 8 videos produced, stack torn down clean, exit 0.