### PR TITLE
fix(videos): never trim content to the duration cap; cursor overlay; video-authoring skill

### DIFF
--- a/.claude/skills/video-authoring/SKILL.md
+++ b/.claude/skills/video-authoring/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: video-authoring
+description: Authoring Modelibr docs feature videos — the record→trim→analyze→collect pipeline, choreography best practices (provision off-camera, show outcomes, cursor overlay, pacing), duration-cap semantics, selector dependencies on the frontend. Use when creating or editing anything under docs/videos (specs, helpers, manifest, pipeline scripts) or when a docs video looks wrong/fails to generate.
+---
+
+# Docs video authoring (Playwright screencast)
+
+Feature videos embedded in `docs/docs/features/*.md`. Generated in CI on every
+docs build (never committed — see the no-committed-binaries rule); regenerate
+locally with one command from the repo root:
+
+```bash
+npm run videos:generate                       # full: e2e stack up → all videos → teardown
+# or, with the e2e stack already running (tests/e2e npm run test:setup):
+cd docs/videos && npm run generate:texture-sets   # one feature (see package.json for all)
+```
+
+## Pipeline (run-videos.js)
+
+`clean → playwright record → trim → analyze → collect`
+
+1. **Record** — each `scripts/<slug>.spec.ts` drives the app against the E2E
+   Docker stack (`FRONTEND_URL` :3002, `API_BASE_URL` :8090) and writes a raw
+   webm via `page.screencast` to `.generated/raw/`.
+2. **Trim** (`trim-videos.js`) — cuts **frozen tails only** (freeze-detect →
+   `recommendedEnd`). It NEVER cuts content to the duration cap; a cap-trim
+   chops the demo mid-action (this was a real bug — texture-sets shipped
+   truncated at exactly its 20s cap).
+3. **Analyze** (`analyze-videos.js`) — the QA gate. Fails on: missing,
+   unreadable, ≥85% black, frozen tail ≥4s, or **duration > manifest cap**.
+4. **Collect** — approved videos land in `docs/static/videos/`.
+
+Reports: `.generated/reports/raw-video-analysis.json` + `final-video-analysis.json`
+(durations, freeze/black segments, per-video issues) — start there when a video
+fails or looks wrong.
+
+## Duration caps (video-manifest.js)
+
+`maxDurationSeconds` is a **QA ceiling with CI headroom, not a target**.
+Choreograph for roughly **60–70% of the cap** on a fast local machine — CI
+renders without GPU and runs visibly slower, and the fixed-length pauses don't
+shrink. If analyze fails `over-max-duration`: tighten the choreography first;
+raise the cap only for a deliberate reason (and keep the manifest comment true).
+
+## Choreography rules — what makes a good feature video
+
+1. **Provision off-camera, demo on-camera.** All data setup (API uploads,
+   `clearAllData`, waiting for thumbnails) happens BEFORE
+   `startFeatureRecording`. Screen time is for the feature, never for loading.
+   If the demo needs generated artifacts (thumbnails, waveforms), wait for them
+   via API/`waitForThumbnails` pre-recording.
+2. **Show outcomes, not just actions.** After every click that changes the
+   screen, hold long enough to read the result (`mediumPause`/`longPause` at
+   payoffs). End on the feature's "hero state" and hold ~1s — the tail-freeze
+   trim keeps it tight.
+3. **Move the mouse like a human.** Use `humanClick`/`smoothMoveTo`/
+   `smoothDrag` — never bare `locator.click()`, which teleports. A synthetic
+   cursor overlay is auto-installed by `navigateTo()` (Playwright screencast
+   does not render the OS pointer; without the overlay every movement is
+   invisible).
+4. **One storyline per video.** A video answers "what does this feature do",
+   not "what does every button do". 3–5 beats: open → core workflow → payoff.
+   Anything more belongs in the written doc.
+5. **Interact with the subject matter.** Orbit the 3D preview (`smoothDrag` on
+   the canvas), play the sound, switch the variant — a static screen of a
+   visual product reads as broken.
+6. **Chapter card first.** `startFeatureRecording` shows the manifest
+   title/description as an overlay; keep manifest descriptions accurate — they
+   are on-screen copy.
+7. **Deterministic waits before recording, visual pacing during.** Inside the
+   recording, `viewerPause`-style timing is fine (it's choreography, not test
+   waiting — rule 4 of the testing rules doesn't apply here). Assertions on
+   app state (`expect(...).toBeVisible`) are still the way to sync with the
+   app between beats.
+
+## Recording mechanics
+
+- `page.screencast.start({ path, size: 1280×720, quality: 90 })`,
+  `showChapter(title, {description})`, `showActions()` captions (top-right),
+  `showOverlay(html)` for custom callouts, `stop()`.
+- Pacing helpers scale by `videoPaceFactor` (0.65) — tune the factor, not
+  individual sleeps.
+- `navigateTo(page, path)` — seeds tab layout via `leftTabs`/`rightTabs` URL
+  params (translated into the navigation store), waits for `.p-splitter` +
+  tab loading to settle, and installs the cursor overlay.
+- `disableHighlights(page)` after navigation kills Playwright's action
+  highlight borders.
+
+## Selector dependencies — check on frontend changes
+
+Videos depend on frontend selectors just like E2E does, but nothing gates them
+on PRs — they break at docs-deploy time. Load-bearing selectors live in
+`helpers/video-helpers.ts` (`.p-splitter`, `.tab-loading`, `.model-card`,
+`.model-card-thumbnail img`) and per-spec (e.g. `.texture-set-card`,
+`.list-toolbar`, `.texture-preview-canvas`, `.files-tab`,
+`.file-mapping-card`). When renaming such classes/testids in
+`src/frontend`, grep `docs/videos/` too — and prefer the same selector policy
+as `e2e-authoring` (role/testid over CSS classes) when touching specs.
+
+## Adding a new feature video
+
+1. Add a manifest entry (slug, outputName, on-screen title/description,
+   realistic cap) in `video-manifest.js`.
+2. Add `scripts/<slug>.spec.ts` following an existing spec (provision via API →
+   `navigateTo` → assert page ready → `startFeatureRecording` → beats →
+   `stopFeatureRecording`).
+3. Add a `generate:<slug>` script to `docs/videos/package.json`
+   (`node run-videos.js --grep "<Title>" --slugs <slug>`).
+4. Embed in the feature doc with the standard `<video>` block (see any
+   `docs/docs/features/*.md`) and remove that page's "video placeholder" note.
+5. Verify locally: `npm run generate:<slug>` with the e2e stack up, then check
+   `.generated/reports/final-video-analysis.json` and watch the collected file
+   in `docs/static/videos/`.
+
+## Failure triage
+
+| Symptom | Meaning |
+| --- | --- |
+| `missing` | Spec crashed before/during recording — run the spec alone with `--grep`, read Playwright output |
+| `black-video` | App never rendered (stack down, wrong URL, WebGL failure) |
+| `frozen-tail` | >4s static tail survived trim — usually a hung final beat |
+| `over-max-duration` | Choreography too long for the cap — tighten or raise deliberately |
+| Video ends mid-action | Must not happen anymore (cap-trim removed); if seen, check `recommendedEnd` in the report for a false freeze detection |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ locally; core behavior must never depend on hosted services.
 
 **Domain-specific conventions live in skills** (auto-loaded when relevant):
 `backend-patterns`, `frontend-patterns`, `frontend-test-authoring`,
-`asset-processor-patterns`, `webdav-patterns`, `e2e-authoring`, `test-triage`. Skills are canonical agent docs — there is no
+`asset-processor-patterns`, `webdav-patterns`, `e2e-authoring`, `test-triage`,
+`video-authoring`. Skills are canonical agent docs — there is no
 parallel "AI documentation" set. **If a skill claim contradicts the code, trust
 the code and fix the skill in the same session.**
 

--- a/docs/videos/analyze-videos.js
+++ b/docs/videos/analyze-videos.js
@@ -16,6 +16,13 @@ for (const result of results) {
         console.error(
             `${result.outputName}: ${result.issues.join(", ")} (duration ${result.duration}s, recommendedEnd ${result.recommendedEnd}s)`,
         );
+        if (result.issues.includes("over-max-duration")) {
+            console.error(
+                `  → recording exceeds its manifest cap (${result.maxDurationSeconds}s). ` +
+                    "Content is never trimmed to the cap; tighten the spec choreography " +
+                    "or raise maxDurationSeconds in video-manifest.js deliberately.",
+            );
+        }
         hasFailure = true;
         continue;
     }

--- a/docs/videos/helpers/video-helpers.ts
+++ b/docs/videos/helpers/video-helpers.ts
@@ -9,6 +9,93 @@ export const ciVideoTimeout = process.env.CI === "true" ? 30000 : 15000;
 const videoPaceFactor = 0.65;
 const LEGACY_NAVIGATION_HASH_KEY = "__docsVideoNavigation";
 const initializedLegacyNavigationPages = new WeakSet<Page>();
+const cursorOverlayPages = new WeakSet<Page>();
+
+/**
+ * Playwright's screencast does not render the mouse pointer, so smooth
+ * mouse movements are invisible and every click looks like teleportation.
+ * Inject a synthetic cursor that follows mousemove events and pulses on
+ * clicks — this is what makes the recorded interactions readable.
+ */
+async function ensureCursorOverlayInitScript(page: Page) {
+    if (cursorOverlayPages.has(page)) {
+        return;
+    }
+
+    await page.addInitScript(() => {
+        function attach() {
+            if (!document.body) {
+                requestAnimationFrame(attach);
+                return;
+            }
+            if (document.getElementById("__docsVideoCursor")) {
+                return;
+            }
+
+            const style = document.createElement("style");
+            style.textContent = `
+                #__docsVideoCursor {
+                    position: fixed;
+                    top: 0;
+                    left: 0;
+                    width: 18px;
+                    height: 18px;
+                    margin: -9px 0 0 -9px;
+                    border-radius: 50%;
+                    background: rgba(255, 255, 255, 0.9);
+                    border: 2px solid rgba(30, 41, 59, 0.85);
+                    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.35);
+                    pointer-events: none;
+                    z-index: 2147483647;
+                    opacity: 0;
+                    transition: opacity 0.15s ease;
+                }
+                #__docsVideoCursor.visible { opacity: 1; }
+                #__docsVideoCursor .ripple {
+                    position: absolute;
+                    inset: -6px;
+                    border-radius: 50%;
+                    border: 2px solid rgba(59, 130, 246, 0.9);
+                    animation: __docsVideoRipple 0.45s ease-out forwards;
+                    pointer-events: none;
+                }
+                @keyframes __docsVideoRipple {
+                    from { transform: scale(0.6); opacity: 1; }
+                    to { transform: scale(2.2); opacity: 0; }
+                }
+            `;
+            document.head.appendChild(style);
+
+            const cursor = document.createElement("div");
+            cursor.id = "__docsVideoCursor";
+            document.body.appendChild(cursor);
+
+            window.addEventListener(
+                "mousemove",
+                (event) => {
+                    cursor.classList.add("visible");
+                    cursor.style.transform = `translate3d(${event.clientX}px, ${event.clientY}px, 0)`;
+                },
+                { capture: true, passive: true },
+            );
+
+            window.addEventListener(
+                "mousedown",
+                () => {
+                    const ripple = document.createElement("div");
+                    ripple.className = "ripple";
+                    cursor.appendChild(ripple);
+                    setTimeout(() => ripple.remove(), 500);
+                },
+                { capture: true, passive: true },
+            );
+        }
+
+        attach();
+    });
+
+    cursorOverlayPages.add(page);
+}
 
 function paceDuration(ms: number) {
     return Math.max(120, Math.round(ms * videoPaceFactor));
@@ -423,6 +510,7 @@ export async function dragElementTo(
 export async function navigateTo(page: Page, path: string) {
     // Use localhost (not 127.0.0.1) so browser origin matches CORS allowed origins
     const baseUrl = process.env.FRONTEND_URL || "http://localhost:3002";
+    await ensureCursorOverlayInitScript(page);
     const usedLegacyNavigation = await applyLegacyNavigationState(
         page,
         path,

--- a/docs/videos/scripts/texture-sets.spec.ts
+++ b/docs/videos/scripts/texture-sets.spec.ts
@@ -187,7 +187,30 @@ test.describe("Texture Sets", () => {
         await expect(textureSetCard.getByText(/3 textures?/i)).toBeVisible({
             timeout: ciVideoTimeout,
         });
+
+        // ── Off-camera prewarm ────────────────────────────────────────────
+        // Open the viewer and the Preview tab once BEFORE recording so the
+        // EXR decode + GPU texture upload cost is paid off-camera. Without
+        // this, the recorded Preview beat spends many seconds on a barely
+        // moving canvas (and synthetic drag steps crawl while the render
+        // loop is saturated). Then restore the pre-recording UI state.
+        await textureSetCard.click();
+        const prewarmViewer = page.locator(".texture-set-viewer");
+        await expect(prewarmViewer).toBeVisible({ timeout: ciVideoTimeout });
+        await page.getByRole("tab", { name: "Preview" }).click();
+        await expect(
+            prewarmViewer.locator(".texture-preview-canvas"),
+        ).toBeVisible({ timeout: ciVideoTimeout });
+        await expect(
+            prewarmViewer.locator(".texture-loading-overlay"),
+        ).toBeHidden({ timeout: ciVideoTimeout });
+        // Restore: back to the default tab, then back to the list tab (the
+        // first dock tab) so the recording starts from the library grid.
+        await page.getByRole("tab", { name: "Texture Types" }).click();
+        await leftPanel.locator(".dock-bar .draggable-tab").first().click();
+        await expect(textureSetCard).toBeVisible({ timeout: ciVideoTimeout });
         await mediumPause(page);
+
         await startFeatureRecording(page, testInfo, { slug: "texture-sets" });
 
         const cardBox = await textureSetCard.boundingBox();
@@ -241,48 +264,23 @@ test.describe("Texture Sets", () => {
         });
         await viewerPause(page, 900);
 
-        // Wait for canvas to have actual layout dimensions before getting bounding box
-        await page.waitForFunction(
-            () => {
-                const el = document.querySelector(
-                    ".texture-set-viewer .texture-preview-canvas",
-                );
-                if (!el) return false;
-                const rect = el.getBoundingClientRect();
-                return rect.width > 0 && rect.height > 0;
-            },
-            { timeout: ciVideoTimeout },
-        );
-
-        // Use evaluate to get bounding rect directly (avoids actionTimeout constraint)
-        const previewBox = await page.evaluate(() => {
-            const el = document.querySelector(
-                ".texture-set-viewer .texture-preview-canvas",
-            );
-            if (!el) return null;
-            const rect = el.getBoundingClientRect();
-            if (rect.width === 0 || rect.height === 0) return null;
-            return {
-                x: rect.x,
-                y: rect.y,
-                width: rect.width,
-                height: rect.height,
-            };
+        // Final beat: switch the preview geometry via Preview Settings — a
+        // visible 3D payoff. Deliberately NOT an orbit drag, and deliberately
+        // plain clicks instead of humanClick: this canvas renders with
+        // frameloop="always", and under software WebGL (headless recording,
+        // CI) every synthetic pointer step over it waits ~2s for the render
+        // loop, so glide paths crossing the canvas turn into slow motion.
+        await page.locator('[aria-label="Open preview settings"]').click();
+        await expect(page.locator("#preview-settings")).toBeVisible({
+            timeout: ciVideoTimeout,
         });
-        if (previewBox) {
-            await page.mouse.move(
-                previewBox.x + previewBox.width * 0.55,
-                previewBox.y + previewBox.height * 0.55,
-                { steps: 12 },
-            );
-            await page.mouse.down();
-            await page.mouse.move(
-                previewBox.x + previewBox.width * 0.72,
-                previewBox.y + previewBox.height * 0.44,
-                { steps: 16 },
-            );
-            await page.mouse.up();
-        }
+        await mediumPause(page);
+        await page.locator("#preview-settings .p-dropdown").click();
+        await page
+            .locator('.p-dropdown-panel .p-dropdown-item:has-text("Sphere")')
+            .click();
+        await viewerPause(page, 700);
+        await page.locator('#preview-settings [title="Close"]').click();
 
         await viewerPause(page, 1200);
         await stopFeatureRecording(page);

--- a/docs/videos/trim-videos.js
+++ b/docs/videos/trim-videos.js
@@ -23,20 +23,20 @@ for (const result of results) {
         continue;
     }
 
+    // Trim ONLY frozen tails (recommendedEnd from freeze detection).
+    // The manifest cap is a QA gate enforced by analyze-videos.js, not a
+    // trim point: cutting a recording at the cap chops the demo mid-action,
+    // which is worse than shipping a slightly longer video. Over-cap
+    // recordings must be fixed in the spec (or the cap raised deliberately).
     const shouldTrim =
-        result.duration > result.maxDurationSeconds ||
-        (result.recommendedEnd && result.recommendedEnd < result.duration - 1);
+        result.recommendedEnd && result.recommendedEnd < result.duration - 1;
 
     if (!shouldTrim) {
         fs.copyFileSync(sourcePath, destPath);
         continue;
     }
 
-    const trimEnd = Math.min(
-        result.duration,
-        result.maxDurationSeconds,
-        result.recommendedEnd || result.duration,
-    );
+    const trimEnd = Math.min(result.duration, result.recommendedEnd);
 
     const trimResult = spawnSync(
         ffmpegPath,

--- a/docs/videos/video-analysis.js
+++ b/docs/videos/video-analysis.js
@@ -148,13 +148,14 @@ export async function analyzeVideoDirectory(rootDir) {
         if (blackRatio >= 0.85) {
             issues.push("black-video");
         }
-        if (
-            tailFreeze &&
-            duration - recommendedEnd >= 4 &&
-            duration > spec.maxDurationSeconds
-        ) {
+        // A long frozen tail is an issue on its own (trim should have
+        // removed it), independent of the duration cap.
+        if (tailFreeze && duration - recommendedEnd >= 4) {
             issues.push("frozen-tail");
         }
+        // The cap is a QA ceiling with headroom built into the manifest,
+        // not a trim point — exceeding it means the spec choreography got
+        // too long and must be tightened (or the cap raised deliberately).
         if (duration > spec.maxDurationSeconds) {
             issues.push("over-max-duration");
         }

--- a/docs/videos/video-manifest.js
+++ b/docs/videos/video-manifest.js
@@ -1,31 +1,36 @@
+// `maxDurationSeconds` is a QA ceiling, not a target or a trim point:
+// recordings are NEVER cut to the cap (only frozen tails are trimmed).
+// analyze-videos.js fails the pipeline when a recording exceeds its cap —
+// that means the spec choreography must be tightened, or the cap raised
+// here deliberately. Caps include headroom for slower CI rendering.
 export const videoManifest = [
     {
         slug: "model-management",
         outputName: "model-management.webm",
         title: "Model Management",
         description: "Compare versions, inspect changes, and keep model history moving.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 45,
     },
     {
         slug: "texture-sets",
         outputName: "texture-sets.webm",
         title: "Texture Sets",
         description: "Inspect a reusable material built from global texture files.",
-        maxDurationSeconds: 20,
+        maxDurationSeconds: 40,
     },
     {
         slug: "recycled-files",
         outputName: "recycled-files.webm",
         title: "Recycled Files",
         description: "Recycle, restore, and permanently delete assets with confidence.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 40,
     },
     {
         slug: "user-interface",
         outputName: "user-interface.webm",
         title: "User Interface",
         description: "Navigate tabs, menus, and workspace controls quickly.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 40,
     },
     {
         slug: "sprites",
@@ -39,21 +44,21 @@ export const videoManifest = [
         outputName: "sounds.webm",
         title: "Sounds",
         description: "Browse, preview, and inspect sound assets.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 40,
     },
     {
         slug: "projects",
         outputName: "projects.webm",
         title: "Projects",
         description: "Browse, search, and inspect production-ready project boards.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 45,
     },
     {
         slug: "packs",
         outputName: "packs.webm",
         title: "Packs",
         description: "Create a pack and attach useful content in one focused flow.",
-        maxDurationSeconds: 30,
+        maxDurationSeconds: 40,
     },
 ];
 


### PR DESCRIPTION
## Problem

Docs feature videos sometimes end mid-demo and look static.

**Truncation (root cause found):** `trim-videos.js` cut every recording at its manifest `maxDurationSeconds` — the shipped `texture-sets.webm` is exactly 20.0s (its cap), ending mid-workflow with the Preview tab just opened. Raw recordings run far longer than the caps (63s measured locally for texture-sets), so users saw a third of the demo.

**Static look:** Playwright's screencast renders no mouse pointer, so all the existing smooth mouse choreography was invisible — every click looked like teleportation. Additionally, the texture-preview beat spent ~50s in slow motion because the r3f canvas (`frameloop="always"` + software WebGL in headless recording) delays every synthetic pointer step by ~2s (measured via `DEBUG=pw:api`: one 16-step drag = 36.9s).

## Changes

- **`trim-videos.js`**: trims **frozen tails only**. Content is never cut to the cap.
- **`video-analysis.js` / `analyze-videos.js`**: the cap is now a QA gate — the pipeline fails with an actionable message ("tighten the choreography or raise the cap deliberately") instead of silently shipping a chopped video. Frozen-tail detection decoupled from the cap.
- **`video-manifest.js`**: caps raised to realistic ceilings with CI headroom (30–45s) and documented as QA ceilings, not targets.
- **`video-helpers.ts`**: synthetic cursor overlay (dot + click ripple) auto-installed by `navigateTo` — mouse movement is finally visible in recordings.
- **`texture-sets.spec.ts`**: EXR preview prewarmed off-camera; the janky canvas drag replaced with a Preview Settings → geometry-switch-to-sphere payoff (plain clicks — glide paths across the canvas crawl under software GL).
- **New `video-authoring` skill** (registered in CLAUDE.md): pipeline map, choreography rules (provision off-camera, show outcomes, one storyline, cap semantics), selector dependencies on the frontend, failure triage.

## Verification

Regenerated `texture-sets` locally against the E2E stack: **36.16s, passes analyze, full story** (grid → viewer → Files → Preview → sphere payoff), cursor and click ripples visible, no truncation. Frame-by-frame montage inspected; scene-change and freeze analysis clean.

## Follow-up (out of scope here)

The underlying app-side issue — the texture preview canvas free-runs (`frameloop="always"`) on a static scene and starves input under software WebGL, which also affects real users on GPU-less machines — is documented for a separate fix (demand-rendering like `ScriptScenePreview` already does).