### PR TITLE
feat(backup): automatic pre-migration backup + gated restore drill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,17 @@ POSTGRES_USER=modelibr
 POSTGRES_PASSWORD=ChangeThisStrongPassword123!
 POSTGRES_PORT=5432
 
+# Pre-migration backup safety net — at startup, if pending EF Core migrations are
+# detected, the app takes an automatic DB-scope backup (prefix "pre-migration-")
+# before applying them, and aborts startup if that backup fails. See
+# docs/docs/features/backups.md.
+# Set to true to bypass the backup and apply migrations unconditionally (NOT
+# recommended outside throwaway/CI databases — there is no rollback point).
+MODELIBR_SKIP_PREMIGRATION_BACKUP=false
+# How many pre-migration-*.tar snapshots to keep before older ones are pruned.
+# User-initiated backups (the "modelibr-*" prefix) are never touched by this.
+MODELIBR_PREMIGRATION_BACKUP_RETENTION=3
+
 # Asset Processor Service
 WORKER_PORT=3001
 WORKER_ID=worker-1

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -106,3 +106,54 @@ jobs:
             - name: Fail if tests failed
               if: steps.slow-tests.outcome == 'failure'
               run: exit 1
+
+    backup-restore-drill:
+        name: Backup & Restore Drill (Nightly)
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
+              with:
+                  ref: ${{ github.event.inputs.branch || github.ref }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "20"
+                  cache: "npm"
+                  cache-dependency-path: tests/backup-restore-e2e/package-lock.json
+
+            - name: Install dependencies
+              working-directory: tests/backup-restore-e2e
+              run: npm ci
+
+            # Needs no GPU (unlike the main e2e/storybook-visual suites, which is
+            # why they stay local-only) — this is a plain Docker + Playwright drill,
+            # so a GitHub-hosted runner can run it. Self-contained: same command as
+            # `npm run test:all -- --only=backup-restore` locally (builds its own
+            # stack, runs every spec — create/list/download, restore round-trip,
+            # concurrent conflict, bad-archive rejection, pre-migration snapshot on
+            # first boot — then tears the stack down). This is the ONLY place the
+            # full create→backup→wipe→restore→verify trust loop actually gates
+            # anything; it was non-gating before and had silently rotted (see
+            # CLAUDE.md rule 10).
+            - name: Run backup/restore trust drill
+              id: backup-restore
+              continue-on-error: true
+              working-directory: tests/backup-restore-e2e
+              run: npm run test:teardown >/dev/null 2>&1; npm run test:full
+
+            - name: Upload Playwright report
+              uses: actions/upload-artifact@v5
+              if: always()
+              with:
+                  name: backup-restore-playwright-report-${{ github.run_number }}
+                  path: tests/backup-restore-e2e/playwright-report/
+                  retention-days: 14
+                  if-no-files-found: ignore
+
+            - name: Fail if backup/restore drill failed
+              if: steps.backup-restore.outcome == 'failure'
+              run: exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - ConnectionStrings__Default=Host=postgres;Port=5432;Database=Modelibr;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
+            - MODELIBR_SKIP_PREMIGRATION_BACKUP=${MODELIBR_SKIP_PREMIGRATION_BACKUP:-false}
+            - MODELIBR_PREMIGRATION_BACKUP_RETENTION=${MODELIBR_PREMIGRATION_BACKUP_RETENTION:-3}
             - DisableHttpsRedirection=true
             - HTTPS_PORT=${HTTPS_PORT:-8443}
             - EXPOSE_443_PORT=${EXPOSE_443_PORT:-true}

--- a/docs/docs/features/backups.md
+++ b/docs/docs/features/backups.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 12
+---
+
+# Backups & Restore
+
+Modelibr can back up your whole library — the database plus every uploaded
+file — into a single archive, and restore from one on the next restart. For a
+local-first app, "your assets survive" is the core promise, so backups get
+extra protection: an automatic safety-net backup runs before any database
+migration is applied.
+
+## Creating a backup
+
+Open the **Settings** page and go to **Backup & Restore**.
+
+1. Click **Create backup**.
+2. Choose whether to include thumbnails. Thumbnails regenerate automatically,
+   so leaving this off keeps the archive smaller — the database and uploaded
+   files are always included.
+3. The new backup appears in the list as `in_progress`, then flips to
+   `ready` once it finishes.
+
+Each backup is a single `.tar` archive containing a Postgres dump
+(`database.dump`), your uploaded files (`uploads/`), optionally thumbnails
+(`thumbnails/`), and a `manifest.json` describing the archive's contents and a
+SHA-256 checksum of the database dump.
+
+## Restoring a backup
+
+Restores apply on the **next restart**, not immediately — this keeps the
+restore path simple and crash-safe (the exact same code runs whether you
+triggered it or the app is recovering from an unclean shutdown).
+
+1. In the backup list, click **Restore** next to the archive you want.
+2. Restart Modelibr (or the `webapi` container).
+3. On boot, Modelibr verifies the archive's checksum, replaces the database
+   and uploaded files, and moves the archive into a `processed/` folder. If
+   the archive is invalid or corrupted, it's moved to a `failed/` folder
+   instead (with an error file explaining why) and your current data is left
+   untouched.
+
+## Automatic pre-migration backups
+
+Modelibr occasionally ships database schema changes. Combined with
+auto-updating desktop installs, a bad migration could otherwise reach every
+user with no way back. To prevent that, Modelibr checks for pending database
+migrations on every startup and, if there are any, takes an automatic backup
+**before** applying them.
+
+- **Scope**: database only (thumbnails and even uploaded files aren't
+  needed to protect the schema change itself, so this backup is fast).
+- **Naming**: these backups are named `pre-migration-<timestamp>.tar` so
+  they're easy to tell apart from backups you created yourself
+  (`modelibr-<timestamp>.tar`). They show up in the same backup list.
+- **Retention**: only the most recent snapshots are kept (3 by default) —
+  older `pre-migration-*` archives are pruned automatically. Backups you
+  created yourself are never touched by this cleanup.
+- **If the backup fails**: Modelibr aborts startup rather than applying an
+  unprotected migration. The application log explains why. This is
+  intentional — a failed pre-migration backup usually means something (disk
+  space, permissions) needs attention before it's safe to proceed.
+
+### Configuration
+
+Set these in your `.env` file:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MODELIBR_SKIP_PREMIGRATION_BACKUP` | `false` | Set to `true` to skip the automatic backup and apply migrations unconditionally. Not recommended outside throwaway/CI databases — there's no rollback point if the migration goes wrong. |
+| `MODELIBR_PREMIGRATION_BACKUP_RETENTION` | `3` | How many `pre-migration-*` snapshots to keep before older ones are pruned. |
+
+## Notes
+
+- Docker deployments store backups under `./data/backups` on the host.
+- Native (desktop) installs don't yet support backups — the automatic
+  pre-migration safety net is disabled there for now and will be enabled once
+  desktop backup support ships.
+- Only one backup can run at a time; starting a second while one is in
+  progress is rejected.
+
+:::note Video placeholder
+The walkthrough video for this page will be added later.
+:::

--- a/scripts/test-runner/suites.config.mjs
+++ b/scripts/test-runner/suites.config.mjs
@@ -134,6 +134,7 @@ export const suites = [
         requiresDocker: true,
         detectPath: "tests/backup-restore-e2e/package.json",
         reportPath: "tests/backup-restore-e2e/playwright-report",
+        note: "Gating nightly on GitHub (.github/workflows/nightly-e2e.yml, job backup-restore-drill) — needs no GPU, unlike storybook-visual/e2e-full which stay local-only.",
     },
     {
         id: "storybook-visual",

--- a/src/Application/Abstractions/Services/IBackupService.cs
+++ b/src/Application/Abstractions/Services/IBackupService.cs
@@ -1,5 +1,23 @@
 namespace Application.Abstractions.Services;
 
+/// <summary>
+/// Filename prefixes that distinguish who created a backup archive. Single source
+/// of truth so retention/cleanup logic can never accidentally touch the wrong kind.
+/// </summary>
+public static class BackupNaming
+{
+    /// <summary>Prefix for user-initiated backups created via <see cref="IBackupService.StartBackupAsync"/>.</summary>
+    public const string ManualBackupPrefix = "modelibr-";
+
+    /// <summary>
+    /// Prefix for automatic snapshots taken before applying pending EF Core migrations
+    /// at startup (see <c>Infrastructure.Extensions.DatabaseExtensions</c>). Retention
+    /// cleanup for these must never touch files outside this prefix — that's the whole
+    /// point of a distinct prefix.
+    /// </summary>
+    public const string PreMigrationSnapshotPrefix = "pre-migration-";
+}
+
 public record BackupScope(bool IncludeThumbnails);
 
 public record BackupSummary(
@@ -49,6 +67,26 @@ public interface IBackupService
     /// restore directory. Throws if the file is missing.
     /// </summary>
     void StageRestore(string fileName);
+
+    /// <summary>
+    /// Runs a backup to completion and awaits it — unlike <see cref="StartBackupAsync"/>,
+    /// which kicks off a background job and returns immediately. Used for automated
+    /// snapshots (e.g. the pre-migration safety backup) whose caller needs to know the
+    /// backup actually succeeded before proceeding. Uses <paramref name="fileNamePrefix"/>
+    /// instead of <see cref="BackupNaming.ManualBackupPrefix"/> so the archive is
+    /// distinguishable from user-initiated backups. Shares the same run lock as
+    /// <see cref="StartBackupAsync"/> — throws <see cref="InvalidOperationException"/> if
+    /// a backup is already in progress.
+    /// </summary>
+    Task<BackupSummary> CreateSnapshotAsync(BackupScope scope, string fileNamePrefix, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the oldest archives whose filename starts with <paramref name="fileNamePrefix"/>
+    /// beyond the newest <paramref name="keepCount"/>. Never touches a file outside that
+    /// prefix — safe to call for automatic-snapshot retention without any risk to
+    /// user-initiated backups.
+    /// </summary>
+    void CleanupSnapshots(string fileNamePrefix, int keepCount);
 }
 
 /// <summary>

--- a/src/Infrastructure/Extensions/DatabaseExtensions.cs
+++ b/src/Infrastructure/Extensions/DatabaseExtensions.cs
@@ -1,29 +1,87 @@
+using Application.Abstractions.Services;
 using Infrastructure.Persistence;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Extensions;
 
+/// <summary>
+/// Thrown when the automatic pre-migration backup fails. Left uncaught by
+/// <see cref="DatabaseExtensions.InitializeDatabaseAsync(WebApplication)"/> on purpose —
+/// it propagates out of <c>Program.Main</c> and aborts startup, because applying a
+/// pending migration with no safety net is worse than not starting at all.
+/// </summary>
+public sealed class PreMigrationBackupFailedException : Exception
+{
+    public PreMigrationBackupFailedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
 public static class DatabaseExtensions
 {
-    public static async Task InitializeDatabaseAsync(this WebApplication app)
+    /// <summary>Env var that opts out of the automatic pre-migration backup (not recommended).</summary>
+    public const string SkipEnvVar = "MODELIBR_SKIP_PREMIGRATION_BACKUP";
+
+    /// <summary>Env var overriding how many pre-migration snapshots are retained.</summary>
+    public const string RetentionEnvVar = "MODELIBR_PREMIGRATION_BACKUP_RETENTION";
+
+    public const int DefaultPreMigrationBackupRetention = 3;
+
+    public static Task InitializeDatabaseAsync(this WebApplication app) =>
+        InitializeDatabaseAsync(app.Services);
+
+    /// <summary>
+    /// Core implementation, decoupled from <see cref="WebApplication"/> so it can be
+    /// exercised against a bare <see cref="IServiceProvider"/> in tests without spinning
+    /// up Kestrel/hosting — see Infrastructure.Tests/Extensions/DatabaseExtensionsTests.cs.
+    /// </summary>
+    internal static async Task InitializeDatabaseAsync(IServiceProvider rootServices)
     {
-        using var scope = app.Services.CreateScope();
+        using var scope = rootServices.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationDbContext>>();
+        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 
+        List<string> pendingMigrations;
         try
         {
             logger.LogInformation("Attempting database initialization...");
 
-            // MigrateAsync creates the database if it doesn't exist yet and then
-            // applies pending migrations. Do NOT gate this on CanConnectAsync:
-            // that returns false when the database itself is missing (e.g. the
-            // native installer's embedded server, where nothing pre-creates the
-            // "Modelibr" database the way the Docker image's POSTGRES_DB does),
-            // which would skip the very migration meant to create it.
+            // Checked separately from MigrateAsync (below) so a pending migration can
+            // trigger a pre-migration backup first. Do NOT gate this on CanConnectAsync:
+            // that returns false when the database itself is missing (e.g. the native
+            // installer's embedded server, where nothing pre-creates the "Modelibr"
+            // database the way the Docker image's POSTGRES_DB does), which would skip
+            // the very migration meant to create it.
+            pendingMigrations = (await context.Database.GetPendingMigrationsAsync()).ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Database initialization failed. Application will start without database connectivity.");
+            return;
+        }
+
+        if (pendingMigrations.Count > 0)
+        {
+            logger.LogInformation(
+                "{Count} pending migration(s) detected: {Migrations}",
+                pendingMigrations.Count,
+                string.Join(", ", pendingMigrations));
+
+            // Intentionally NOT inside the try/catch below — a failure here must
+            // propagate out of InitializeDatabaseAsync and abort startup (unless the
+            // operator explicitly opted out), never be swallowed like a connectivity
+            // failure.
+            await TakePreMigrationBackupAsync(scope.ServiceProvider, logger, configuration);
+        }
+
+        try
+        {
             await context.Database.MigrateAsync();
 
             logger.LogInformation("Database initialization completed successfully");
@@ -32,6 +90,63 @@ public static class DatabaseExtensions
         {
             logger.LogWarning(ex, "Database initialization failed. Application will start without database connectivity.");
             // Don't throw - allow application to start even if database is not available
+        }
+    }
+
+    private static async Task TakePreMigrationBackupAsync(
+        IServiceProvider services,
+        ILogger logger,
+        IConfiguration configuration)
+    {
+        if (configuration.GetValue<bool>(SkipEnvVar))
+        {
+            logger.LogWarning(
+                "{EnvVar}=true — skipping the automatic pre-migration backup. If the " +
+                "upcoming migration fails or is destructive there is no automatic rollback " +
+                "point. This is not recommended outside throwaway environments.",
+                SkipEnvVar);
+            return;
+        }
+
+        var backupService = services.GetRequiredService<IBackupService>();
+
+        try
+        {
+            // Logged upfront so a large library doesn't look like a hang — this backup
+            // runs before the app serves any traffic.
+            var estimate = await backupService.EstimateSizeAsync(CancellationToken.None);
+            logger.LogInformation(
+                "Taking automatic pre-migration backup before applying migrations " +
+                "(estimated database ~{DbMb:N1} MB, uploads ~{UploadsMb:N1} MB; thumbnails " +
+                "excluded — they regenerate). The app has not started serving traffic yet; " +
+                "this may take a while for a large library.",
+                estimate.DatabaseBytes / 1024d / 1024d,
+                estimate.UploadsBytes / 1024d / 1024d);
+
+            var summary = await backupService.CreateSnapshotAsync(
+                new BackupScope(IncludeThumbnails: false),
+                BackupNaming.PreMigrationSnapshotPrefix,
+                CancellationToken.None);
+
+            logger.LogInformation(
+                "Pre-migration backup completed: {FileName} ({SizeBytes:N0} bytes).",
+                summary.FileName,
+                summary.SizeBytes);
+
+            var retention = configuration.GetValue<int?>(RetentionEnvVar) ?? DefaultPreMigrationBackupRetention;
+            backupService.CleanupSnapshots(BackupNaming.PreMigrationSnapshotPrefix, retention);
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(
+                ex,
+                "Pre-migration backup failed — aborting startup before applying pending " +
+                "migrations so a schema change is never made without a safety net. Set " +
+                "{EnvVar}=true to bypass this check (not recommended).",
+                SkipEnvVar);
+            throw new PreMigrationBackupFailedException(
+                "Automatic pre-migration backup failed; aborting startup before applying pending migrations.",
+                ex);
         }
     }
 }

--- a/src/Infrastructure/Services/BackupService.cs
+++ b/src/Infrastructure/Services/BackupService.cs
@@ -52,7 +52,7 @@ public sealed class BackupService : IBackupService
         }
 
         var createdAt = DateTime.UtcNow;
-        var fileName = $"modelibr-{createdAt:yyyy-MM-dd-HHmmss}.tar";
+        var fileName = $"{BackupNaming.ManualBackupPrefix}{createdAt:yyyy-MM-dd-HHmmss}.tar";
         var finalPath = Path.Combine(_paths.BackupRoot, fileName);
         var tmpPath = Path.Combine(_paths.BackupTmp, fileName);
 
@@ -217,6 +217,80 @@ public sealed class BackupService : IBackupService
         finally
         {
             _stageLock.Release();
+        }
+    }
+
+    public async Task<BackupSummary> CreateSnapshotAsync(BackupScope scope, string fileNamePrefix, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(fileNamePrefix))
+            throw new ArgumentException("Snapshot filename prefix must not be empty.", nameof(fileNamePrefix));
+
+        if (!_runLock.Wait(0, cancellationToken))
+        {
+            throw new InvalidOperationException("A backup is already in progress.");
+        }
+
+        var createdAt = DateTime.UtcNow;
+        var fileName = $"{fileNamePrefix}{createdAt:yyyy-MM-dd-HHmmss}.tar";
+        var finalPath = Path.Combine(_paths.BackupRoot, fileName);
+        var tmpPath = Path.Combine(_paths.BackupTmp, fileName);
+
+        try
+        {
+            await RunBackupAsync(scope, tmpPath, finalPath, createdAt);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Automatic snapshot failed: {FileName}", fileName);
+            try { if (File.Exists(tmpPath)) File.Delete(tmpPath); } catch { /* swallow */ }
+            throw;
+        }
+        finally
+        {
+            _runLock.Release();
+        }
+
+        var info = new FileInfo(finalPath);
+        _logger.LogInformation("Automatic snapshot completed: {FileName} ({SizeBytes} bytes)", fileName, info.Length);
+
+        return new BackupSummary(
+            FileName: fileName,
+            SizeBytes: info.Length,
+            CreatedAtUtc: createdAt,
+            Status: "ready",
+            HostPath: _paths.HostRelativeBackupPath(fileName),
+            ContainerPath: finalPath,
+            IncludesThumbnails: scope.IncludeThumbnails,
+            Error: null);
+    }
+
+    public void CleanupSnapshots(string fileNamePrefix, int keepCount)
+    {
+        if (string.IsNullOrWhiteSpace(fileNamePrefix))
+            throw new ArgumentException("Snapshot filename prefix must not be empty.", nameof(fileNamePrefix));
+        if (keepCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(keepCount), keepCount, "Retention count cannot be negative.");
+
+        if (!Directory.Exists(_paths.BackupRoot)) return;
+
+        // The filename embeds the creation timestamp (yyyy-MM-dd-HHmmss), so an
+        // ordinal sort of the name is already chronological — no need to hit the
+        // filesystem for LastWriteTimeUtc.
+        var candidates = Directory.EnumerateFiles(_paths.BackupRoot, $"{fileNamePrefix}*.tar")
+            .OrderByDescending(path => Path.GetFileName(path), StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var stale in candidates.Skip(keepCount))
+        {
+            try
+            {
+                File.Delete(stale);
+                _logger.LogInformation("Pruned old automatic snapshot: {FileName}", Path.GetFileName(stale));
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Failed to prune old automatic snapshot {Path}", stale);
+            }
         }
     }
 
@@ -505,8 +579,9 @@ public sealed class BackupService : IBackupService
     {
         if (string.IsNullOrWhiteSpace(name)) return false;
         if (name.Contains('/') || name.Contains('\\') || name.Contains("..", StringComparison.Ordinal)) return false;
-        return name.EndsWith(".tar", StringComparison.OrdinalIgnoreCase)
-            && name.StartsWith("modelibr-", StringComparison.OrdinalIgnoreCase);
+        if (!name.EndsWith(".tar", StringComparison.OrdinalIgnoreCase)) return false;
+        return name.StartsWith(BackupNaming.ManualBackupPrefix, StringComparison.OrdinalIgnoreCase)
+            || name.StartsWith(BackupNaming.PreMigrationSnapshotPrefix, StringComparison.OrdinalIgnoreCase);
     }
 
     // ── nested config types ─────────────────────────────────────────────

--- a/src/desktop/src/processManager.js
+++ b/src/desktop/src/processManager.js
@@ -193,6 +193,7 @@ export class ProcessManager {
       uploads: path.join(dataRoot, 'uploads'),
       thumbnails: path.join(dataRoot, 'thumbnails'),
       restore: path.join(dataRoot, 'restore'),
+      backups: path.join(dataRoot, 'backups'),
       postgresData: path.join(dataRoot, 'postgres'),
       blender: path.join(dataRoot, 'blender'),
       temp: path.join(userDataDir, 'temp'),
@@ -430,6 +431,7 @@ export class ProcessManager {
       ensureDirectory(this.paths.uploads),
       ensureDirectory(this.paths.thumbnails),
       ensureDirectory(this.paths.restore),
+      ensureDirectory(this.paths.backups),
       ensureDirectory(this.paths.postgresData),
       ensureDirectory(this.paths.blender),
       ensureDirectory(this.paths.temp),
@@ -700,8 +702,20 @@ export class ProcessManager {
         UPLOAD_STORAGE_PATH: this.paths.uploads,
         THUMBNAIL_STORAGE_PATH: this.paths.thumbnails,
         RESTORE_STORAGE_PATH: this.paths.restore,
+        BACKUP_STORAGE_PATH: this.paths.backups,
         BLENDER_INSTALL_PATH: this.paths.blender,
         ConnectionStrings__Default: `Host=127.0.0.1;Port=${this.runningConfig.postgresPort};Database=${POSTGRES_DATABASE};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};`,
+        // TODO(backup on desktop): BackupService shells out to `pg_dump`/`psql` by
+        // bare name (relies on PATH). The bundled Postgres runtime ships those
+        // binaries under runtimeDir/postgres/bin (see prepare-bundle.mjs), but
+        // nothing here adds that directory to PATH, unlike pg_ctl which this file
+        // always invokes by absolute path. Until that's wired up, the automatic
+        // pre-migration backup would fail here (as would the manual "Backup now"
+        // button in Settings) and, per its abort-on-failure policy, would prevent
+        // the app from starting after any future migration ships. Opting out here
+        // — rather than shipping a startup-blocking regression on desktop — until
+        // a follow-up resolves pg_dump/psql to an absolute path.
+        MODELIBR_SKIP_PREMIGRATION_BACKUP: 'true',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/tests/Infrastructure.Tests/Extensions/DatabaseExtensionsTests.cs
+++ b/tests/Infrastructure.Tests/Extensions/DatabaseExtensionsTests.cs
@@ -1,0 +1,240 @@
+using Application.Abstractions.Services;
+using Infrastructure.Extensions;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace Infrastructure.Tests.Extensions;
+
+/// <summary>
+/// Covers the pre-migration-backup gate added to
+/// <see cref="DatabaseExtensions.InitializeDatabaseAsync(IServiceProvider)"/>: pending
+/// migrations must trigger an automatic backup BEFORE MigrateAsync runs, a failed backup
+/// must abort startup before any schema change, and the opt-out env var must bypass the
+/// backup while still letting migrations proceed.
+///
+/// Requires a real PostgreSQL instance (GetPendingMigrationsAsync/MigrateAsync are
+/// relational-only — the InMemory provider used by other Infrastructure.Tests doesn't
+/// support them). Runs against localhost:5432, matching WebApi.Tests'
+/// <c>ModelibrWebFactory</c> credentials. Each test instance gets its OWN uniquely
+/// named database (created in InitializeAsync, dropped in DisposeAsync) rather than
+/// sharing one fixed name — the dev Postgres container this targets is also the shared
+/// backend-integration/backup-restore-e2e database, potentially touched by other
+/// suites/worktrees at the same time, and Npgsql pools physical connections per exact
+/// connection-string text, so reusing one fixed database name across instances was
+/// observed to race a DROP/CREATE cycle against a still-in-flight MigrateAsync from a
+/// different instance and kill it with "terminating connection due to administrator
+/// command". A unique name per instance removes any possibility of that collision.
+///
+/// <see cref="IBackupService"/> is mocked — this suite intentionally does NOT depend on
+/// `pg_dump`/`psql` being on PATH (they usually aren't on a bare dev machine or CI
+/// runner; only the backup-restore-e2e Docker image guarantees them). The real backup
+/// pipeline (pg_dump succeeding, archive contents) is covered by
+/// tests/backup-restore-e2e instead — this suite only covers the orchestration
+/// contract: does the migration path actually call the backup and respect its outcome.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class DatabaseExtensionsTests : IAsyncLifetime
+{
+    private const string Host = "localhost";
+    private const int Port = 5432;
+    private const string Username = "modelibr";
+    private const string Password = "ChangeThisStrongPassword123!";
+
+    // Unique per test instance (xUnit creates a fresh instance per [Fact]) — see the
+    // class remarks for why a shared fixed name isn't safe here.
+    private readonly string _testDatabase = $"Modelibr_PreMigrationBackupTests_{Guid.NewGuid():N}";
+
+    private static readonly string AdminConnectionString =
+        $"Host={Host};Port={Port};Database=postgres;Username={Username};Password={Password};";
+
+    private string TestConnectionString =>
+        $"Host={Host};Port={Port};Database={_testDatabase};Username={Username};Password={Password};";
+
+    public async Task InitializeAsync()
+    {
+        await using var conn = new NpgsqlConnection(AdminConnectionString);
+        await conn.OpenAsync();
+
+        await using var create = conn.CreateCommand();
+        create.CommandText = $"CREATE DATABASE \"{_testDatabase}\";";
+        await create.ExecuteNonQueryAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            // Npgsql pools physical connections; force them closed so DROP DATABASE
+            // (which requires zero connections) doesn't have to wait/fail on one this
+            // test instance itself opened and returned to the pool.
+            NpgsqlConnection.ClearPool(new NpgsqlConnection(TestConnectionString));
+
+            await using var conn = new NpgsqlConnection(AdminConnectionString);
+            await conn.OpenAsync();
+
+            await using var terminate = conn.CreateCommand();
+            terminate.CommandText = $"""
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = '{_testDatabase}' AND pid <> pg_backend_pid();
+                """;
+            await terminate.ExecuteNonQueryAsync();
+
+            await using var drop = conn.CreateCommand();
+            drop.CommandText = $"DROP DATABASE IF EXISTS \"{_testDatabase}\";";
+            await drop.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup — a CI runner without Postgres shouldn't fail teardown
+            // on top of the real failure.
+        }
+    }
+
+    private ServiceProvider BuildProvider(IBackupService backupService, Dictionary<string, string?>? extraConfig = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddProvider(NullLoggerProvider.Instance));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(extraConfig ?? new Dictionary<string, string?>())
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+
+        services.AddDbContext<ApplicationDbContext>(o => o.UseNpgsql(TestConnectionString));
+        services.AddSingleton(backupService);
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// A standalone ApplicationDbContext for assertions, independent of the DI
+    /// container/scope used by the method under test — no scope-disposal bookkeeping
+    /// needed, just `await using`.
+    /// </summary>
+    private ApplicationDbContext NewVerificationContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(TestConnectionString)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static BackupSummary FakeSummary(string prefix) => new(
+        FileName: $"{prefix}2026-01-01-000000.tar",
+        SizeBytes: 1234,
+        CreatedAtUtc: DateTime.UtcNow,
+        Status: "ready",
+        HostPath: "./data/backups/x.tar",
+        ContainerPath: "/var/lib/modelibr/backups/x.tar",
+        IncludesThumbnails: false,
+        Error: null);
+
+    [Fact]
+    public async Task InitializeDatabaseAsync_PendingMigrations_BacksUpBeforeMigratingThenCleansUp()
+    {
+        var mockBackup = new Mock<IBackupService>();
+        mockBackup
+            .Setup(b => b.EstimateSizeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BackupSizeEstimate(DatabaseBytes: 1024, UploadsBytes: 2048, ThumbnailsBytes: 0));
+        mockBackup
+            .Setup(b => b.CreateSnapshotAsync(
+                It.Is<BackupScope>(s => s.IncludeThumbnails == false),
+                BackupNaming.PreMigrationSnapshotPrefix,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeSummary(BackupNaming.PreMigrationSnapshotPrefix));
+
+        await using var provider = BuildProvider(mockBackup.Object);
+
+        await DatabaseExtensions.InitializeDatabaseAsync((IServiceProvider)provider);
+
+        mockBackup.Verify(
+            b => b.CreateSnapshotAsync(
+                It.Is<BackupScope>(s => s.IncludeThumbnails == false),
+                BackupNaming.PreMigrationSnapshotPrefix,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        mockBackup.Verify(
+            b => b.CleanupSnapshots(BackupNaming.PreMigrationSnapshotPrefix, DatabaseExtensions.DefaultPreMigrationBackupRetention),
+            Times.Once);
+
+        await using var verify = NewVerificationContext();
+        var pending = await verify.Database.GetPendingMigrationsAsync();
+        Assert.Empty(pending); // migrations were actually applied
+    }
+
+    [Fact]
+    public async Task InitializeDatabaseAsync_PreMigrationBackupFails_AbortsBeforeAnyMigrationIsApplied()
+    {
+        var mockBackup = new Mock<IBackupService>();
+        mockBackup
+            .Setup(b => b.EstimateSizeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BackupSizeEstimate(0, 0, 0));
+        mockBackup
+            .Setup(b => b.CreateSnapshotAsync(It.IsAny<BackupScope>(), BackupNaming.PreMigrationSnapshotPrefix, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("pg_dump exited with code 1: simulated failure"));
+
+        await using var provider = BuildProvider(mockBackup.Object);
+
+        await using (var precheck = NewVerificationContext())
+        {
+            Assert.NotEmpty(await precheck.Database.GetPendingMigrationsAsync());
+        }
+
+        await Assert.ThrowsAsync<PreMigrationBackupFailedException>(
+            () => DatabaseExtensions.InitializeDatabaseAsync((IServiceProvider)provider));
+
+        mockBackup.Verify(
+            b => b.CleanupSnapshots(It.IsAny<string>(), It.IsAny<int>()),
+            Times.Never); // a failed backup must never trigger retention cleanup
+
+        await using var verify = NewVerificationContext();
+        var appliedAfterAbort = await verify.Database.GetAppliedMigrationsAsync();
+        Assert.Empty(appliedAfterAbort); // MigrateAsync must never have run
+    }
+
+    [Fact]
+    public async Task InitializeDatabaseAsync_SkipEnvVarSet_SkipsBackupButStillMigrates()
+    {
+        var mockBackup = new Mock<IBackupService>(MockBehavior.Strict);
+        // Strict mock: ANY call to IBackupService fails the test — proves the skip
+        // path never touches the backup service at all, not even EstimateSizeAsync.
+
+        await using var provider = BuildProvider(mockBackup.Object, new Dictionary<string, string?>
+        {
+            [DatabaseExtensions.SkipEnvVar] = "true",
+        });
+
+        await DatabaseExtensions.InitializeDatabaseAsync((IServiceProvider)provider);
+
+        await using var verify = NewVerificationContext();
+        var pending = await verify.Database.GetPendingMigrationsAsync();
+        Assert.Empty(pending); // migrations still applied despite the backup being skipped
+    }
+
+    [Fact]
+    public async Task InitializeDatabaseAsync_NoPendingMigrations_NeverTouchesBackupService()
+    {
+        var mockBackup = new Mock<IBackupService>(MockBehavior.Strict);
+
+        await using var provider = BuildProvider(mockBackup.Object);
+
+        // Bring the schema fully up to date directly, bypassing the method under test,
+        // so the second call below sees zero pending migrations.
+        await using (var seed = NewVerificationContext())
+        {
+            await seed.Database.MigrateAsync();
+        }
+
+        // Ordinary boot with nothing pending must never resolve IBackupService — the
+        // strict mock throws on any invocation if it does.
+        await DatabaseExtensions.InitializeDatabaseAsync((IServiceProvider)provider);
+    }
+}

--- a/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
+++ b/tests/Infrastructure.Tests/Services/BackupServiceTests.cs
@@ -1,0 +1,136 @@
+using Application.Abstractions.Services;
+using Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.Tests.Services;
+
+/// <summary>
+/// Covers BackupService's pure filesystem bookkeeping (snapshot retention, filename
+/// validation) — none of this needs Postgres or `pg_dump`, unlike CreateSnapshotAsync/
+/// StartBackupAsync themselves, so it runs as a fast, non-Integration unit test against
+/// a real temp directory. The safety constraint under test — automatic-snapshot cleanup
+/// must never delete a user-initiated backup — is called out explicitly in the
+/// pre-migration-backup spec, so it gets its own direct coverage here rather than only
+/// being implied by the higher-level DatabaseExtensionsTests.
+/// </summary>
+public sealed class BackupServiceTests
+{
+    private static (BackupService service, string backupRoot) NewService()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "modelibr_backup_tests", Path.GetRandomFileName());
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BACKUP_STORAGE_PATH"] = Path.Combine(root, "backups"),
+                ["RESTORE_STORAGE_PATH"] = Path.Combine(root, "restore"),
+                ["UPLOAD_STORAGE_PATH"] = Path.Combine(root, "uploads"),
+                ["THUMBNAIL_STORAGE_PATH"] = Path.Combine(root, "thumbnails"),
+            })
+            .Build();
+
+        var service = new BackupService(config, NullLogger<BackupService>.Instance);
+        return (service, Path.Combine(root, "backups"));
+    }
+
+    private static void TouchFile(string backupRoot, string fileName)
+    {
+        File.WriteAllBytes(Path.Combine(backupRoot, fileName), new byte[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void CleanupSnapshots_KeepsNewestWithinPrefix_DeletesOlderOnes()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "pre-migration-2026-01-01-000001.tar");
+        TouchFile(root, "pre-migration-2026-01-02-000001.tar");
+        TouchFile(root, "pre-migration-2026-01-03-000001.tar");
+        TouchFile(root, "pre-migration-2026-01-04-000001.tar");
+
+        service.CleanupSnapshots(BackupNaming.PreMigrationSnapshotPrefix, keepCount: 2);
+
+        var remaining = Directory.GetFiles(root, "pre-migration-*.tar").Select(Path.GetFileName).ToHashSet();
+        Assert.Equal(2, remaining.Count);
+        Assert.Contains("pre-migration-2026-01-04-000001.tar", remaining);
+        Assert.Contains("pre-migration-2026-01-03-000001.tar", remaining);
+        Assert.DoesNotContain("pre-migration-2026-01-02-000001.tar", remaining);
+        Assert.DoesNotContain("pre-migration-2026-01-01-000001.tar", remaining);
+    }
+
+    [Fact]
+    public void CleanupSnapshots_NeverDeletesFilesOutsideThePrefix()
+    {
+        var (service, root) = NewService();
+        // Manual, user-initiated backups — must survive no matter how aggressive the
+        // retention count for the *different* automatic-snapshot prefix is.
+        TouchFile(root, "modelibr-2026-01-01-000001.tar");
+        TouchFile(root, "modelibr-2026-01-02-000001.tar");
+        TouchFile(root, "pre-migration-2026-01-01-000001.tar");
+
+        service.CleanupSnapshots(BackupNaming.PreMigrationSnapshotPrefix, keepCount: 0);
+
+        var remaining = Directory.GetFiles(root, "*.tar").Select(Path.GetFileName).ToHashSet();
+        Assert.Contains("modelibr-2026-01-01-000001.tar", remaining);
+        Assert.Contains("modelibr-2026-01-02-000001.tar", remaining);
+        Assert.DoesNotContain("pre-migration-2026-01-01-000001.tar", remaining);
+    }
+
+    [Fact]
+    public void CleanupSnapshots_FewerFilesThanKeepCount_DeletesNothing()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "pre-migration-2026-01-01-000001.tar");
+
+        service.CleanupSnapshots(BackupNaming.PreMigrationSnapshotPrefix, keepCount: 3);
+
+        Assert.True(File.Exists(Path.Combine(root, "pre-migration-2026-01-01-000001.tar")));
+    }
+
+    [Fact]
+    public void ResolveBackupPath_AcceptsPreMigrationPrefix()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "pre-migration-2026-01-01-000001.tar");
+
+        var resolved = service.ResolveBackupPath("pre-migration-2026-01-01-000001.tar");
+
+        Assert.NotNull(resolved);
+        Assert.True(File.Exists(resolved));
+    }
+
+    [Fact]
+    public void DeleteBackup_AcceptsPreMigrationPrefix()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "pre-migration-2026-01-01-000001.tar");
+
+        service.DeleteBackup("pre-migration-2026-01-01-000001.tar");
+
+        Assert.False(File.Exists(Path.Combine(root, "pre-migration-2026-01-01-000001.tar")));
+    }
+
+    [Fact]
+    public void ResolveBackupPath_RejectsNamesOutsideKnownPrefixes()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "not-a-known-prefix-2026-01-01-000001.tar");
+
+        var resolved = service.ResolveBackupPath("not-a-known-prefix-2026-01-01-000001.tar");
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ListBackups_IncludesBothManualAndPreMigrationSnapshots()
+    {
+        var (service, root) = NewService();
+        TouchFile(root, "modelibr-2026-01-01-000001.tar");
+        TouchFile(root, "pre-migration-2026-01-02-000001.tar");
+
+        var names = service.ListBackups().Select(b => b.FileName).ToHashSet();
+
+        Assert.Contains("modelibr-2026-01-01-000001.tar", names);
+        Assert.Contains("pre-migration-2026-01-02-000001.tar", names);
+    }
+}

--- a/tests/WebApi.Tests/Integration/ModelibrWebFactory.cs
+++ b/tests/WebApi.Tests/Integration/ModelibrWebFactory.cs
@@ -39,6 +39,15 @@ public class ModelibrWebFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("RESTORE_STORAGE_PATH", Path.Combine(_uploadPath, "restore"));
         Environment.SetEnvironmentVariable("THUMBNAIL_STORAGE_PATH", Path.Combine(_uploadPath, "thumbnails"));
 
+        // The freshly-created test database has every migration pending, which would
+        // trigger DatabaseExtensions' automatic pre-migration backup (and, on backup
+        // failure, abort startup) on every single test using this factory. That backup
+        // shells out to `pg_dump`, which isn't guaranteed to be on PATH on a dev machine
+        // or CI runner — so it's skipped by default here. Tests that specifically cover
+        // the pre-migration-backup gate build their own minimal host instead of this
+        // factory (see Infrastructure.Tests/Extensions/DatabaseExtensionsTests.cs).
+        Environment.SetEnvironmentVariable("MODELIBR_SKIP_PREMIGRATION_BACKUP", "true");
+
         EnsureTestDatabaseCreated();
     }
 
@@ -56,6 +65,7 @@ public class ModelibrWebFactory : WebApplicationFactory<Program>
                 // which isn't writable when the host boots on a dev machine.
                 ["RESTORE_STORAGE_PATH"] = Path.Combine(_uploadPath, "restore"),
                 ["THUMBNAIL_STORAGE_PATH"] = Path.Combine(_uploadPath, "thumbnails"),
+                ["BACKUP_STORAGE_PATH"] = Path.Combine(_uploadPath, "backups"),
                 ["HTTPS_PORT"] = "0",
                 ["EXPOSE_443_PORT"] = "false",
                 ["DisableHttpsRedirection"] = "true",

--- a/tests/backup-restore-e2e/specs/06-premigration-backup-on-first-boot.spec.ts
+++ b/tests/backup-restore-e2e/specs/06-premigration-backup-on-first-boot.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { getWebapiLogs } from "../helpers/docker-stack.js";
+
+// Numbering note: this suite gained a "05" spec (webdav-blend archive exclusion) on
+// another branch that this branch doesn't have yet — numbered 06 to stay clear of it
+// rather than reusing 05.
+//
+// Covers the pre-migration-backup safety net (DatabaseExtensions.InitializeDatabaseAsync):
+// before applying pending EF Core migrations at startup, the app takes an automatic
+// DB-scope backup (prefix "pre-migration-") and aborts startup if that backup fails.
+//
+// This stack's Postgres container is created empty by `test:setup` (`docker compose up
+// --build`), so on webapi's very first boot EVERY migration is "pending" — the exact
+// condition this feature targets. That makes the ordinary suite startup itself a live
+// exercise of the real code path (real pg_dump — the webapi image bundles
+// postgresql-client-16, see README) without needing to fabricate an upgrade boundary.
+//
+// Verified via container logs rather than the `/backups` list or `data/backups/` on
+// disk: `01-create-list-download.spec.ts`'s beforeAll deletes every existing backup
+// (this one included) before its own test runs, and specs execute in file order, so by
+// the time this spec runs the archive itself is very likely already gone — but `docker
+// logs` retains the whole container lifetime, so the startup log lines survive.
+test.describe("Pre-migration backup on first boot", () => {
+    test("Startup with pending migrations logs a pre-migration snapshot before migrating", async () => {
+        const logs = await getWebapiLogs(100000);
+
+        expect(logs).toMatch(/pending migration\(s\) detected/i);
+        expect(logs).toMatch(/Taking automatic pre-migration backup/i);
+        expect(logs).toMatch(/Pre-migration backup completed: pre-migration-[\d-]+\.tar/);
+        expect(logs).toMatch(/Database initialization completed successfully/);
+
+        // The backup log line must appear BEFORE the "initialization completed"
+        // line that follows MigrateAsync — proving the backup ran first, not just
+        // that both happened somewhere in the log.
+        const backupIdx = logs.search(/Pre-migration backup completed:/);
+        const migratedIdx = logs.search(/Database initialization completed successfully/);
+        expect(backupIdx).toBeGreaterThan(-1);
+        expect(migratedIdx).toBeGreaterThan(-1);
+        expect(backupIdx).toBeLessThan(migratedIdx);
+
+        // The safety net must not have been silently bypassed.
+        expect(logs).not.toMatch(/MODELIBR_SKIP_PREMIGRATION_BACKUP=true/);
+    });
+});

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -13,6 +13,13 @@ services:
             - AllowedOrigins__0=http://localhost:3002
             - AllowedOrigins__1=http://localhost:3010
             - BLENDER_INSTALL_PATH=/var/lib/modelibr/blender
+            # This stack recreates its DB fresh every run, so first boot always has
+            # every migration pending. It has no backup configuration (no POSTGRES_*
+            # env / BACKUP_STORAGE_PATH), so the pre-migration backup cannot run here
+            # and would abort startup by design. The pre-migration path itself is
+            # covered by backup-restore-e2e spec 06 + the DatabaseExtensions
+            # integration tests.
+            - MODELIBR_SKIP_PREMIGRATION_BACKUP=true
         ports:
             - "8090:8080"
         healthcheck:


### PR DESCRIPTION
## What (prompt 17 — backup trust hardening)

### Backup-before-migrate
- Startup now checks `GetPendingMigrationsAsync()` before `MigrateAsync()`. If migrations are pending: logs an upfront size estimate, takes an automatic **DB-scope** backup (`pre-migration-` prefix, thumbnails excluded — they regenerate), then migrates. Auto-updating installs can no longer take a bad migration without a rollback snapshot.
- **Failure policy:** a failed pre-migration backup aborts startup with a critical log (a silent skip would defeat the purpose). Opt-out: `MODELIBR_SKIP_PREMIGRATION_BACKUP=true`; retention: `MODELIBR_PREMIGRATION_BACKUP_RETENTION` (default 3) — both wired through `.env.example` + `docker-compose.yml`.
- Retention cleanup is glob-scoped to the `pre-migration-` prefix only — it can never touch manual backups (unit-proven). Snapshots surface in the existing Settings backups UI automatically.

### Gated restore drill
- The backup-restore drill (previously non-gating, rotted silently before) now runs as a **nightly GitHub Actions job** next to the slow-E2E job — it needs no GPU, so a hosted runner works; the job runs the exact manifest command so CI and `npm run test:all -- --only=backup-restore` are identical.
- New spec `06-premigration-backup-on-first-boot`: a fresh stack's first boot has every migration pending, so the feature fires for real (real `pg_dump`) — asserted via container logs, ordering included (backup completes before migrations).
- Pending-migrations contract also covered by `Category=Integration` tests with a mocked `IBackupService` (backup-then-migrate ordering, abort-on-failure before any schema change, skip-env bypass, no-op when nothing pending), since `pg_dump` isn't guaranteed on PATH outside the e2e image.

### Discovered along the way
- **Backups were silently non-functional on desktop installs** — the tray host never wired `BACKUP_STORAGE_PATH`. This PR wires the path for parity but explicitly sets `MODELIBR_SKIP_PREMIGRATION_BACKUP=true` for the desktop-spawned WebApi: `BackupService` calls `pg_dump`/`psql` by bare name and the bundled Postgres `bin/` isn't on PATH there, so shipping this unmodified would make every desktop upgrade with a pending migration fail to boot. Proper desktop backup support (absolute-path resolution) is a follow-up, documented in code and docs.
- New feature docs page: `docs/docs/features/backups.md` (backups were shipped but undocumented).

## Verification
- `dotnet build` clean; unit tests 610 passed / 0 failed; integration tests 10/10 (real Postgres)
- `backup-restore` suite: **8/8 passed** including the new spec, clean teardown
- `npm run test:audit` green; `npm run docs:audit` 10 passed (1 pre-existing unrelated README warning)
- Desktop `processManager` node tests 12/12