### PR TITLE
fix(worker): delete dead legacy pipeline and cancel job timeouts

### DIFF
--- a/.claude/skills/asset-processor-patterns/SKILL.md
+++ b/.claude/skills/asset-processor-patterns/SKILL.md
@@ -7,8 +7,8 @@ description: Modelibr asset-processor (Node.js worker) conventions — config.js
 
 ESM (`"type": "module"`), Vitest (NOT Jest — the frontend is the inverse),
 structured winston `logger` + `withJobContext(jobId)` — never `console.log`.
-Known debt + planned refactors: prompts 24 (folder grouping), 41 (dead code +
-timeout cancellation), 42 (client factory + hygiene) in `.claude/prompts/`.
+Known debt + planned refactors: prompt 24 (folder grouping), 42 (client
+factory + hygiene) in `.claude/prompts/`.
 
 ## Configuration
 - ALL runtime config lives in `config.js` (rendering, orbit, encoding,
@@ -27,24 +27,33 @@ timeout cancellation), 42 (client factory + hygiene) in `.claude/prompts/`.
   Registered: `Model`, `Sound`, `TextureSet`, `EnvironmentMap`,
   `MeshAnalysis` (stub — logs not-implemented; `meshProcessor.js` documents
   the planned shape).
-- `BaseProcessor` is the template method: `execute()` wraps your `process()`
-  with error handling, `withJobContext` logging, and `JobApiClient`
-  callbacks. New processor = extend it, implement `get processorType()` +
-  `async process(job, jobLogger)`, register in the registry constructor.
-- TRAP — `jobProcessor.js` still contains a full LEGACY inline pipeline
-  (`processModelJobAsync`/`processSoundJobAsync`/`processModel`/
-  `processSound`, ~580 lines) that nothing calls; dispatch goes through the
-  registry. Don't fix or extend the legacy path — prompt 41 deletes it.
+- `BaseProcessor` is the template method: `execute(job, signal)` wraps your
+  `process()` with error handling, `withJobContext` logging, and
+  `JobApiClient` callbacks. New processor = extend it, implement
+  `get processorType()` + `async process(job, jobLogger, signal)`, register
+  in the registry constructor.
+- `jobProcessor.js` dispatch goes exclusively through `ProcessorRegistry` —
+  there is no other code path; don't add one.
 
 ## Job lifecycle (how work arrives and runs)
 - Delivery is belt-and-braces: SignalR push notification → worker CLAIMS via
   `POST /thumbnail-jobs/dequeue` (backend arbitrates racing workers) →
   local queue (cap 50; full = drop notification, fallback polling sweeps
   later) → up to `config.maxConcurrentJobs` (default 3) run concurrently.
-- TRAP — the job timeout is a `Promise.race`: it marks the job failed but
-  does NOT cancel the work; a hung render keeps its pool renderer (slot
-  starvation). Prompt 41 fixes this — until then never rely on the timeout
-  to free resources; make your processor's awaits fail rather than hang.
+- The job timeout (`processQueue` in `jobProcessor.js`) actually cancels: it
+  aborts an `AbortController` whose `signal` flows into `process()`.
+  Renderer-backed processors (Thumbnail/TextureSet/EnvironmentMap) MUST arm
+  it right after acquiring: `disarmAbort = this._armRendererAbort(signal,
+  this.rendererPool, renderer, jobLogger)`, then call `disarmAbort()` in
+  `finally` before `release()`. Skipping this reintroduces slot starvation.
+  On abort it calls `rendererPool.forceReinit(renderer)` →
+  `PuppeteerRenderer.reinitialize()` (the crash-recovery path), so the slot
+  comes back usable instead of hung.
+- `BaseProcessor.execute()` checks `signal?.aborted` before calling
+  `markCompleted`/`markFailed` — the backend has no double-finish guard
+  (`ThumbnailJob.MarkAsCompleted`/`MarkAsFailed` unconditionally overwrite
+  status), so a late result from an aborted job is discarded, not
+  re-reported.
 - Retry/dead-letter logic is backend-side (`FinishThumbnailJobCommand`) —
   the worker just reports finish/fail honestly.
 

--- a/src/asset-processor/jobProcessor.js
+++ b/src/asset-processor/jobProcessor.js
@@ -1,38 +1,26 @@
 import { JobApiClient } from './jobApiClient.js'
 import { SignalRQueueService } from './signalrQueueService.js'
 import { ModelFileService } from './modelFileService.js'
-import { SoundFileService } from './soundFileService.js'
-import { WaveformGeneratorService } from './waveformGeneratorService.js'
 import { ModelDataService } from './modelDataService.js'
-import { PuppeteerRenderer } from './puppeteerRenderer.js'
-import { FrameEncoderService } from './frameEncoderService.js'
-import { ThumbnailStorageService } from './thumbnailStorageService.js'
-import { JobEventService } from './jobEventService.js'
-import { ThumbnailApiService } from './thumbnailApiService.js'
 import { ProcessorRegistry } from './processors/processorRegistry.js'
 import {
   config,
   refreshBlenderConfigFromApi,
   refreshThumbnailRenderConfigFromApi,
 } from './config.js'
-import logger, { withJobContext } from './logger.js'
+import logger from './logger.js'
 
 /**
- * Job processor that handles thumbnail generation using SignalR real-time queue
+ * Job processor that handles thumbnail generation using SignalR real-time queue.
+ * Dispatch goes exclusively through ProcessorRegistry (see processors/) —
+ * this class owns queueing, concurrency, timeouts and lifecycle only.
  */
 export class JobProcessor {
   constructor() {
     this.jobService = new JobApiClient()
     this.signalrQueueService = new SignalRQueueService()
     this.modelFileService = new ModelFileService()
-    this.soundFileService = new SoundFileService()
-    this.waveformGenerator = new WaveformGeneratorService()
     this.modelDataService = new ModelDataService()
-    this.thumbnailStorage = new ThumbnailStorageService()
-    this.jobEventService = new JobEventService()
-    this.thumbnailApiService = new ThumbnailApiService()
-    this.puppeteerRenderer = null // Legacy — kept for backward compat, active rendering uses ProcessorRegistry
-    this.frameEncoder = null // Will be initialized when needed
     this.isShuttingDown = false
     this.activeJobs = new Map()
     this.jobQueue = [] // Local queue for sequential processing
@@ -293,27 +281,50 @@ export class JobProcessor {
           activeJobs: activePromises.size,
         })
 
+        this.activeJobs.set(job.id, job)
+
         const timeoutMs = config.jobTimeout || 300000
+        const abortController = new AbortController()
+        let timeoutHandle
+        let processorInvoked = false
+
         const jobPromise = (async () => {
           try {
             await refreshBlenderConfigFromApi(this.jobService)
             await refreshThumbnailRenderConfigFromApi(this.jobService)
-            const timeoutPromise = new Promise((_, reject) =>
-              setTimeout(
-                () =>
-                  reject(
-                    new Error(`Job processing timed out after ${timeoutMs}ms`)
-                  ),
-                timeoutMs
-              )
-            )
-            await Promise.race([processor(job), timeoutPromise])
+
+            const timeoutPromise = new Promise((_, reject) => {
+              timeoutHandle = setTimeout(() => {
+                reject(
+                  new Error(`Job processing timed out after ${timeoutMs}ms`)
+                )
+              }, timeoutMs)
+            })
+
+            // Pass an abort signal through to the processor so cancellable
+            // awaits (and, for renderer-backed processors, the RendererPool
+            // slot they're holding) can be torn down instead of hanging
+            // forever once the timeout below fires.
+            processorInvoked = true
+            await Promise.race([
+              processor(job, abortController.signal),
+              timeoutPromise,
+            ])
+            clearTimeout(timeoutHandle)
           } catch (error) {
+            clearTimeout(timeoutHandle)
+
             if (error.message.includes('timed out')) {
               logger.error(`Job ${job.id} timed out after ${timeoutMs}ms`, {
                 jobId: job.id,
                 timeoutMs,
               })
+              // Abort the abandoned work. Renderer-backed processors react
+              // to this by force-reinitializing the pool slot they hold —
+              // without it a hung Puppeteer page keeps that slot forever
+              // and every concurrent job eventually deadlocks the worker
+              // while /health keeps reporting healthy.
+              abortController.abort()
               try {
                 await this.jobService.markJobFailed(job.id, error.message)
               } catch (markFailedError) {
@@ -322,13 +333,45 @@ export class JobProcessor {
                   error: markFailedError.message,
                 })
               }
-              this.activeJobs.delete(job.id)
+            } else if (!processorInvoked) {
+              // Failed before the processor ever ran (e.g. a config
+              // refresh error) — nothing else has reported this job's
+              // outcome, so without this it would sit as "Processing"
+              // until the backend's lock timeout eventually expires.
+              logger.error('Job failed before processing started', {
+                jobId: job.id,
+                error: error.message,
+              })
+              try {
+                await this.jobService.markJobFailed(job.id, error.message)
+              } catch (markFailedError) {
+                logger.error('Failed to mark job as failed', {
+                  jobId: job.id,
+                  error: markFailedError.message,
+                })
+              }
+            } else {
+              // BaseProcessor.execute() already reported this job's
+              // outcome to the backend — or deliberately skipped doing so
+              // because it was aborted by the timeout branch above. The
+              // backend has no guard against a job being finished twice,
+              // so don't call markJobFailed again here: a duplicate call
+              // could clobber a job a different worker has since
+              // reclaimed.
+              logger.error('Job processing failed', {
+                jobId: job.id,
+                error: error.message,
+                aborted: abortController.signal.aborted,
+              })
             }
           }
         })()
 
         activePromises.add(jobPromise)
-        jobPromise.finally(() => activePromises.delete(jobPromise))
+        jobPromise.finally(() => {
+          activePromises.delete(jobPromise)
+          this.activeJobs.delete(job.id)
+        })
       }
 
       // Fill initial slots up to maxConcurrent
@@ -370,588 +413,6 @@ export class JobProcessor {
   }
 
   /**
-   * Process a model thumbnail job asynchronously
-   * @param {Object} job - The job to process
-   */
-  async processModelJobAsync(job) {
-    const jobLogger = withJobContext(job.id, job.modelId)
-    this.activeJobs.set(job.id, job)
-
-    try {
-      jobLogger.info('Starting thumbnail generation')
-
-      // Log job started event
-      await this.jobEventService.logJobStarted(
-        job.id,
-        job.modelId,
-        job.modelHash
-      )
-
-      // Process the model
-      const thumbnailMetadata = await this.processModel(job, jobLogger)
-
-      await this.jobService.markJobCompleted(job.id, thumbnailMetadata)
-
-      // Log job completed event
-      await this.jobEventService.logJobCompleted(job.id, thumbnailMetadata)
-
-      jobLogger.info('Thumbnail generation completed successfully')
-    } catch (error) {
-      jobLogger.error('Thumbnail generation failed', {
-        error: error.message,
-        stack: error.stack,
-      })
-
-      // Log job failed event
-      await this.jobEventService.logJobFailed(
-        job.id,
-        error.message,
-        error.stack
-      )
-
-      try {
-        await this.jobService.markJobFailed(job.id, error.message)
-      } catch (markFailedError) {
-        jobLogger.error('Failed to mark job as failed', {
-          markFailedError: markFailedError.message,
-        })
-      }
-    } finally {
-      this.activeJobs.delete(job.id)
-    }
-  }
-
-  /**
-   * Process a sound waveform job asynchronously
-   * @param {Object} job - The job to process
-   */
-  async processSoundJobAsync(job) {
-    const jobLogger = withJobContext(job.id, job.soundId)
-    this.activeJobs.set(job.id, job)
-
-    try {
-      jobLogger.info('Starting waveform generation')
-
-      // Log job started event
-      await this.jobEventService.logJobStarted(
-        job.id,
-        job.soundId,
-        job.soundHash
-      )
-
-      // Process the sound
-      const thumbnailMetadata = await this.processSound(job, jobLogger)
-
-      await this.jobService.finishSoundJob(job.id, true, thumbnailMetadata)
-
-      // Log job completed event
-      await this.jobEventService.logJobCompleted(job.id, thumbnailMetadata)
-
-      jobLogger.info(
-        'Waveform generation completed successfully',
-        thumbnailMetadata
-      )
-    } catch (error) {
-      jobLogger.error('Waveform generation failed', {
-        error: error.message,
-        stack: error.stack,
-      })
-
-      // Log job failed event
-      await this.jobEventService.logJobFailed(
-        job.id,
-        error.message,
-        error.stack
-      )
-
-      try {
-        await this.jobService.finishSoundJob(job.id, false, {}, error.message)
-      } catch (markFailedError) {
-        jobLogger.error('Failed to mark sound job as failed', {
-          markFailedError: markFailedError.message,
-        })
-      }
-    } finally {
-      this.activeJobs.delete(job.id)
-    }
-  }
-
-  /**
-   * Process a model for thumbnail generation
-   * @param {Object} job - The job being processed
-   * @param {Object} jobLogger - Logger with job context
-   */
-  async processModel(job, jobLogger) {
-    let tempFilePath = null
-    let texturePaths = null
-
-    try {
-      jobLogger.info('Starting model processing', {
-        modelId: job.modelId,
-        modelHash: job.modelHash,
-      })
-
-      // Step 1: Check if thumbnails already exist for this model hash
-      jobLogger.info('Checking for existing thumbnails', {
-        modelHash: job.modelHash,
-      })
-      const existingThumbnails =
-        await this.thumbnailStorage.checkThumbnailsExist(job.modelHash)
-
-      if (existingThumbnails.skipRendering) {
-        jobLogger.info('Thumbnails already exist, skipping rendering', {
-          modelHash: job.modelHash,
-          webpExists: existingThumbnails.webpExists,
-          posterExists: existingThumbnails.posterExists,
-          webpPath: existingThumbnails.paths?.webpPath,
-          posterPath: existingThumbnails.paths?.posterPath,
-        })
-
-        // Update thumbnail metadata if needed (thumbnails exist but job was still created)
-        // This can happen in edge cases where job was queued before thumbnails were stored
-        // For existing thumbnails, we need to provide default metadata since we can't complete without it
-        jobLogger.warn(
-          'Thumbnails already exist, providing default metadata for job completion'
-        )
-        return {
-          thumbnailPath: existingThumbnails.paths?.webpPath || '/default/path',
-          sizeBytes: 0,
-          width: 256,
-          height: 256,
-        }
-      }
-
-      // Step 2: Fetch the model file
-      jobLogger.info('Fetching model file from API')
-      await this.jobEventService.logModelDownloadStarted(job.id, job.modelId)
-
-      const fileInfo = await this.modelFileService.fetchModelFile(
-        job.modelId,
-        job.modelVersionId
-      )
-      tempFilePath = fileInfo.filePath
-
-      jobLogger.info('Model file fetched successfully', {
-        originalFileName: fileInfo.originalFileName,
-        fileType: fileInfo.fileType,
-        filePath: fileInfo.filePath,
-      })
-
-      await this.jobEventService.logModelDownloaded(
-        job.id,
-        job.modelId,
-        fileInfo.fileType,
-        fileInfo.filePath
-      )
-
-      // Step 3: Initialize Puppeteer renderer and load model
-      jobLogger.info('Initializing Puppeteer renderer and loading model')
-      await this.jobEventService.logModelLoadingStarted(
-        job.id,
-        fileInfo.fileType
-      )
-
-      // Initialize Puppeteer renderer if not already done
-      if (!this.puppeteerRenderer) {
-        this.puppeteerRenderer = new PuppeteerRenderer()
-        await this.puppeteerRenderer.initialize()
-      }
-
-      // Load model in browser
-      const polygonCount = await this.puppeteerRenderer.loadModel(
-        fileInfo.filePath,
-        fileInfo.fileType
-      )
-
-      jobLogger.info('Model loaded successfully in browser', {
-        polygonCount,
-        fileType: fileInfo.fileType,
-      })
-
-      await this.jobEventService.logModelLoaded(
-        job.id,
-        polygonCount,
-        fileInfo.fileType
-      )
-
-      // Step 3.5: Fetch and apply textures if default texture set is configured
-      try {
-        // Use defaultTextureSetId from job (version-specific)
-        if (job.defaultTextureSetId) {
-          jobLogger.info('Model version has default texture set configured', {
-            defaultTextureSetId: job.defaultTextureSetId,
-            modelVersionId: job.modelVersionId,
-          })
-
-          await this.jobEventService.logEvent(
-            job.id,
-            'TextureFetchStarted',
-            `Fetching texture set ${job.defaultTextureSetId} for version ${job.modelVersionId}`
-          )
-
-          const textureSet = await this.modelDataService.getTextureSet(
-            job.defaultTextureSetId
-          )
-
-          if (
-            textureSet &&
-            textureSet.textures &&
-            textureSet.textures.length > 0
-          ) {
-            jobLogger.info('Downloading texture files', {
-              textureSetId: textureSet.id,
-              textureSetName: textureSet.name,
-              textureCount: textureSet.textures.length,
-            })
-
-            texturePaths =
-              await this.modelDataService.downloadTextureSetFiles(textureSet)
-
-            if (Object.keys(texturePaths).length > 0) {
-              jobLogger.info('Applying textures to model', {
-                textureTypes: Object.keys(texturePaths),
-              })
-
-              const texturesApplied =
-                await this.puppeteerRenderer.applyTextures(
-                  texturePaths,
-                  fileInfo.fileType
-                )
-
-              if (texturesApplied) {
-                await this.jobEventService.logEvent(
-                  job.id,
-                  'TexturesApplied',
-                  `Applied ${Object.keys(texturePaths).length} textures to model`
-                )
-                jobLogger.info('Textures applied successfully')
-              } else {
-                jobLogger.warn(
-                  'Failed to apply textures, continuing without them'
-                )
-              }
-            } else {
-              jobLogger.warn('No texture files could be downloaded')
-            }
-          } else {
-            jobLogger.info(
-              'Texture set has no textures or could not be fetched'
-            )
-          }
-        } else {
-          jobLogger.debug('No default texture set configured for this model')
-        }
-      } catch (textureError) {
-        jobLogger.warn(
-          'Failed to fetch or apply textures, continuing without them',
-          {
-            error: textureError.message,
-          }
-        )
-        // Don't fail the job if textures can't be applied, continue with rendering
-      }
-
-      // Step 4: Generate orbit frames using Puppeteer renderer
-      if (config.orbit.enabled) {
-        jobLogger.info('Starting orbit frame rendering with Puppeteer')
-
-        // Calculate frame count for logging
-        const angleRange = config.orbit.endAngle - config.orbit.startAngle
-        const frameCount = Math.ceil(angleRange / config.orbit.angleStep)
-
-        await this.jobEventService.logFrameRenderingStarted(
-          job.id,
-          frameCount,
-          {
-            outputWidth: config.rendering.outputWidth,
-            outputHeight: config.rendering.outputHeight,
-            orbitAngleStep: config.orbit.angleStep,
-            orbitStartAngle: config.orbit.startAngle,
-            orbitEndAngle: config.orbit.endAngle,
-          }
-        )
-
-        // Render orbit frames
-        const renderStartTime = Date.now()
-        const frames = await this.puppeteerRenderer.renderOrbitFrames(jobLogger)
-
-        // Log memory statistics
-        const memoryStats = this.puppeteerRenderer.getMemoryStats(frames)
-        jobLogger.info('Orbit frame rendering completed successfully', {
-          polygonCount,
-          ...memoryStats,
-          processingConfig: {
-            outputWidth: config.rendering.outputWidth,
-            outputHeight: config.rendering.outputHeight,
-            outputFormat: config.rendering.outputFormat,
-            orbitAngleStep: config.orbit.angleStep,
-            orbitStartAngle: config.orbit.startAngle,
-            orbitEndAngle: config.orbit.endAngle,
-            cameraDistance: config.rendering.cameraDistance,
-            maxPolygonCount: config.modelProcessing.maxPolygonCount,
-            normalizedScale: config.modelProcessing.normalizedScale,
-          },
-        })
-
-        const renderTime = Date.now() - renderStartTime
-        await this.jobEventService.logFrameRenderingCompleted(
-          job.id,
-          frames.length,
-          renderTime
-        )
-
-        // Note: Frames are stored in memory for processing
-        jobLogger.info('Frames stored in memory for processing', {
-          frameCount: frames.length,
-          memoryUsageMB: memoryStats.totalSizeMB,
-        })
-
-        // Step 5: Encode frames into animated WebP and poster if enabled
-        if (config.encoding.enabled) {
-          jobLogger.info('Starting frame encoding')
-          await this.jobEventService.logEncodingStarted(job.id, frames.length)
-
-          // Initialize frame encoder if not already done
-          if (!this.frameEncoder) {
-            this.frameEncoder = new FrameEncoderService()
-          }
-
-          // Encode frames to WebP and poster
-          const encodingResult = await this.frameEncoder.encodeFrames(
-            frames,
-            jobLogger
-          )
-
-          jobLogger.info('Frame encoding completed successfully', {
-            webpPath: encodingResult.webpPath,
-            posterPath: encodingResult.posterPath,
-            encodeTimeMs: encodingResult.encodeTimeMs,
-            frameCount: encodingResult.frameCount,
-          })
-
-          await this.jobEventService.logEncodingCompleted(
-            job.id,
-            encodingResult.webpPath,
-            encodingResult.posterPath,
-            encodingResult.encodeTimeMs
-          )
-
-          // Step 6: Store thumbnails via API upload
-          if (this.thumbnailStorage.enabled) {
-            jobLogger.info('Uploading thumbnails to API')
-            await this.jobEventService.logThumbnailUploadStarted(
-              job.id,
-              job.modelHash
-            )
-
-            const storageResult = await this.thumbnailStorage.storeThumbnails(
-              job.modelHash,
-              encodingResult.webpPath,
-              encodingResult.posterPath,
-              encodingResult.pngPath,
-              job.modelId, // Pass model ID for API upload
-              job.modelVersionId // Pass model version ID for version-specific upload
-            )
-
-            jobLogger.info('Thumbnail API upload completed', {
-              stored: storageResult.stored,
-              webpStored: storageResult.webpStored,
-              posterStored: storageResult.posterStored,
-              pngStored: storageResult.pngStored,
-              uploadResults: storageResult.uploadResults?.length || 0,
-              allSuccessful: storageResult.apiResponse?.allSuccessful,
-            })
-
-            await this.jobEventService.logThumbnailUploadCompleted(
-              job.id,
-              storageResult.uploadResults
-            )
-
-            // Extract thumbnail metadata from successful upload for job completion
-            if (
-              storageResult.stored &&
-              storageResult.uploadResults?.length > 0
-            ) {
-              const successfulUpload = storageResult.uploadResults.find(
-                upload => upload.success && upload.data
-              )
-              if (successfulUpload && successfulUpload.data) {
-                const thumbnailData = successfulUpload.data
-                jobLogger.info(
-                  'Extracted thumbnail metadata for job completion',
-                  {
-                    thumbnailPath: thumbnailData.thumbnailPath,
-                    sizeBytes: thumbnailData.sizeBytes,
-                    width: thumbnailData.width,
-                    height: thumbnailData.height,
-                  }
-                )
-
-                return {
-                  thumbnailPath: thumbnailData.thumbnailPath,
-                  sizeBytes: thumbnailData.sizeBytes,
-                  width: thumbnailData.width,
-                  height: thumbnailData.height,
-                }
-              }
-            }
-
-            // If upload failed, throw error instead of returning default metadata
-            const errorMsg =
-              'Thumbnail upload failed - no valid thumbnail data available'
-            jobLogger.error(errorMsg)
-            await this.jobEventService.logError(
-              job.id,
-              'ThumbnailUploadFailed',
-              errorMsg,
-              new Error(errorMsg)
-            )
-            throw new Error(errorMsg)
-          } else {
-            const errorMsg =
-              'Persistent thumbnail storage is disabled - cannot complete job'
-            jobLogger.error(errorMsg)
-            await this.jobEventService.logError(
-              job.id,
-              'StorageDisabled',
-              errorMsg,
-              new Error(errorMsg)
-            )
-            throw new Error(errorMsg)
-          }
-        } else {
-          const errorMsg =
-            'Frame encoding is disabled - cannot generate thumbnails'
-          jobLogger.error(errorMsg)
-          await this.jobEventService.logError(
-            job.id,
-            'EncodingDisabled',
-            errorMsg,
-            new Error(errorMsg)
-          )
-          throw new Error(errorMsg)
-        }
-      } else {
-        const errorMsg =
-          'Orbit rendering is disabled - cannot generate thumbnails'
-        jobLogger.error(errorMsg)
-        await this.jobEventService.logError(
-          job.id,
-          'RenderingDisabled',
-          errorMsg,
-          new Error(errorMsg)
-        )
-        throw new Error(errorMsg)
-      }
-    } catch (error) {
-      jobLogger.error('Model processing failed', {
-        error: error.message,
-        modelId: job.modelId,
-      })
-      throw error
-    } finally {
-      // Clean up temporary file
-      if (tempFilePath) {
-        await this.modelFileService.cleanupFile(tempFilePath)
-      }
-
-      // Clean up temporary texture files
-      if (texturePaths) {
-        await this.modelDataService.cleanupTextureFiles(texturePaths)
-      }
-    }
-  }
-
-  /**
-   * Process a sound for waveform thumbnail generation
-   * @param {Object} job - The job being processed
-   * @param {Object} jobLogger - Logger with job context
-   */
-  async processSound(job, jobLogger) {
-    let tempFilePath = null
-
-    try {
-      jobLogger.info('Starting sound waveform processing', {
-        soundId: job.soundId,
-        soundHash: job.soundHash,
-      })
-
-      // Step 1: Fetch the sound file
-      jobLogger.info('Fetching sound file from API')
-
-      const fileInfo = await this.soundFileService.fetchSoundFile(job.soundId)
-      tempFilePath = fileInfo.filePath
-
-      jobLogger.info('Sound file fetched successfully', {
-        originalFileName: fileInfo.originalFileName,
-        fileType: fileInfo.fileType,
-        filePath: fileInfo.filePath,
-      })
-
-      // Step 2: Generate waveform PNG
-      jobLogger.info('Generating waveform thumbnail')
-
-      const tempOutputPath = `${tempFilePath}.waveform.png`
-      const { peaks, duration } = await this.waveformGenerator.generateWaveform(
-        tempFilePath,
-        tempOutputPath,
-        {
-          width: 800,
-          height: 150,
-          peakCount: 200,
-          color: '#3b82f6',
-        }
-      )
-
-      jobLogger.info('Waveform thumbnail generated', {
-        outputPath: tempOutputPath,
-        duration,
-        peakCount: peaks.length,
-      })
-
-      // Step 3: Upload waveform thumbnail to backend API
-      jobLogger.info('Uploading waveform thumbnail to backend')
-
-      const uploadResult = await this.thumbnailApiService.uploadSoundWaveform(
-        job.soundId,
-        tempOutputPath,
-        job.soundHash
-      )
-
-      if (!uploadResult.success) {
-        throw new Error(
-          `Failed to upload waveform thumbnail: ${uploadResult.error}`
-        )
-      }
-
-      jobLogger.info('Waveform thumbnail uploaded successfully', {
-        storagePath: uploadResult.storagePath,
-        sizeBytes: uploadResult.sizeBytes,
-      })
-
-      return {
-        waveformPath: uploadResult.storagePath,
-        sizeBytes: uploadResult.sizeBytes,
-      }
-    } catch (error) {
-      jobLogger.error('Sound waveform generation failed', {
-        error: error.message,
-        stack: error.stack,
-      })
-      throw error
-    } finally {
-      // Clean up temporary files
-      if (tempFilePath) {
-        this.soundFileService.cleanupFile(tempFilePath)
-
-        // Also cleanup the waveform output file
-        const tempOutputPath = `${tempFilePath}.waveform.png`
-        this.soundFileService.cleanupFile(tempOutputPath)
-      }
-    }
-  }
-
-  /**
    * Start periodic cleanup of temporary files
    */
   startPeriodicCleanup() {
@@ -964,11 +425,6 @@ export class JobProcessor {
 
             // Clean up old texture files
             await this.modelDataService.cleanupOldTextureFiles()
-
-            // Also cleanup old frame encoder files if encoder is initialized
-            if (this.frameEncoder) {
-              await this.frameEncoder.cleanupOldFiles()
-            }
           } catch (error) {
             logger.warn('Periodic cleanup failed', { error: error.message })
           }
@@ -1011,19 +467,8 @@ export class JobProcessor {
       this.jobQueue = [] // Clear the queue
     }
 
-    // Dispose of Puppeteer renderer resources
-    if (this.puppeteerRenderer) {
-      await this.puppeteerRenderer.dispose()
-      this.puppeteerRenderer = null
-    }
-
-    // Clean up frame encoder resources
-    if (this.frameEncoder) {
-      await this.frameEncoder.cleanupOldFiles(0) // Clean all files immediately
-      this.frameEncoder = null
-    }
-
-    // Clean up all registered processors
+    // Clean up all registered processors (each owns its own RendererPool /
+    // FrameEncoderService and releases them here)
     if (this.processorRegistry) {
       await this.processorRegistry.cleanupAll()
     }

--- a/src/asset-processor/processors/baseProcessor.js
+++ b/src/asset-processor/processors/baseProcessor.js
@@ -29,9 +29,14 @@ export class BaseProcessor {
   /**
    * Execute the full job lifecycle: start → process → complete/fail.
    * @param {Object} job - The dequeued job object from the API.
+   * @param {AbortSignal} [signal] - Aborted by the job queue when this job's
+   *   timeout fires. Threaded through to process() so cancellable awaits can
+   *   stop early; also used here to avoid double-reporting a job's outcome
+   *   to the backend (which has no guard against being finished twice) once
+   *   the queue's timeout handler has already reported it as failed.
    * @returns {Promise<void>}
    */
-  async execute(job) {
+  async execute(job, signal) {
     const assetId =
       job.modelId ||
       job.soundId ||
@@ -49,7 +54,18 @@ export class BaseProcessor {
         job.modelHash || job.soundHash
       )
 
-      const result = await this.process(job, jobLogger)
+      const result = await this.process(job, jobLogger, signal)
+
+      if (signal?.aborted) {
+        // The job queue already timed this job out and reported it failed
+        // while we were still running. Discard this late result instead of
+        // double-finishing the job — a different worker may have already
+        // reclaimed it for retry.
+        jobLogger.warn(
+          `${this.processorType} processing finished after the job had already timed out — discarding stale result`
+        )
+        return
+      }
 
       await this.markCompleted(job, result)
 
@@ -68,12 +84,18 @@ export class BaseProcessor {
         error.stack
       )
 
-      try {
-        await this.markFailed(job, error.message)
-      } catch (markFailedError) {
-        jobLogger.error('Failed to mark job as failed', {
-          markFailedError: markFailedError.message,
-        })
+      if (signal?.aborted) {
+        jobLogger.warn(
+          'Skipping markFailed — job was already finished by the timeout handler'
+        )
+      } else {
+        try {
+          await this.markFailed(job, error.message)
+        } catch (markFailedError) {
+          jobLogger.error('Failed to mark job as failed', {
+            markFailedError: markFailedError.message,
+          })
+        }
       }
 
       throw error
@@ -84,11 +106,47 @@ export class BaseProcessor {
    * Process the job. Must be overridden by subclasses.
    * @param {Object} job - The job to process.
    * @param {Object} jobLogger - Logger with job context.
+   * @param {AbortSignal} [signal] - Set when the job queue times this job
+   *   out. Renderer-backed processors should listen for 'abort' and hand
+   *   their held renderer to `_armRendererAbort()` so the pool slot is
+   *   force-reinitialized instead of left hung.
    * @returns {Promise<Object>} Result metadata.
    */
   // eslint-disable-next-line no-unused-vars
-  async process(job, jobLogger) {
+  async process(job, jobLogger, signal) {
     throw new Error('Subclass must implement process()')
+  }
+
+  /**
+   * Arm an abort listener that force-reinitializes a RendererPool slot when
+   * the job holding it times out. Puppeteer's in-flight page.evaluate()
+   * calls reject once the page is torn down, which unwinds the processor's
+   * own try/finally and returns the slot via the normal `rendererPool
+   * .release()` path — but with a fresh, usable page instead of a hung one.
+   * @param {AbortSignal|undefined} signal
+   * @param {import('../rendererPool.js').RendererPool} rendererPool
+   * @param {*} renderer - The renderer this job currently holds.
+   * @param {Object} jobLogger
+   * @returns {() => void} Disarm function — call it once the renderer has
+   *   been released normally so a later abort (there shouldn't be one) is
+   *   a no-op.
+   */
+  _armRendererAbort(signal, rendererPool, renderer, jobLogger) {
+    if (!signal || !renderer) {
+      return () => {}
+    }
+
+    const onAbort = () => {
+      jobLogger.warn('Job aborted — force-reinitializing renderer pool slot')
+      rendererPool.forceReinit(renderer).catch(reinitError => {
+        jobLogger.error('Failed to force-reinitialize renderer after abort', {
+          error: reinitError.message,
+        })
+      })
+    }
+
+    signal.addEventListener('abort', onAbort)
+    return () => signal.removeEventListener('abort', onAbort)
   }
 
   /**

--- a/src/asset-processor/processors/environmentMapProcessor.js
+++ b/src/asset-processor/processors/environmentMapProcessor.js
@@ -18,9 +18,16 @@ export class EnvironmentMapProcessor extends BaseProcessor {
     return 'environment-map'
   }
 
-  async process(job, jobLogger) {
+  /**
+   * @param {Object} job - The job to process.
+   * @param {Object} jobLogger - Logger with job context.
+   * @param {AbortSignal} [signal] - Set when the job times out; used to
+   *   force-reinitialize the held renderer instead of leaving it hung.
+   */
+  async process(job, jobLogger, signal) {
     let renderer = null
     let source = null
+    let disarmAbort = () => {}
 
     try {
       const environmentMapId = job.environmentMapId
@@ -47,6 +54,12 @@ export class EnvironmentMapProcessor extends BaseProcessor {
       }
 
       renderer = await this.rendererPool.acquire()
+      disarmAbort = this._armRendererAbort(
+        signal,
+        this.rendererPool,
+        renderer,
+        jobLogger
+      )
 
       await renderer.loadEnvironmentPreview(source, config.environmentMaps)
 
@@ -75,6 +88,7 @@ export class EnvironmentMapProcessor extends BaseProcessor {
 
       return storageResult
     } finally {
+      disarmAbort()
       if (renderer) {
         this.rendererPool.release(renderer)
       }

--- a/src/asset-processor/processors/meshProcessor.js
+++ b/src/asset-processor/processors/meshProcessor.js
@@ -79,7 +79,7 @@ export class MeshAnalysisProcessor extends BaseProcessor {
    * @returns {Promise<Object>} Mesh analysis result.
    */
   // eslint-disable-next-line no-unused-vars
-  async process(job, jobLogger) {
+  async process(job, jobLogger, signal) {
     // Guard: Blender must be installed
     if (!config.blender.enabled) {
       throw new Error(

--- a/src/asset-processor/processors/soundProcessor.js
+++ b/src/asset-processor/processors/soundProcessor.js
@@ -25,7 +25,11 @@ export class SoundProcessor extends BaseProcessor {
    * @param {Object} jobLogger - Logger with job context.
    * @returns {Promise<Object>} Waveform metadata { waveformPath, sizeBytes }.
    */
-  async process(job, jobLogger) {
+  // No renderer/RendererPool is held here, so there's nothing for the abort
+  // signal to cancel — accept the standard (job, jobLogger, signal) shape
+  // for consistency but don't use it.
+  // eslint-disable-next-line no-unused-vars
+  async process(job, jobLogger, signal) {
     let tempFilePath = null
 
     try {

--- a/src/asset-processor/processors/textureSetProcessor.js
+++ b/src/asset-processor/processors/textureSetProcessor.js
@@ -33,12 +33,15 @@ export class TextureSetProcessor extends BaseProcessor {
    * Process a texture set thumbnail job.
    * @param {Object} job - The dequeued job object (must have textureSetId).
    * @param {Object} jobLogger - Logger with job context.
+   * @param {AbortSignal} [signal] - Set when the job times out; used to
+   *   force-reinitialize the held renderer instead of leaving it hung.
    * @returns {Promise<Object>} Thumbnail metadata.
    */
-  async process(job, jobLogger) {
+  async process(job, jobLogger, signal) {
     let texturePaths = null
 
     let renderer = null
+    let disarmAbort = () => {}
 
     try {
       const textureSetId = job.textureSetId
@@ -106,6 +109,12 @@ export class TextureSetProcessor extends BaseProcessor {
       }
 
       renderer = await this.rendererPool.acquire()
+      disarmAbort = this._armRendererAbort(
+        signal,
+        this.rendererPool,
+        renderer,
+        jobLogger
+      )
 
       // Use the stored preview geometry type (defaults to plane)
       const geometryType = textureSet.previewGeometryType || 'plane'
@@ -197,6 +206,7 @@ export class TextureSetProcessor extends BaseProcessor {
         'Thumbnail upload failed — no valid thumbnail data available'
       )
     } finally {
+      disarmAbort()
       if (renderer) {
         this.rendererPool.release(renderer)
       }

--- a/src/asset-processor/processors/thumbnailProcessor.js
+++ b/src/asset-processor/processors/thumbnailProcessor.js
@@ -37,13 +37,16 @@ export class ThumbnailProcessor extends BaseProcessor {
    * Process a model thumbnail job.
    * @param {Object} job - The job to process.
    * @param {Object} jobLogger - Logger with job context.
+   * @param {AbortSignal} [signal] - Set when the job times out; used to
+   *   force-reinitialize the held renderer instead of leaving it hung.
    * @returns {Promise<Object>} Thumbnail metadata { thumbnailPath, sizeBytes, width, height }.
    */
-  async process(job, jobLogger) {
+  async process(job, jobLogger, signal) {
     let tempFilePath = null
     let glbConvertedPath = null
     let texturePaths = null
     let renderer = null
+    let disarmAbort = () => {}
 
     try {
       jobLogger.info('Starting model processing', {
@@ -192,6 +195,12 @@ export class ThumbnailProcessor extends BaseProcessor {
       }
 
       renderer = await this.rendererPool.acquire()
+      disarmAbort = this._armRendererAbort(
+        signal,
+        this.rendererPool,
+        renderer,
+        jobLogger
+      )
 
       // The "Embedded" variant (__embedded__) means "render the model's own
       // materials / vertex colors" — keep them instead of the neutral override.
@@ -294,6 +303,7 @@ export class ThumbnailProcessor extends BaseProcessor {
         'Thumbnail upload failed — no valid thumbnail data available'
       )
     } finally {
+      disarmAbort()
       if (renderer) {
         this.rendererPool.release(renderer)
       }

--- a/src/asset-processor/puppeteerRenderer.js
+++ b/src/asset-processor/puppeteerRenderer.js
@@ -258,6 +258,16 @@ export class PuppeteerRenderer {
   }
 
   /**
+   * Public entry point for forcing reinitialization from outside this
+   * renderer — used by RendererPool.forceReinit() when the job holding
+   * this renderer times out. Same crash-recovery path as the internal
+   * page-crash/frame-detach handling.
+   */
+  async reinitialize() {
+    await this._reinitialize()
+  }
+
+  /**
    * Start a local HTTP file server for serving texture files to the browser.
    * This avoids encoding all textures as base64 and sending them through CDP,
    * which causes Chromium OOM crashes with large (4K) textures.

--- a/src/asset-processor/rendererPool.js
+++ b/src/asset-processor/rendererPool.js
@@ -98,6 +98,24 @@ export class RendererPool {
   }
 
   /**
+   * Force a specific renderer to reinitialize — used when the job holding
+   * it times out. Reuses the renderer's own crash-recovery machinery (the
+   * same path taken when a page detaches/crashes mid-render) so the pool
+   * gets back a USABLE renderer instead of one still stuck mid-render.
+   *
+   * This only repairs the renderer in place; it does not touch `available`
+   * or `_waiting`. The caller (the abandoned job's own processor, reacting
+   * to the same abort) is still responsible for eventually calling
+   * `release()` once its try/finally unwinds.
+   * @param {PuppeteerRenderer} renderer
+   */
+  async forceReinit(renderer) {
+    if (!renderer) return
+    logger.warn('Force-reinitializing renderer pool slot (job aborted)')
+    await renderer.reinitialize()
+  }
+
+  /**
    * Shut down all renderers and the shared browser.
    */
   async dispose() {

--- a/src/asset-processor/tests/baseProcessor.test.js
+++ b/src/asset-processor/tests/baseProcessor.test.js
@@ -162,6 +162,131 @@ describe('BaseProcessor', () => {
     })
   })
 
+  describe('abort signal (timeout cancellation)', () => {
+    it('passes the abort signal through to process()', async () => {
+      const controller = new AbortController()
+      processor.process = vi.fn().mockResolvedValue({ ok: true })
+
+      await processor.execute(mockJob, controller.signal)
+
+      expect(processor.process).toHaveBeenCalledWith(
+        mockJob,
+        expect.anything(),
+        controller.signal
+      )
+    })
+
+    it('discards a stale success instead of double-completing an aborted job', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      processor._processResult = { thumbnailPath: '/path' }
+
+      await processor.execute(mockJob, controller.signal)
+
+      expect(mockMarkJobCompleted).not.toHaveBeenCalled()
+      expect(mockLogJobCompleted).not.toHaveBeenCalled()
+    })
+
+    it('does not call markFailed a second time for an already-timed-out job', async () => {
+      const controller = new AbortController()
+      controller.abort()
+      processor.process = vi.fn().mockRejectedValue(new Error('boom'))
+
+      await expect(
+        processor.execute(mockJob, controller.signal)
+      ).rejects.toThrow('boom')
+
+      // The job queue's timeout handler already reported this job failed —
+      // the backend has no double-finish guard, so a second markFailed call
+      // here could clobber a job a different worker has since reclaimed.
+      expect(mockMarkJobFailed).not.toHaveBeenCalled()
+      // Still logs the failure event for visibility.
+      expect(mockLogJobFailed).toHaveBeenCalledWith(
+        42,
+        'boom',
+        expect.any(String)
+      )
+    })
+
+    it('still marks completed/failed normally when no signal is provided', async () => {
+      const result = { thumbnailPath: '/path' }
+      processor._processResult = result
+
+      await processor.execute(mockJob)
+
+      expect(mockMarkJobCompleted).toHaveBeenCalledWith(42, result)
+    })
+  })
+
+  describe('_armRendererAbort', () => {
+    it('is a no-op when no signal or no renderer is provided', () => {
+      const jobLogger = { warn: vi.fn(), error: vi.fn() }
+      const pool = { forceReinit: vi.fn() }
+
+      expect(() =>
+        processor._armRendererAbort(undefined, pool, {}, jobLogger)()
+      ).not.toThrow()
+      expect(() =>
+        processor._armRendererAbort(
+          new AbortController().signal,
+          pool,
+          null,
+          jobLogger
+        )()
+      ).not.toThrow()
+      expect(pool.forceReinit).not.toHaveBeenCalled()
+    })
+
+    it('force-reinitializes the renderer pool slot when the signal aborts', () => {
+      const controller = new AbortController()
+      const renderer = { id: 'renderer-1' }
+      const jobLogger = { warn: vi.fn(), error: vi.fn() }
+      const forceReinit = vi.fn().mockResolvedValue(undefined)
+      const pool = { forceReinit }
+
+      processor._armRendererAbort(controller.signal, pool, renderer, jobLogger)
+      controller.abort()
+
+      expect(forceReinit).toHaveBeenCalledWith(renderer)
+    })
+
+    it('logs but does not throw when force-reinit fails', async () => {
+      const controller = new AbortController()
+      const jobLogger = { warn: vi.fn(), error: vi.fn() }
+      const forceReinit = vi.fn().mockRejectedValue(new Error('reinit boom'))
+      const pool = { forceReinit }
+
+      processor._armRendererAbort(controller.signal, pool, {}, jobLogger)
+      controller.abort()
+
+      // Let the fire-and-forget rejection handler run.
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(jobLogger.error).toHaveBeenCalledWith(
+        'Failed to force-reinitialize renderer after abort',
+        expect.objectContaining({ error: 'reinit boom' })
+      )
+    })
+
+    it('disarm() removes the abort listener', () => {
+      const controller = new AbortController()
+      const jobLogger = { warn: vi.fn(), error: vi.fn() }
+      const forceReinit = vi.fn().mockResolvedValue(undefined)
+      const pool = { forceReinit }
+
+      const disarm = processor._armRendererAbort(
+        controller.signal,
+        pool,
+        {},
+        jobLogger
+      )
+      disarm()
+      controller.abort()
+
+      expect(forceReinit).not.toHaveBeenCalled()
+    })
+  })
+
   describe('cleanup', () => {
     it('should be a no-op by default', async () => {
       await expect(processor.cleanup()).resolves.toBeUndefined()

--- a/src/asset-processor/tests/jobProcessor.test.js
+++ b/src/asset-processor/tests/jobProcessor.test.js
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies
+vi.mock('../logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+  withJobContext: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  })),
+}))
+
+const mockMarkJobFailed = vi.fn()
+const mockTestConnection = vi.fn()
+const mockPollForJob = vi.fn()
+
+vi.mock('../jobApiClient.js', () => ({
+  JobApiClient: vi.fn(function () {
+    this.testConnection = mockTestConnection
+    this.markJobFailed = mockMarkJobFailed
+    this.pollForJob = mockPollForJob
+  }),
+}))
+
+vi.mock('../signalrQueueService.js', () => ({
+  SignalRQueueService: vi.fn(function () {
+    this.onJobReceived = vi.fn()
+    this.start = vi.fn().mockResolvedValue(true)
+    this.stop = vi.fn().mockResolvedValue(undefined)
+    this.acknowledgeJob = vi.fn()
+    this.connected = true
+  }),
+}))
+
+vi.mock('../modelFileService.js', () => ({
+  ModelFileService: vi.fn(function () {
+    this.cleanupOldFiles = vi.fn()
+  }),
+}))
+
+vi.mock('../modelDataService.js', () => ({
+  ModelDataService: vi.fn(function () {
+    this.cleanupOldTextureFiles = vi.fn()
+  }),
+}))
+
+vi.mock('../processors/processorRegistry.js', () => ({
+  ProcessorRegistry: vi.fn(function () {
+    this.getProcessor = vi.fn()
+    this.cleanupAll = vi.fn()
+  }),
+}))
+
+const mockRefreshBlender = vi.fn().mockResolvedValue(undefined)
+const mockRefreshThumbnailRender = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../config.js', () => ({
+  config: {
+    workerId: 'test-worker',
+    modelProcessing: {},
+    maxConcurrentJobs: 1,
+    jobTimeout: 30,
+  },
+  refreshBlenderConfigFromApi: (...args) => mockRefreshBlender(...args),
+  refreshThumbnailRenderConfigFromApi: (...args) =>
+    mockRefreshThumbnailRender(...args),
+}))
+
+const { JobProcessor } = await import('../jobProcessor.js')
+
+describe('JobProcessor timeout cancellation', () => {
+  let processor
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRefreshBlender.mockResolvedValue(undefined)
+    mockRefreshThumbnailRender.mockResolvedValue(undefined)
+    mockMarkJobFailed.mockResolvedValue(undefined)
+    processor = new JobProcessor()
+  })
+
+  it('frees a renderer-pool slot after a job times out, so a subsequent job can complete', async () => {
+    // A minimal fake "renderer pool" with capacity 1, mirroring the
+    // contract real processors are expected to honor: acquire a slot, and
+    // on abort force-reinit it instead of leaving it hung.
+    let slotHeld = false
+    const fakePool = {
+      acquire: () => {
+        if (slotHeld) {
+          throw new Error('slot already held — pool exhausted')
+        }
+        slotHeld = true
+        return 'the-renderer'
+      },
+      forceReinit: () => {
+        slotHeld = false
+      },
+      release: () => {
+        slotHeld = false
+      },
+    }
+
+    // job1's processor acquires the only slot and then hangs forever —
+    // like a Puppeteer page.evaluate() that never settles on its own. It
+    // only frees the slot if the queue aborts it.
+    const job1Processor = (job, signal) =>
+      new Promise((_resolve, reject) => {
+        fakePool.acquire()
+        signal.addEventListener('abort', () => {
+          fakePool.forceReinit()
+          reject(new Error('job1 aborted'))
+        })
+      })
+
+    let job2Completed = false
+    const job2Processor = async () => {
+      // Throws if job1 still holds the slot — proving the pool actually
+      // recovered instead of deadlocking.
+      fakePool.acquire()
+      job2Completed = true
+      fakePool.release()
+      return { ok: true }
+    }
+
+    processor.jobQueue.push({ job: { id: 1 }, processor: job1Processor })
+    await processor.processQueue()
+
+    // The 30ms job timeout should have fired, aborted the fake processor,
+    // reported the job failed, and freed the slot.
+    expect(mockMarkJobFailed).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('timed out')
+    )
+    expect(slotHeld).toBe(false)
+    expect(processor.activeJobs.has(1)).toBe(false)
+
+    // A second job queued afterwards should be able to acquire the slot and
+    // complete normally.
+    processor.jobQueue.push({ job: { id: 2 }, processor: job2Processor })
+    await processor.processQueue()
+
+    expect(job2Completed).toBe(true)
+  })
+
+  it('clears the timeout timer on normal completion (no late failure report)', async () => {
+    const job1Processor = vi.fn().mockResolvedValue({ ok: true })
+
+    processor.jobQueue.push({ job: { id: 10 }, processor: job1Processor })
+    await processor.processQueue()
+
+    expect(job1Processor).toHaveBeenCalledTimes(1)
+    expect(mockMarkJobFailed).not.toHaveBeenCalled()
+
+    // Wait past the configured job timeout (30ms) — if the timer wasn't
+    // cleared, it would still fire and report a bogus timeout failure for
+    // a job that already finished.
+    await new Promise(resolve => setTimeout(resolve, 60))
+
+    expect(mockMarkJobFailed).not.toHaveBeenCalled()
+  })
+
+  it('does not double-report a non-timeout failure the processor already reported itself', async () => {
+    // Simulates a BaseProcessor.execute() that already called markFailed
+    // internally before rethrowing — jobProcessor must not call
+    // markJobFailed again for the same job.
+    const job1Processor = vi.fn().mockRejectedValue(new Error('render crash'))
+
+    processor.jobQueue.push({ job: { id: 20 }, processor: job1Processor })
+    await processor.processQueue()
+
+    expect(mockMarkJobFailed).not.toHaveBeenCalled()
+  })
+
+  it('defensively marks a job failed when it fails before the processor ever runs', async () => {
+    mockRefreshBlender.mockRejectedValueOnce(new Error('settings API down'))
+    const job1Processor = vi.fn()
+
+    processor.jobQueue.push({ job: { id: 30 }, processor: job1Processor })
+    await processor.processQueue()
+
+    expect(job1Processor).not.toHaveBeenCalled()
+    expect(mockMarkJobFailed).toHaveBeenCalledWith(30, 'settings API down')
+  })
+})

--- a/src/asset-processor/tests/rendererPool.test.js
+++ b/src/asset-processor/tests/rendererPool.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Regression coverage for the timeout-cancellation "force-reinit" path
+// (prompt 41): when a job times out, jobProcessor.js aborts it and the
+// processor hands its held renderer to RendererPool.forceReinit(), which
+// must reuse PuppeteerRenderer's own crash-recovery path so the pool gets
+// back a USABLE renderer instead of a hung page. This uses the REAL
+// RendererPool with a stubbed PuppeteerRenderer (no real Chromium).
+
+vi.mock('../logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('../config.js', () => ({
+  config: { maxConcurrentJobs: 3 },
+}))
+
+const mockLaunch = vi.fn()
+vi.mock('puppeteer', () => ({
+  default: { launch: (...args) => mockLaunch(...args) },
+}))
+
+const mockInitialize = vi.fn()
+const mockReinitialize = vi.fn()
+
+vi.mock('../puppeteerRenderer.js', () => {
+  const PuppeteerRenderer = vi.fn(function (sharedBrowser) {
+    this.browser = sharedBrowser || null
+    this.page = { closed: false }
+    this.initialize = (...args) => mockInitialize(...args)
+    this.reinitialize = (...args) => mockReinitialize(...args)
+  })
+  PuppeteerRenderer.getLaunchOptions = vi.fn(() => ({}))
+  return { PuppeteerRenderer }
+})
+
+const { RendererPool } = await import('../rendererPool.js')
+
+describe('RendererPool.forceReinit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLaunch.mockResolvedValue({ close: vi.fn() })
+    mockInitialize.mockResolvedValue(true)
+    mockReinitialize.mockResolvedValue(undefined)
+  })
+
+  it('reinitializes the renderer in place instead of tearing down the whole pool', async () => {
+    const pool = new RendererPool(1)
+    await pool.initialize()
+
+    const renderer = await pool.acquire()
+    expect(renderer).toBeDefined()
+
+    await pool.forceReinit(renderer)
+
+    expect(mockReinitialize).toHaveBeenCalledTimes(1)
+    // Only the renderer's own page/browser recovery ran — the pool's shared
+    // browser was launched once at initialize() and never relaunched.
+    expect(mockLaunch).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op for a null/undefined renderer', async () => {
+    const pool = new RendererPool(1)
+    await pool.initialize()
+
+    await expect(pool.forceReinit(null)).resolves.toBeUndefined()
+    expect(mockReinitialize).not.toHaveBeenCalled()
+  })
+
+  it('hands the reinitialized renderer to the next acquire() after release', async () => {
+    const pool = new RendererPool(1)
+    await pool.initialize()
+
+    const renderer = await pool.acquire()
+    await pool.forceReinit(renderer)
+    pool.release(renderer)
+
+    const nextRenderer = await pool.acquire()
+    expect(nextRenderer).toBe(renderer)
+  })
+
+  it('propagates reinit failures to the caller instead of silently losing the slot', async () => {
+    const pool = new RendererPool(1)
+    await pool.initialize()
+    const renderer = await pool.acquire()
+
+    mockReinitialize.mockRejectedValueOnce(new Error('chrome crashed harder'))
+
+    await expect(pool.forceReinit(renderer)).rejects.toThrow(
+      'chrome crashed harder'
+    )
+  })
+})


### PR DESCRIPTION
## What (prompt 41 — the worker's zombie-slot deadlock + drift trap)

### Dead legacy pipeline deleted
- `jobProcessor.js`: **1080 → 525 lines**. Removed the pre-`ProcessorRegistry` inline pipeline (`processModelJobAsync`, `processSoundJobAsync`, `processModel` ~385 lines, `processSound`), the legacy `puppeteerRenderer` field, and seven imports/service instances that existed only for that path — all with zero call sites (grep-verified, including dynamic references).
- **Mandated drift diff before deletion:** compared the dead copies line-by-line against the live `thumbnailProcessor`/`soundProcessor` and cross-checked git history — no commit ever touched the dead bodies post-registry, so **nothing existed only in the dead copy; nothing to port**.
- Incidental finds fixed: the periodic frame-encoder cleanup was a production no-op (only the dead path populated it), and `activeJobs` — which `/health` and `/metrics` (`worker_active_jobs`) report — always read zero; it now tracks real concurrent jobs.

### Job timeouts now cancel instead of abandoning
- Previously `Promise.race` marked the job failed on timeout while the processor **kept running and kept its `RendererPool` slot** — a hung Puppeteer page + backend retries eventually starved every slot; the worker deadlocked while `/health` stayed green.
- Now: an `AbortController` per job threads through `BaseProcessor.execute() → process(job, logger, signal)`. Renderer-backed processors arm the signal right after `acquire()` via `BaseProcessor._armRendererAbort()`; on abort, `RendererPool.forceReinit()` reuses `PuppeteerRenderer`'s existing crash-recovery path so the pool gets back a **usable** renderer. Closing the page also makes the abandoned in-flight `page.evaluate()` reject, unwinding the orphaned processor's own `finally` normally.
- Timeout timer cleared on every settle path. Backend double-finish semantics were **checked, not guessed**: `ThumbnailJob.MarkAsCompleted/MarkAsFailed` overwrite unconditionally, so a `signal.aborted` guard discards late results instead of re-reporting a job the timeout already resolved. Errors occurring before the processor runs (config refresh failures) are now reported instead of silently swallowed.
- `asset-processor-patterns` skill updated in-session: dead-pipeline TRAP removed, stale timeout TRAP replaced with the actual cancellation contract.

## Verification
- Worker: 95 Vitest tests passed (incl. new regression suite: pool-of-1 + never-resolving processor → slot usable after timeout, subsequent job completes; real `RendererPool` + stubbed renderer covering `forceReinit`), lint clean, format clean.
- **Live compose-stack smoke:** happy path — uploaded an STL, thumbnail reached `Ready` (1024×1024). Timeout path — with `JOB_TIMEOUT_MS=1500` (shorter than the render), two consecutive timeouts each showed: timeout → abort → forced renderer reinit (`Target closed` on the abandoned call) → double-finish guard skipping redundant `markFailed` → next job immediately acquiring and rendering. **No deadlock across repeated timeouts.**