### PR TITLE
fix(storybook): register MSW worker at Storybook base path

### DIFF
--- a/src/frontend/.storybook/preview.ts
+++ b/src/frontend/.storybook/preview.ts
@@ -11,8 +11,17 @@ import { initialize, mswLoader } from 'msw-storybook-addon'
 
 import { handlers } from '../src/mocks/handlers'
 
-// Initialize MSW with default handlers
-initialize()
+// Initialize MSW with default handlers.
+// Use a relative worker URL so registration works both in dev (Storybook served
+// at the origin root) and on the GitHub Pages deploy, where Storybook lives
+// under the `/Modelibr/storybook/` sub-path. MSW resolves this against the
+// iframe's location, so the worker is found at whatever base Storybook is served
+// from — the default absolute `/mockServiceWorker.js` 404s under the sub-path.
+initialize({
+  serviceWorker: {
+    url: 'mockServiceWorker.js',
+  },
+})
 
 const preview: Preview = {
   parameters: {


### PR DESCRIPTION
## Problem

The deployed Storybook (https://papyszoo.github.io/Modelibr/storybook/index.html) logs on load:

```
[MSW] Failed to register the Service Worker:
  at bre (/Modelibr/storybook/assets/iframe-*.js)
```

`.storybook/preview.ts` called `initialize()` with no options, so MSW defaulted to registering its service worker at the **origin root** — `/mockServiceWorker.js`. On GitHub Pages the site is served under the `/Modelibr/storybook/` sub-path, so that root path returns the Pages 404 HTML page instead of the worker script, and `navigator.serviceWorker.register` fails. Storybook's own UI was unaffected because its assets use relative paths; only the SW registration used an absolute one.

## Fix

Pass a **relative** worker URL to `initialize()`:

```ts
initialize({ serviceWorker: { url: 'mockServiceWorker.js' } })
```

MSW resolves the URL against the iframe's `location.href`, so the worker is found at whatever base Storybook is served from:

- dev → `http://localhost:6006/mockServiceWorker.js`
- Pages → `https://papyszoo.github.io/Modelibr/storybook/mockServiceWorker.js`

This mirrors how the demo app already handles it in `src/main.tsx` (which uses `import.meta.env.BASE_URL`; that isn't usable in Storybook, whose Vite build has base `/`).

## Verification

- `npm run format:check` on the file passes; `storybook build` succeeds and the built iframe bundle emits the relative `mockServiceWorker.js` reference.
- Served the build under a simulated `/Modelibr/storybook/` root — both `iframe.html` and `mockServiceWorker.js` return `200 text/javascript` at the exact path MSW requests.

## Notes

- `npm run storybook` (dev, port 6006) serves at the origin root and works with or without this change, so it does **not** reproduce the bug; the sub-path serve above is the only local setup that exercises the deploy condition.
- The fix reaches the live site only after the `build-storybook` → docs deploy runs on the version branch.