### PR TITLE
feat(frontend): design-system skill, Storybook gallery with light/dark, compact density alignment

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: design-system
+description: Modelibr design system — the --mod-* token vocabulary, the shared primitive catalog (feedback states, ListHeader, ListToolbar, asset tiles) with import paths, the card/page visual identity rules, Storybook gallery + light/dark themes, and the known drift to never copy. Use when styling anything, writing CSS, building or editing UI components, or adding Storybook stories under src/frontend.
+---
+
+# Design system
+
+Goal: **every page looks like part of the same application.** The Models tab
+is the design identity other tabs follow. The mechanism is (1) tokens instead
+of raw values, (2) shared primitives instead of per-feature copies. Both
+exist; historical code predates them — new/edited code must not add to the
+drift (prompts 13/18/20 dismantle it).
+
+## Density — this is an application, not a website
+
+Modelibr is a dense desktop tool. The recurring agent failure mode is
+website styling: hero-sized headers, generous section padding, nested
+"card in card in padded page" framing. User-stated direction: *"no
+fireworks — only clean, useful app"*. Concretely:
+
+- Headers/toolbars: vertical padding ≤ `--mod-space-sm` (12px); the largest
+  text in the whole app is 1.5rem (`--mod-text-2xl`) and there is
+  deliberately no bigger token. Default UI text is `--mod-text-sm`.
+- Page/section padding tops out at `--mod-space-md` (16px). `lg`+ spacing is
+  for empty states and dialog chrome only — never anything that repeats.
+- Don't stack padding: page pad + framed card + inner pad = wasted space
+  (the scripts page shipped this way and was cut back — don't reintroduce).
+- No decorative wrappers: content sits flat on `--surface-ground`; a
+  1px `--surface-border` separator beats a framed card almost always.
+
+See it live: `npm run design` (root or `src/frontend`) opens Storybook
+directly on **Design System / Gallery** — the full token vocabulary and
+primitive set on one page; the toolbar paintbrush switches light/dark for
+any story.
+
+## Live design loop — agents verify by looking
+
+Vite HMR makes the gallery the live view of the design system: with
+`npm run design` running, any edit to `tokens.css`, a primitive, or its CSS
+hot-reloads in the open browser in under a second — the user watches changes
+land in real time.
+
+**Agent rule: never claim a styling change works without having seen it.**
+Builds passing is not visual evidence. Screenshot the gallery (and any
+directly affected story) after the change and read the image:
+
+```js
+// node --input-type=module -e "..." from src/frontend (Playwright is a dep)
+// against `npm run design` (port 6006) or a served `build-storybook` output.
+const page = await (await chromium.launch()).newPage()
+await page.goto(
+  'http://localhost:6006/iframe.html?id=design-system-gallery--dark&viewMode=story',
+  { waitUntil: 'networkidle' }
+)
+await page.screenshot({ path: '<scratchpad>/gallery.png', fullPage: true })
+```
+
+Shoot both `--dark` and `--light`. This loop is what catches the bug classes
+below — it found both on the day the gallery was built.
+
+## Tokens — `src/shared/styles/tokens.css`
+
+`--mod-*` variables layered on the PrimeReact Lara theme (light/dark both
+flow through). Rules:
+
+- **Color:** never hardcode hex/rgb in feature CSS or inline styles — use a
+  `--mod-color-*` token; raw PrimeReact vars (`--surface-*`, `--text-color*`,
+  `--primary-*`) are acceptable where no `--mod` alias exists. Exceptions
+  (three.js scene colors = content, not chrome) get a comment. Sweep + lint
+  gate is prompt 20; don't add to the pile.
+- **Selection rings / hover tints:** `rgba(var(--primary-color-rgb), …)` —
+  the triplet is defined in tokens.css; don't redefine it.
+- **Spacing / radius / z-index / motion / shadows:** use the `--mod-space-*`,
+  `--mod-radius-*`, `--mod-z-*`, `--mod-transition-*`, `--mod-shadow-*`
+  scales. No new magic z-indexes.
+- **Type scale:** `--mod-text-xs` (0.75) / `sm` (0.875, the default) / `md`
+  (1) / `lg` (1.125) / `xl` (1.25, tab titles) / `2xl` (1.5, page-title
+  ceiling — no 3xl exists on purpose). TRAP — the codebase has eight ad-hoc
+  "small" sizes (0.7/0.8/0.813/0.82/0.85/0.9…); never add another. Small
+  text is `sm` or `xs`, full stop. Weights via `--mod-font-weight-*`.
+- **Breakpoints:** CSS vars can't be used in `@media`; use the TS constants
+  in `shared/styles/breakpoints.ts` for runtime checks and write media
+  queries matching the documented `--mod-bp-*` values.
+
+## Primitive catalog — use these, don't hand-roll
+
+Barrel: `@/shared/components` (feedback + layout + overlay re-exported).
+
+| Need | Use | Never |
+|---|---|---|
+| Empty list / no results | `EmptyState` (variants `default`/`compact`, drop-target props) | a new `.x-empty` class — 19 hand-rolled variants exist; that's the disease |
+| Load failure | `ErrorState` (`block`/`inline`, `onRetry`) | ad-hoc error divs |
+| Loading | `LoadingState` (`block`/`inline`) | one-off spinners |
+| Page/tab title row | `ListHeader` (`page`=h1 / `tab`=h2, stats + actions slots) | per-feature `*-list-header` CSS |
+| Search/filter/actions bar | `ListToolbar*` family (`@/shared/components/list-toolbar`) | bespoke toolbar rows |
+| Asset card + grid | `AssetGrid`, `AssetTile`, `AssetTilePlaceholder`, `AddTile` (`@/shared/components/asset-tile`) | copying `.model-card` / `.sound-card` CSS |
+| Modal | `Dialog` (overlay wrapper, sizes) | raw PrimeReact Dialog with custom chrome |
+| Tag editing | `TagInput` (`@/shared/components/tags`) | new chip UIs |
+| Card size control | `CardWidthSlider` | duplicate sliders |
+| Category sidebar/filter | `CategoryTreePanel` (`@/shared/components/categories`) | per-page trees or re-styled copies |
+
+**Categories standard** (user-set, from the scripts page): the quiet
+`CategoryTreePanel` default — transparent background sitting directly on the
+page surface (**no** card frame or own background behind it), tight
+0.3rem-padded rows, hover = `--surface-hover`, selection = primary *tint*
+(`rgba(var(--primary-color-rgb), 0.12)` + 0.24 border), never solid primary.
+A `border-right` separates a sidebar from the grid. `compact` prop = framed
+variant for dialogs only.
+
+**Card identity** (encoded in `AssetTile.css` — change it there or nowhere):
+radius `--mod-radius-lg`, shadow `--mod-shadow-sm`, hover lift
+`--asset-card-hover-lift` (-4px) with `--mod-transition-fast`, name in the
+bottom `--asset-card-overlay-gradient` overlay. TRAP — legacy cards drift
+three ways (`scale(1.02)`/0.3s vs `translateY(-2px)`/0.2s vs the tile); when
+touching one, migrate it to `AssetTile` rather than tuning its copy.
+
+Shared primitives stay **dumb and composable** — no asset-type awareness, no
+data fetching; callers pass nodes/handlers. New shared UI goes in
+`src/shared/components/` (never legacy root `src/components` — prompt 36).
+A primitive's classes are styled in **its own** CSS file — never rely on
+another component's stylesheet happening to be loaded (the gallery renders
+primitives in isolation and exposes such leaks; ListToolbarSearchInput
+shipped one).
+
+## Known drift — grandfathered, not a template
+
+The six list pages (`ModelList`, `SoundList`, `SpriteList`, `PackList`,
+`ScriptList`, `TextureSetList`, plus `ProjectList`) predate the primitives:
+four different header designs, h1-vs-h2 drift, per-feature empty states and
+cards. This is queued debt (prompt 18 replaces them with a generic
+descriptor-driven page; prompt 13 consolidates primitives). **Never copy an
+existing `XList.tsx`/`XList.css` as a starting point.** When editing one,
+swap the section you touch to the shared primitive.
+
+## Storybook — the visual contract
+
+- Every shared primitive ships a `*.stories.tsx` next to it (see
+  `EmptyState.stories.tsx` for the house style: `Meta`/`StoryObj`, `title:
+  'Shared/<Area>/<Name>'`, `tags: ['autodocs']`).
+- **Design System / Gallery** (`src/shared/design-system/`) renders all
+  tokens + primitives on one page, with explicit `Dark` and `Light` stories —
+  one snapshot shows the whole family, so a primitive that stops matching its
+  siblings is visible at a glance. **Extend the gallery when adding a token
+  or primitive.**
+- Light/dark: the preview toolbar `theme` global swaps the Lara theme
+  stylesheet exactly like the app's `useTheme` hook (managed `<link>` +
+  `color-scheme`). Story-level `globals: { theme: 'light' }` pins a story to
+  a mode (that's how the gallery variants work). Don't reintroduce a static
+  theme import in `.storybook/preview.ts`.
+- The `storybook-visual` suite screenshots **every story** (run:
+  `npm run test:all -- --only=storybook-visual --yes --no-open`; baselines
+  are machine-local, refresh with `npm run test-storybook:update`). It is
+  non-gating and has rotted before — CLAUDE.md rule 10: grep it when
+  changing shared UI.
+
+## PrimeReact traps (visual state that silently doesn't render)
+
+PrimeReact fails soft: a prop of the wrong *shape* renders fine with the
+state feature dead — no error, no type failure in some cases. Known cases:
+
+- `Tree selectionMode="single"` takes `selectionKeys` as a **string** (the
+  key) — the `{ key: true }` map is only for multiple/checkbox modes; passing
+  it means selection never highlights (shipped bug, found by the gallery).
+- Disabled state renders as the `p-disabled` **class**, not
+  `aria-disabled`/`disabled` attributes (known from the e2e suite).
+- Overlay components (Dropdown panels, Dialogs) portal to `document.body` —
+  styling them via a parent's CSS scope silently misses (see
+  `frontend-test-authoring` for the testing side).
+
+When a selection/highlight/disabled/expanded state doesn't show: suspect the
+prop shape first, and verify the state visually in the gallery — that's what
+it's for. Found a new one? Add it to this list in the same session.
+
+## Verify
+
+`cd src/frontend && npm test && npm run lint && npm run format:check && npm run build`
+plus the storybook-visual suite when shared styles/primitives moved — and
+the screenshot loop above for anything visual.

--- a/.claude/skills/frontend-patterns/SKILL.md
+++ b/.claude/skills/frontend-patterns/SKILL.md
@@ -50,6 +50,9 @@ half-implement it as a side effect.
   neighbors do.
 
 ## Styling
+- Full rules — token vocabulary, shared-primitive catalog, density/identity
+  rules, Storybook gallery + themes — live in the **`design-system`** skill;
+  read it before writing any CSS or UI component. Highlights:
 - Design tokens: `src/shared/styles/tokens.css` — use `var(--token)`; no new
   hardcoded colors (a sweep + lint gate is prompt 20; don't add to the pile).
 - Component CSS files are **global scope** — prefix class names with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ locally; core behavior must never depend on hosted services.
 
 **Domain-specific conventions live in skills** (auto-loaded when relevant):
 `backend-patterns`, `frontend-patterns`, `frontend-test-authoring`,
-`asset-processor-patterns`, `webdav-patterns`, `e2e-authoring`, `test-triage`. Skills are canonical agent docs — there is no
+`design-system`, `asset-processor-patterns`, `webdav-patterns`,
+`e2e-authoring`, `test-triage`. Skills are canonical agent docs — there is no
 parallel "AI documentation" set. **If a skill claim contradicts the code, trust
 the code and fix the skill in the same session.**
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "format": "cd src/frontend && npm run format && cd ../asset-processor && npm run format",
         "format:check": "cd src/frontend && npm run format:check && cd ../asset-processor && npm run format:check",
         "test:frontend": "cd src/frontend && npm test",
+        "design": "cd src/frontend && npm run design",
         "test:e2e": "cd tests/e2e && npm test",
         "test:e2e:demo": "cd tests/e2e && npm run test:demo",
         "videos:generate": "(cd tests/e2e && npm run test:teardown >/dev/null 2>&1); (cd tests/e2e && npm run test:setup) && (cd docs/videos && ([ -d node_modules ] || npm ci) && npx playwright install chromium && npm run generate); ec=$?; (cd tests/e2e && npm run test:teardown); exit $ec",

--- a/src/frontend/.storybook/preview.ts
+++ b/src/frontend/.storybook/preview.ts
@@ -1,5 +1,5 @@
-// Import PrimeReact theme and styles
-import 'primereact/resources/themes/lara-dark-blue/theme.css'
+// Import PrimeReact core styles (the theme stylesheet itself is managed
+// dynamically — see applyTheme below).
 import 'primereact/resources/primereact.min.css'
 import 'primeicons/primeicons.css'
 // Import application design tokens + global styles
@@ -8,8 +8,47 @@ import '../src/index.css'
 
 import type { Preview } from '@storybook/react-vite'
 import { initialize, mswLoader } from 'msw-storybook-addon'
+// The ?url suffix tells Vite to return the URL to the file instead of its
+// contents — same mechanism the app's useTheme hook uses to swap themes.
+import darkTheme from 'primereact/resources/themes/lara-dark-blue/theme.css?url'
+import lightTheme from 'primereact/resources/themes/lara-light-blue/theme.css?url'
 
 import { handlers } from '../src/mocks/handlers'
+
+const THEME_LINK_ID = 'storybook-primereact-theme'
+
+/**
+ * Swap the PrimeReact Lara theme exactly like the app does (managed <link>
+ * + color-scheme), so every story can be viewed in light and dark via the
+ * toolbar. Story-level `globals: { theme: 'light' }` pins a story to a mode.
+ */
+function applyTheme(theme: 'light' | 'dark') {
+  document.documentElement.style.colorScheme = theme
+
+  let link = document.getElementById(THEME_LINK_ID) as HTMLLinkElement | null
+  if (!link) {
+    link = document.createElement('link')
+    link.id = THEME_LINK_ID
+    link.rel = 'stylesheet'
+    document.head.appendChild(link)
+  }
+
+  const href = theme === 'dark' ? darkTheme : lightTheme
+  if (!link.href.endsWith(href)) {
+    link.href = href
+  }
+
+  // The story canvas tracks the theme's surfaces instead of a hardcoded
+  // backgrounds-addon color.
+  document.body.style.background = 'var(--surface-ground)'
+  document.body.style.color = 'var(--text-color)'
+
+  // index.css locks html/body to overflow:hidden for the app's fixed
+  // tab-shell viewport; stories (e.g. the design-system gallery) are
+  // documents and must scroll.
+  document.documentElement.style.overflow = 'auto'
+  document.body.style.overflow = 'auto'
+}
 
 // Initialize MSW with default handlers.
 // Use a relative worker URL so registration works both in dev (Storybook served
@@ -31,23 +70,33 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    backgrounds: {
-      default: 'dark',
-      values: [
-        {
-          name: 'dark',
-          value: '#242424',
-        },
-        {
-          name: 'light',
-          value: '#ffffff',
-        },
-      ],
-    },
     msw: {
       handlers,
     },
   },
+  globalTypes: {
+    theme: {
+      description: 'PrimeReact Lara theme',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'dark', icon: 'moon', title: 'Dark' },
+          { value: 'light', icon: 'sun', title: 'Light' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: 'dark',
+  },
+  decorators: [
+    (Story, context) => {
+      applyTheme(context.globals.theme === 'light' ? 'light' : 'dark')
+      return Story()
+    },
+  ],
   loaders: [mswLoader],
 }
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -17,6 +17,7 @@
     "test:coverage": "jest --coverage",
     "test:webgl": "npx playwright test --config playwright.webgl.config.ts",
     "storybook": "storybook dev -p 6006",
+    "design": "storybook dev -p 6006 --initial-path=/story/design-system-gallery--dark",
     "build-storybook": "storybook build",
     "test-storybook": "npx playwright test --config playwright.config.ts",
     "test-storybook:update": "npx playwright test --config playwright.config.ts --update-snapshots",

--- a/src/frontend/src/features/scripts/components/ScriptList.css
+++ b/src/frontend/src/features/scripts/components/ScriptList.css
@@ -5,8 +5,8 @@
   position: relative;
   background: var(--surface-ground);
   box-sizing: border-box;
-  padding: 1rem;
-  gap: 0.75rem;
+  padding: 0.75rem;
+  gap: 0.5rem;
 }
 
 .script-list-loading {
@@ -16,16 +16,13 @@
   height: 100%;
 }
 
-/* Body: category tree sidebar + scripts grid, framed as a card so the page
-   has clear margins (mirroring the Models layout). */
+/* Body: category tree sidebar + scripts grid, flat on the page background —
+   the quiet CategoryTreePanel default provides the sidebar look; only a
+   border separates it from the grid. */
 .script-list-body {
   display: flex;
   flex: 1;
   min-height: 0;
-  border: 1px solid var(--surface-border);
-  border-radius: 8px;
-  overflow: hidden;
-  background: var(--surface-card);
 }
 
 /* Left category panel: a quiet sidebar with a "Manage categories" footer. */
@@ -36,42 +33,12 @@
   flex-direction: column;
   min-height: 0;
   border-right: 1px solid var(--surface-border);
-  background: var(--surface-card);
 }
 
 .script-category-sidebar .category-tree-panel {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  gap: 0.25rem;
-  padding: 0.5rem;
-  background: transparent;
-  border: none;
-}
-
-/* The "Uncategorized" row should read as part of the panel, not a button:
-   transparent until hovered/active, with tight padding. */
-.script-category-sidebar .category-tree-unassigned {
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  padding: 0.3rem 0.5rem;
-}
-
-.script-category-sidebar .category-tree-unassigned:hover {
-  background: var(--surface-hover);
-}
-
-.script-category-sidebar .category-tree-unassigned.is-active {
-  background: rgba(var(--primary-color-rgb), 0.12);
-  border-color: rgba(var(--primary-color-rgb), 0.24);
-  color: var(--text-color);
-}
-
-.script-category-sidebar
-  .category-tree-unassigned.is-active
-  .category-tree-count {
-  color: var(--text-color-secondary);
 }
 
 .script-category-manage-btn {
@@ -84,7 +51,7 @@
   border-top: 1px solid var(--surface-border);
   background: transparent;
   color: var(--text-color-secondary);
-  font-size: 0.82rem;
+  font-size: var(--mod-text-xs);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -108,7 +75,7 @@
 .script-grid-container {
   flex: 1;
   overflow: auto;
-  padding: 1rem;
+  padding: 0.75rem;
   position: relative;
 }
 

--- a/src/frontend/src/shared/components/FilterPanel.css
+++ b/src/frontend/src/shared/components/FilterPanel.css
@@ -34,43 +34,8 @@
   gap: 0.75rem;
 }
 
-.list-filters-search {
-  position: relative;
-  display: flex;
-  align-items: center;
-  background: var(--surface-ground);
-  border: 1px solid var(--surface-border);
-  border-radius: 10px;
-  transition: all 0.2s ease;
-  overflow: hidden;
-}
-
-.list-filters-search:focus-within {
-  border-color: var(--primary-color);
-  background: var(--surface-card);
-  box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb, 100, 108, 255), 0.1);
-}
-
-.list-filters-search .pi-search {
-  color: var(--text-color-secondary);
-  font-size: 0.875rem;
-  padding: 0.75rem;
-  pointer-events: none;
-}
-
-.list-filters-search-input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  outline: none;
-  font-size: 0.875rem;
-  color: var(--text-color);
-  padding: 0.75rem 0.75rem 0.75rem 0;
-}
-
-.list-filters-search-input::placeholder {
-  color: var(--text-color-secondary);
-}
+/* .list-filters-search* rules live in list-toolbar/ListToolbar.css — they
+   style ListToolbarSearchInput, which owns those class names. */
 
 .list-filters-row {
   display: flex;

--- a/src/frontend/src/shared/components/categories/CategoryTreeControls.css
+++ b/src/frontend/src/shared/components/categories/CategoryTreeControls.css
@@ -1,15 +1,18 @@
+/* Default look = the quiet sidebar: transparent (sits on whatever surface the
+   page provides), tight rows, primary-tint selection. This is the app-wide
+   categories standard — don't re-add per-page backgrounds or frames. */
 .category-tree-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  background: var(--surface-card);
-  border-bottom: 1px solid var(--surface-border);
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background: transparent;
   flex-shrink: 0;
 }
 
+/* Framed variant for use inside dialogs/popovers where the tree needs its
+   own boundary. */
 .category-tree-panel.is-compact {
-  padding: 0.5rem;
   border: 1px solid var(--surface-border);
   border-radius: 8px;
 }
@@ -22,13 +25,15 @@
   width: 100%;
 }
 
+/* The "Unassigned" row reads as part of the tree, not a button: transparent
+   until hovered, selection = primary tint (matches .p-highlight below). */
 .category-tree-unassigned {
-  border: 1px solid var(--surface-border);
-  border-radius: 8px;
-  padding: 0.625rem 0.875rem;
-  background: var(--surface-ground);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+  background: transparent;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.15s ease;
 }
 
 .category-tree-unassigned:hover {
@@ -36,9 +41,9 @@
 }
 
 .category-tree-unassigned.is-active {
-  background: var(--primary-color);
-  color: var(--primary-color-text);
-  border-color: var(--primary-color);
+  background: rgba(var(--primary-color-rgb), 0.12);
+  border-color: rgba(var(--primary-color-rgb), 0.24);
+  color: var(--text-color);
 }
 
 .category-tree-unassigned.is-drag-over,
@@ -62,7 +67,7 @@
 }
 
 .category-tree-unassigned.is-active .category-tree-count {
-  color: inherit;
+  color: var(--text-color-secondary);
 }
 
 .category-tree {

--- a/src/frontend/src/shared/components/categories/CategoryTreePanel.tsx
+++ b/src/frontend/src/shared/components/categories/CategoryTreePanel.tsx
@@ -53,10 +53,13 @@ export function CategoryTreePanel<TCategory extends HierarchicalCategory>({
     () => buildExpandedKeys(categoryNodes),
     [categoryNodes]
   )
+  // PrimeReact Tree in `selectionMode="single"` expects selectionKeys to be
+  // the selected key as a string — the `{ key: true }` map form is only for
+  // multiple/checkbox modes and silently never highlights in single mode.
   const selectedTreeKeys =
     activeCategoryId !== null && activeCategoryId !== unassignedCategoryId
-      ? { [String(activeCategoryId)]: true }
-      : {}
+      ? String(activeCategoryId)
+      : null
 
   return (
     <div className={`category-tree-panel${compact ? ' is-compact' : ''}`}>

--- a/src/frontend/src/shared/components/categories/__tests__/CategoryTreePanel.test.tsx
+++ b/src/frontend/src/shared/components/categories/__tests__/CategoryTreePanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { HierarchicalCategory } from '@/shared/types/categories'
+
+import { CategoryTreePanel } from '../CategoryTreePanel'
+
+const categories: HierarchicalCategory[] = [
+  { id: 1, name: 'Environment', path: '1' },
+  { id: 2, name: 'Props', path: '2' },
+  { id: 3, name: 'Rocks', parentId: 2, path: '2/3' },
+]
+
+const UNASSIGNED_ID = -1
+
+function renderPanel(
+  activeCategoryId: number | null,
+  onCategoryChange = jest.fn()
+) {
+  render(
+    <CategoryTreePanel
+      categories={categories}
+      activeCategoryId={activeCategoryId}
+      dragOverCategoryId={null}
+      categoryCounts={new Map([[2, 8]])}
+      unassignedCount={4}
+      unassignedCategoryId={UNASSIGNED_ID}
+      unassignedLabel="Uncategorized"
+      onCategoryChange={onCategoryChange}
+      onCategoryDragOver={jest.fn()}
+      onCategoryDragLeave={jest.fn()}
+      onCategoryDrop={jest.fn()}
+    />
+  )
+  return onCategoryChange
+}
+
+describe('CategoryTreePanel selection', () => {
+  // Regression: selectionKeys was passed as a `{ key: true }` map, which
+  // PrimeReact Tree only understands in multiple/checkbox modes — in
+  // selectionMode="single" it expects the key string, so the active
+  // category silently never got its p-highlight tint (shipped bug).
+  it('highlights the active category node', () => {
+    renderPanel(2)
+
+    const highlighted = document.querySelector(
+      '.category-tree .p-highlight .p-treenode-content, .category-tree .p-treenode-content.p-highlight'
+    )
+    expect(highlighted).not.toBeNull()
+    expect(highlighted!.textContent).toContain('Props')
+  })
+
+  it('does not highlight any tree node when the unassigned bucket is active', () => {
+    renderPanel(UNASSIGNED_ID)
+
+    expect(document.querySelector('.category-tree .p-highlight')).toBeNull()
+    expect(
+      document.querySelector('.category-tree-unassigned')!.className
+    ).toContain('is-active')
+  })
+
+  // Contract with getSelectedTreeId: node keys are String(id) and clicking a
+  // node must surface the numeric id — catches key-format drift between
+  // buildCategoryTree and the selection plumbing.
+  it('reports the clicked category id', async () => {
+    const user = userEvent.setup()
+    const onCategoryChange = renderPanel(null)
+
+    await user.click(screen.getByText('Environment'))
+
+    expect(onCategoryChange).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/frontend/src/shared/components/layout/ListHeader.css
+++ b/src/frontend/src/shared/components/layout/ListHeader.css
@@ -1,15 +1,18 @@
+/* Compact by design — this is an application header row, not a website hero
+   band. Density budget: vertical padding ≤ --mod-space-sm (page variant:
+   --mod-space-md); don't re-pad. */
 .mod-list-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--mod-space-md);
-  padding: var(--mod-space-lg) var(--mod-space-xl);
+  padding: var(--mod-space-sm) var(--mod-space-md);
   background: var(--mod-color-surface);
   border-bottom: 1px solid var(--mod-color-border);
 }
 
 .mod-list-header--page {
-  padding: var(--mod-space-xl) var(--mod-space-2xl);
+  padding: var(--mod-space-md);
 }
 
 .mod-list-header__main {

--- a/src/frontend/src/shared/components/list-toolbar/ListToolbar.css
+++ b/src/frontend/src/shared/components/list-toolbar/ListToolbar.css
@@ -197,3 +197,46 @@
     display: none;
   }
 }
+
+/* ── ListToolbarSearchInput chrome ──────────────────────────────────────
+   Moved here from FilterPanel.css: these classes are emitted by
+   ListToolbarSearchInput, so its own stylesheet must style them — the
+   design-system gallery renders primitives in isolation and exposes any
+   styles leaking in from other components' CSS files. */
+.list-filters-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: var(--surface-ground);
+  border: 1px solid var(--surface-border);
+  border-radius: 10px;
+  transition: all 0.2s ease;
+  overflow: hidden;
+}
+
+.list-filters-search:focus-within {
+  border-color: var(--primary-color);
+  background: var(--surface-card);
+  box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb, 100, 108, 255), 0.1);
+}
+
+.list-filters-search .pi-search {
+  color: var(--text-color-secondary);
+  font-size: var(--mod-text-sm);
+  padding: 0.75rem;
+  pointer-events: none;
+}
+
+.list-filters-search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: var(--mod-text-sm);
+  color: var(--text-color);
+  padding: 0.75rem 0.75rem 0.75rem 0;
+}
+
+.list-filters-search-input::placeholder {
+  color: var(--text-color-secondary);
+}

--- a/src/frontend/src/shared/design-system/DesignSystemGallery.css
+++ b/src/frontend/src/shared/design-system/DesignSystemGallery.css
@@ -1,0 +1,146 @@
+/* Gallery chrome only — everything it showcases must come from tokens or
+   the primitives themselves. The gallery practices the density it preaches. */
+.dsg {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-md);
+  padding: var(--mod-space-md);
+  background: var(--mod-color-bg);
+  color: var(--mod-color-text);
+  font-size: var(--mod-text-sm);
+}
+
+.dsg-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-xs);
+}
+
+.dsg-section-title {
+  margin: 0;
+  font-size: var(--mod-text-lg);
+  font-weight: var(--mod-font-weight-semibold);
+  border-bottom: 1px solid var(--mod-color-border);
+  padding-bottom: var(--mod-space-2xs);
+}
+
+.dsg-label {
+  font-size: var(--mod-text-xs);
+  color: var(--mod-color-text-muted);
+}
+
+.dsg code {
+  font-size: var(--mod-text-xs);
+  color: var(--mod-color-text-muted);
+}
+
+/* ── Colors ── */
+.dsg-color-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-xs);
+}
+
+.dsg-color-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-2xs);
+}
+
+.dsg-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mod-space-xs);
+}
+
+.dsg-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mod-space-2xs);
+}
+
+.dsg-swatch-chip {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--mod-radius-sm);
+  border: 1px solid var(--mod-color-border-strong);
+  flex-shrink: 0;
+}
+
+/* ── Typography ── */
+.dsg-type-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-2xs);
+}
+
+.dsg-type-row {
+  display: grid;
+  grid-template-columns: 10rem 1fr auto;
+  align-items: baseline;
+  gap: var(--mod-space-md);
+}
+
+/* ── Spacing ── */
+.dsg-space-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mod-space-2xs);
+}
+
+.dsg-space-row {
+  display: grid;
+  grid-template-columns: 10rem auto;
+  align-items: center;
+  gap: var(--mod-space-md);
+}
+
+.dsg-space-bar {
+  height: 0.75rem;
+  background: var(--mod-color-primary);
+  border-radius: var(--mod-radius-sm);
+}
+
+/* ── Radius & shadows ── */
+.dsg-tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mod-space-sm);
+}
+
+.dsg-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 6.5rem;
+  height: 3rem;
+  background: var(--mod-color-surface);
+  border: 1px solid var(--mod-color-border);
+}
+
+/* ── Category demo ── */
+.dsg-category-demo {
+  display: flex;
+  min-height: 10rem;
+}
+
+.dsg-category-demo .category-tree-panel {
+  width: 220px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--mod-color-border);
+}
+
+.dsg-category-demo-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+
+/* ── Feedback ── */
+.dsg-feedback-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: var(--mod-space-sm);
+  align-items: start;
+}

--- a/src/frontend/src/shared/design-system/DesignSystemGallery.stories.tsx
+++ b/src/frontend/src/shared/design-system/DesignSystemGallery.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { DesignSystemGallery } from './DesignSystemGallery'
+
+/**
+ * The whole design system on one page — see the `design-system` skill.
+ * Explicit Dark and Light stories pin the theme global so the
+ * storybook-visual suite snapshots both modes.
+ */
+const meta: Meta<typeof DesignSystemGallery> = {
+  title: 'Design System/Gallery',
+  component: DesignSystemGallery,
+  parameters: { layout: 'fullscreen' },
+}
+
+export default meta
+type Story = StoryObj<typeof DesignSystemGallery>
+
+export const Dark: Story = {
+  globals: { theme: 'dark' },
+}
+
+export const Light: Story = {
+  globals: { theme: 'light' },
+}

--- a/src/frontend/src/shared/design-system/DesignSystemGallery.tsx
+++ b/src/frontend/src/shared/design-system/DesignSystemGallery.tsx
@@ -1,0 +1,299 @@
+import './DesignSystemGallery.css'
+
+import { Button } from 'primereact/button'
+import { useState } from 'react'
+
+import {
+  AddTile,
+  AssetGrid,
+  AssetTile,
+  AssetTilePlaceholder,
+} from '@/shared/components/asset-tile'
+import { CategoryTreePanel } from '@/shared/components/categories/CategoryTreePanel'
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+} from '@/shared/components/feedback'
+import { ListHeader } from '@/shared/components/layout'
+import {
+  ListToolbar,
+  ListToolbarActions,
+  ListToolbarButton,
+  ListToolbarCount,
+  ListToolbarPanel,
+  ListToolbarRow,
+  ListToolbarSearchInput,
+} from '@/shared/components/list-toolbar'
+import { TagInput } from '@/shared/components/tags/TagInput'
+import type { HierarchicalCategory } from '@/shared/types/categories'
+
+/**
+ * One page showing the whole design system — token vocabulary plus every
+ * shared primitive in its standard state. A primitive that stops matching
+ * its siblings is visible at a glance, and the storybook-visual suite
+ * snapshots the family in one image (light + dark stories).
+ *
+ * Extend this gallery whenever a token or shared primitive is added — see
+ * the `design-system` skill.
+ */
+
+const COLOR_TOKENS: { group: string; tokens: string[] }[] = [
+  {
+    group: 'Surfaces & borders',
+    tokens: [
+      '--mod-color-bg',
+      '--mod-color-surface',
+      '--mod-color-surface-raised',
+      '--mod-color-surface-hover',
+      '--mod-color-border',
+      '--mod-color-border-strong',
+    ],
+  },
+  {
+    group: 'Text',
+    tokens: ['--mod-color-text', '--mod-color-text-muted'],
+  },
+  {
+    group: 'Brand & semantic',
+    tokens: [
+      '--mod-color-primary',
+      '--mod-color-primary-hover',
+      '--mod-color-danger',
+      '--mod-color-danger-bg',
+      '--mod-color-warning',
+      '--mod-color-warning-bg',
+      '--mod-color-success',
+      '--mod-color-success-bg',
+      '--mod-color-info',
+      '--mod-color-info-bg',
+    ],
+  },
+]
+
+const TEXT_TOKENS: { token: string; usage: string }[] = [
+  { token: '--mod-text-xs', usage: 'counts, captions, badges' },
+  { token: '--mod-text-sm', usage: 'default body/UI text' },
+  { token: '--mod-text-md', usage: 'inputs, emphasized body' },
+  { token: '--mod-text-lg', usage: 'section/panel titles' },
+  { token: '--mod-text-xl', usage: 'tab page titles' },
+  { token: '--mod-text-2xl', usage: 'page title ceiling' },
+]
+
+const SPACE_TOKENS = ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl']
+const RADIUS_TOKENS = ['sm', 'md', 'lg', 'xl', 'pill']
+const SHADOW_TOKENS = ['sm', 'md', 'lg']
+
+const SAMPLE_CATEGORIES: HierarchicalCategory[] = [
+  { id: 1, name: 'Environment', path: '1' },
+  { id: 2, name: 'Props', path: '2' },
+  { id: 3, name: 'Rocks', parentId: 2, path: '2/3' },
+  { id: 4, name: 'Characters', path: '4' },
+]
+
+const SAMPLE_CATEGORY_COUNTS = new Map<number, number>([
+  [1, 12],
+  [2, 8],
+  [3, 5],
+  [4, 3],
+])
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="dsg-section">
+      <h2 className="dsg-section-title">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function noop() {}
+
+export function DesignSystemGallery() {
+  const [search, setSearch] = useState('')
+  const [tags, setTags] = useState(['stylized', 'rock'])
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(2)
+
+  return (
+    <div className="dsg">
+      <Section title="Color tokens">
+        <div className="dsg-color-groups">
+          {COLOR_TOKENS.map(({ group, tokens }) => (
+            <div key={group} className="dsg-color-group">
+              <span className="dsg-label">{group}</span>
+              <div className="dsg-swatches">
+                {tokens.map(token => (
+                  <div key={token} className="dsg-swatch">
+                    <span
+                      className="dsg-swatch-chip"
+                      style={{ background: `var(${token})` }}
+                    />
+                    <code>{token}</code>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Typography">
+        <div className="dsg-type-rows">
+          {TEXT_TOKENS.map(({ token, usage }) => (
+            <div key={token} className="dsg-type-row">
+              <code className="dsg-type-token">{token}</code>
+              <span style={{ fontSize: `var(${token})` }}>
+                Clean, useful app — no fireworks
+              </span>
+              <span className="dsg-label">{usage}</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Spacing">
+        <div className="dsg-space-rows">
+          {SPACE_TOKENS.map(step => (
+            <div key={step} className="dsg-space-row">
+              <code>--mod-space-{step}</code>
+              <span
+                className="dsg-space-bar"
+                style={{ width: `var(--mod-space-${step})` }}
+              />
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Radius & shadows">
+        <div className="dsg-tiles">
+          {RADIUS_TOKENS.map(step => (
+            <div
+              key={step}
+              className="dsg-tile"
+              style={{ borderRadius: `var(--mod-radius-${step})` }}
+            >
+              <code>radius-{step}</code>
+            </div>
+          ))}
+          {SHADOW_TOKENS.map(step => (
+            <div
+              key={step}
+              className="dsg-tile"
+              style={{ boxShadow: `var(--mod-shadow-${step})` }}
+            >
+              <code>shadow-{step}</code>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="ListHeader — compact application header">
+        <ListHeader
+          variant="tab"
+          title="Models"
+          stats={[{ icon: 'pi-box', label: '128 models' }]}
+          actions={<Button label="Upload" icon="pi pi-upload" size="small" />}
+        />
+      </Section>
+
+      <Section title="ListToolbar">
+        <ListToolbar>
+          <ListToolbarRow>
+            <ListToolbarActions>
+              <ListToolbarButton icon="pi pi-search" label="Search" active />
+              <ListToolbarButton
+                icon="pi pi-filter"
+                label="Filters"
+                badge={2}
+              />
+              <ListToolbarButton icon="pi pi-refresh" ariaLabel="Refresh" />
+            </ListToolbarActions>
+            <ListToolbarCount count={128} unitLabel="model" />
+          </ListToolbarRow>
+          <ListToolbarPanel open>
+            <ListToolbarSearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder="Search models..."
+            />
+          </ListToolbarPanel>
+        </ListToolbar>
+      </Section>
+
+      <Section title="Asset tiles — the card identity">
+        <AssetGrid cardWidth={140}>
+          <AssetTile
+            name="rock_large.glb"
+            meta="3 variants"
+            media={<AssetTilePlaceholder icon="pi pi-box" />}
+          />
+          <AssetTile
+            name="selected.glb"
+            selected
+            media={<AssetTilePlaceholder icon="pi pi-box" />}
+          />
+          <AssetTile
+            name="footsteps.wav"
+            meta="0:04"
+            media={<AssetTilePlaceholder icon="pi pi-volume-up" />}
+          />
+          <AddTile label="Add" onClick={noop} />
+        </AssetGrid>
+      </Section>
+
+      <Section title="Category sidebar — the categories standard">
+        <div className="dsg-category-demo">
+          <CategoryTreePanel
+            categories={SAMPLE_CATEGORIES}
+            activeCategoryId={activeCategoryId}
+            dragOverCategoryId={null}
+            categoryCounts={SAMPLE_CATEGORY_COUNTS}
+            unassignedCount={4}
+            unassignedCategoryId={-1}
+            unassignedLabel="Uncategorized"
+            onCategoryChange={id => setActiveCategoryId(id)}
+            onCategoryDragOver={noop}
+            onCategoryDragLeave={noop}
+            onCategoryDrop={noop}
+          />
+          <div className="dsg-category-demo-content dsg-label">
+            content area — sidebar sits flat on the page surface, no frame
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Tags">
+        <TagInput
+          value={tags}
+          onChange={setTags}
+          suggestions={['stylized', 'rock', 'nature', 'scanned']}
+        />
+      </Section>
+
+      <Section title="Feedback states">
+        <div className="dsg-feedback-row">
+          <LoadingState message="Loading models…" />
+          <EmptyState
+            icon="pi-box"
+            title="No models yet"
+            message="Drag and drop files to get started."
+            variant="compact"
+          />
+          <ErrorState
+            title="Failed to load"
+            message="The server did not respond."
+            onRetry={noop}
+            variant="inline"
+          />
+        </div>
+      </Section>
+    </div>
+  )
+}

--- a/src/frontend/src/shared/styles/tokens.css
+++ b/src/frontend/src/shared/styles/tokens.css
@@ -40,14 +40,19 @@
   --mod-color-info-bg: rgba(59, 130, 246, 0.12);
 
   /* ── Spacing scale ────────────────────────────────────────────── */
-  --mod-space-2xs: 0.25rem; /*  4px */
-  --mod-space-xs: 0.5rem; /*  8px */
-  --mod-space-sm: 0.75rem; /* 12px */
-  --mod-space-md: 1rem; /* 16px */
-  --mod-space-lg: 1.5rem; /* 24px */
-  --mod-space-xl: 2rem; /* 32px */
-  --mod-space-2xl: 3rem; /* 48px */
-  --mod-space-3xl: 4rem; /* 64px */
+  /* Modelibr is a dense desktop application, not a website. The workhorses
+     are 2xs–md (the app's real distribution: gap 0.5rem ≫ 0.75 ≫ 1rem;
+     padding 1rem ≥ 0.5 ≥ 0.75rem). lg and up are reserved for empty states,
+     dialogs, and centered placeholders — never for headers, toolbars, or
+     anything that repeats down the page. */
+  --mod-space-2xs: 0.25rem; /*  4px — inline icon/label gaps */
+  --mod-space-xs: 0.5rem; /*  8px — default gap between controls */
+  --mod-space-sm: 0.75rem; /* 12px — panel/toolbar padding */
+  --mod-space-md: 1rem; /* 16px — page/section padding ceiling */
+  --mod-space-lg: 1.5rem; /* 24px — dialog padding */
+  --mod-space-xl: 2rem; /* 32px — empty states only */
+  --mod-space-2xl: 3rem; /* 48px — empty states only */
+  --mod-space-3xl: 4rem; /* 64px — empty states only */
 
   /* ── Radius ───────────────────────────────────────────────────── */
   --mod-radius-sm: 4px;
@@ -57,13 +62,17 @@
   --mod-radius-pill: 9999px;
 
   /* ── Typography ───────────────────────────────────────────────── */
-  --mod-text-xs: 0.75rem;
-  --mod-text-sm: 0.875rem;
-  --mod-text-md: 1rem;
-  --mod-text-lg: 1.125rem;
-  --mod-text-xl: 1.25rem;
-  --mod-text-2xl: 1.5rem;
-  --mod-text-3xl: 2rem;
+  /* sm (0.875rem) is the app's default UI text size by a wide margin; xs is
+     for counts/captions/badges. 2xl (1.5rem) is the largest text in the app
+     — the Models page title — and the hard ceiling: there is deliberately
+     no 3xl. If a heading feels like it needs more, the layout is drifting
+     toward "website"; don't. */
+  --mod-text-xs: 0.75rem; /* counts, captions, badges */
+  --mod-text-sm: 0.875rem; /* DEFAULT body/UI text */
+  --mod-text-md: 1rem; /* inputs, emphasized body */
+  --mod-text-lg: 1.125rem; /* section/panel titles */
+  --mod-text-xl: 1.25rem; /* tab page titles */
+  --mod-text-2xl: 1.5rem; /* page title ceiling (Models h1) */
 
   --mod-font-weight-regular: 400;
   --mod-font-weight-medium: 500;


### PR DESCRIPTION
## Summary

Establishes the design system as a guarded, visible artifact:

- **`design-system` agent skill** (registered in CLAUDE.md): compact application density rules (no website styling), token vocabulary with real-app roles, shared-primitive catalog, the categories standard, PrimeReact soft-fail traps, and a mandatory screenshot-verification loop for styling changes.
- **Storybook light/dark theme switcher**: toolbar global swaps the Lara stylesheet exactly like the app's `useTheme` hook; story canvas tracks theme surfaces; stories scroll (app's `overflow: hidden` shell no longer leaks in).
- **Design System / Gallery**: every token and shared primitive on one page with pinned Dark/Light stories, so the storybook-visual suite snapshots the whole family in both modes. `npm run design` opens straight to it.
- **Tokens audited against real app values**: per-step usage docs; unused `--mod-text-3xl` removed (1.5rem is the deliberate ceiling).
- **Compact fixes**: ListHeader loses its 32/48px hero padding (now 12/16px); scripts page loses the card frame + nested padding; category tree's quiet sidebar look becomes the shared default.
- **Two real bugs the gallery caught, fixed**:
  1. `ListToolbarSearchInput` styles lived in `FilterPanel.css` — moved into the primitive's own stylesheet.
  2. Category selection never highlighted: PrimeReact Tree in single mode needs `selectionKeys` as a string, not a `{ key: true }` map. Regression test added (renders the real Tree, asserts the highlight).

## Notes

- **Stacked on #560** (touches the same `.storybook/preview.ts`); retarget/rebase to `version/0.4` once #560 merges.
- Machine-local storybook-visual baselines will diff once (theme-driven canvas replaces the hardcoded `#242424` background) — refresh with `npm run test-storybook:update`.

## Verification

- `npm test` (428 passed), `npm run lint`, `npm run format:check`, `npm run build`, `npm run build:demo`, `npm run build-storybook` — all green
- Gallery screenshotted in both themes via Playwright; scroll behavior verified programmatically