### PR TITLE
feat(demo): seed Base Meshes (CC0) pack from remote fork URLs

### DIFF
--- a/src/frontend/src/mocks/db/__tests__/baseMeshesSeed.test.ts
+++ b/src/frontend/src/mocks/db/__tests__/baseMeshesSeed.test.ts
@@ -1,0 +1,71 @@
+import {
+  BASE_MESHES_COMMIT,
+  BASE_MESHES_PACK_ID,
+  baseMeshFileAssets,
+  baseMeshRemoteThumbnails,
+  buildBaseMeshSeed,
+} from '../baseMeshesSeed'
+
+// The Base Meshes demo pack is stitched together across three modules
+// (demoDb seeding, the seedFileAssets map, the seedRemoteThumbnails map)
+// keyed only by generated ids. An id-scheme drift between them doesn't
+// throw — it silently produces 404 files or endlessly "generating"
+// thumbnails in the hosted demo. These tests pin the cross-module contract.
+describe('baseMeshesSeed', () => {
+  const now = '2026-07-12T00:00:00.000Z'
+  const { models, versions, pack } = buildBaseMeshSeed(now)
+  const fileAssets = baseMeshFileAssets()
+  const remoteThumbnails = baseMeshRemoteThumbnails()
+
+  it('links every model to exactly one version sharing its single file', () => {
+    expect(models.length).toBeGreaterThan(0)
+    for (const model of models) {
+      expect(model.files).toHaveLength(1)
+      const version = versions.find(v => v.id === model.activeVersionId)
+      expect(version).toBeDefined()
+      expect(version!.modelId).toBe(model.id)
+      expect(version!.files[0].id).toBe(model.files[0].id)
+    }
+  })
+
+  it('keeps seeded ids above the demo id sequences (start at 100/1000)', () => {
+    // Collision here would let a user-created model overwrite a seeded one.
+    for (const model of models) expect(model.id).toBeGreaterThan(1000)
+    for (const version of versions) expect(version.id).toBeGreaterThan(1000)
+    for (const model of models) expect(model.files[0].id).toBeGreaterThan(1000)
+  })
+
+  it('serves every model file from the pinned fork commit', () => {
+    for (const model of models) {
+      const url = fileAssets[model.files[0].id]
+      expect(url).toBeDefined()
+      expect(url).toContain(BASE_MESHES_COMMIT)
+      expect(url.endsWith(`/${model.files[0].originalFileName}`)).toBe(true)
+    }
+  })
+
+  it('provides a remote animated thumbnail for every model and version', () => {
+    for (const model of models) {
+      expect(remoteThumbnails[`model:${model.id}`]).toMatch(/\.webp$/)
+    }
+    for (const version of versions) {
+      expect(remoteThumbnails[`version:${version.id}`]).toMatch(/\.webp$/)
+    }
+  })
+
+  it('keeps the pack membership and counts consistent', () => {
+    expect(pack.id).toBe(BASE_MESHES_PACK_ID)
+    expect(pack.modelCount).toBe(models.length)
+    expect(pack.models.map(m => m.id)).toEqual(models.map(m => m.id))
+    for (const model of models) {
+      expect(model.packs).toEqual([{ id: pack.id, name: pack.name }])
+    }
+  })
+
+  it('credits the CC0 sources on the pack', () => {
+    expect(pack.licenseType).toBe('CC0')
+    expect(pack.url).toBe('https://www.thebasemesh.com/')
+    expect(pack.description).toContain('thebasemesh.com')
+    expect(pack.description).toContain('M3-org/base-meshes')
+  })
+})

--- a/src/frontend/src/mocks/db/baseMeshesSeed.ts
+++ b/src/frontend/src/mocks/db/baseMeshesSeed.ts
@@ -1,0 +1,220 @@
+/**
+ * "Base Meshes (CC0)" demo pack — a curated subset of the base-meshes content
+ * repo, served remotely so no binaries live in this repository.
+ *
+ * Credits: meshes by The Base Mesh (https://www.thebasemesh.com/, CC0 1.0),
+ * glTF conversion by https://github.com/M3-org/base-meshes, thumbnails
+ * rendered with Modelibr's own asset-processor pipeline in the fork
+ * https://github.com/Papyszoo/base-meshes.
+ *
+ * URLs are pinned to a commit SHA so upstream pushes can never break the demo.
+ * Each model folder provides `{name}.glb` plus pipeline-identical thumbnails
+ * (`{name}.webp` animated turntable, `{name}.png` static fallback).
+ */
+import type { DemoModel, DemoModelVersion, DemoPack } from './demoDb'
+
+export const BASE_MESHES_COMMIT = '792e14d4f80d6345c2382d13c17dd9f862fb3a75'
+
+const RAW_BASE = `https://raw.githubusercontent.com/Papyszoo/base-meshes/${BASE_MESHES_COMMIT}/models`
+
+export const BASE_MESHES_PACK_ID = 3
+
+// Seeded ids live far above the demo id sequences (which start at 100) so
+// user-created entities can never collide with them.
+const MODEL_ID_BASE = 7000
+const FILE_ID_BASE = 7000
+const VERSION_ID_BASE = 7000
+
+interface BaseMeshEntry {
+  name: string
+  sizeBytes: number
+}
+
+// Curated subset (54 of ~900); sizes are the real GLB byte counts.
+const BASE_MESHES: BaseMeshEntry[] = [
+  { name: 'anvil', sizeBytes: 27964 },
+  { name: 'axe', sizeBytes: 22292 },
+  { name: 'battle_axe', sizeBytes: 46272 },
+  { name: 'bronze_age_sword', sizeBytes: 59844 },
+  { name: 'dagger', sizeBytes: 23600 },
+  { name: 'halberd', sizeBytes: 26776 },
+  { name: 'round_shield', sizeBytes: 48880 },
+  { name: 'breastplate_armour_01', sizeBytes: 52256 },
+  { name: 'iron_brazier_01', sizeBytes: 69384 },
+  { name: 'iron_chandelier', sizeBytes: 753100 },
+  { name: 'goblet_01', sizeBytes: 41444 },
+  { name: 'scroll_01', sizeBytes: 19976 },
+  { name: 'ornate_key', sizeBytes: 75616 },
+  { name: 'padlock', sizeBytes: 28780 },
+  { name: 'wood_barrel', sizeBytes: 133692 },
+  { name: 'wooden_crate_01', sizeBytes: 62624 },
+  { name: 'wooden_ladder', sizeBytes: 16212 },
+  { name: 'japanese_stone_lantern_01', sizeBytes: 58916 },
+  { name: 'torii_gate_01', sizeBytes: 29140 },
+  { name: 'greek_column_02', sizeBytes: 225040 },
+  { name: 'greek_vase_01', sizeBytes: 80784 },
+  { name: 'obelisk_01', sizeBytes: 5004 },
+  { name: 'headstone_01', sizeBytes: 5208 },
+  { name: 'stone_archway_01', sizeBytes: 9640 },
+  { name: 'oil_barrel', sizeBytes: 99484 },
+  { name: 'traffic_cone_01', sizeBytes: 28388 },
+  { name: 'pallet', sizeBytes: 27760 },
+  { name: 'crowbar', sizeBytes: 17068 },
+  { name: 'sledgehammer', sizeBytes: 31780 },
+  { name: 'pick_axe', sizeBytes: 22300 },
+  { name: 'shovel_01', sizeBytes: 62404 },
+  { name: 'lamp_post_01', sizeBytes: 139956 },
+  { name: 'park_bench', sizeBytes: 71556 },
+  { name: 'retro_tv', sizeBytes: 239692 },
+  { name: 'retro_computer', sizeBytes: 65280 },
+  { name: 'vintage_phone', sizeBytes: 473288 },
+  { name: 'computer_keyboard', sizeBytes: 107104 },
+  { name: 'computer_mouse_01', sizeBytes: 17808 },
+  { name: 'microwave', sizeBytes: 73572 },
+  { name: 'piano', sizeBytes: 467348 },
+  { name: 'electric_guitar', sizeBytes: 2388052 },
+  { name: 'acoustic_guitar', sizeBytes: 366932 },
+  { name: 'skateboard_setup', sizeBytes: 1289036 },
+  { name: 'globe', sizeBytes: 50636 },
+  { name: 'wall_clock', sizeBytes: 20040 },
+  { name: 'wine_bottle', sizeBytes: 26088 },
+  { name: 'mug', sizeBytes: 29464 },
+  { name: 'teapot', sizeBytes: 129812 },
+  { name: 'deer_head', sizeBytes: 38424 },
+  { name: 'ship_wheel', sizeBytes: 620828 },
+  { name: 'd20_dice', sizeBytes: 11048 },
+  { name: 'health', sizeBytes: 13180 },
+  { name: 'question_mark', sizeBytes: 11396 },
+  { name: 'location_marker', sizeBytes: 6948 },
+]
+
+const glbUrl = (name: string) => `${RAW_BASE}/${name}/${name}.glb`
+const webpUrl = (name: string) => `${RAW_BASE}/${name}/${name}.webp`
+
+const displayName = (name: string) =>
+  name
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+
+const modelId = (index: number) => MODEL_ID_BASE + index + 1
+const fileId = (index: number) => FILE_ID_BASE + index + 1
+const versionId = (index: number) => VERSION_ID_BASE + index + 1
+
+/** fileId → absolute GLB URL, merged into the seed static-asset map. */
+export function baseMeshFileAssets(): Record<number, string> {
+  const map: Record<number, string> = {}
+  BASE_MESHES.forEach((entry, index) => {
+    map[fileId(index)] = glbUrl(entry.name)
+  })
+  return map
+}
+
+/**
+ * entityKey ("model:{id}" / "version:{id}") → remote animated-WebP thumbnail.
+ * Served instead of generating a thumbnail in the browser.
+ */
+export function baseMeshRemoteThumbnails(): Record<string, string> {
+  const map: Record<string, string> = {}
+  BASE_MESHES.forEach((entry, index) => {
+    map[`model:${modelId(index)}`] = webpUrl(entry.name)
+    map[`version:${versionId(index)}`] = webpUrl(entry.name)
+  })
+  return map
+}
+
+export function buildBaseMeshSeed(now: string): {
+  models: DemoModel[]
+  versions: DemoModelVersion[]
+  pack: DemoPack
+} {
+  const packRef = { id: BASE_MESHES_PACK_ID, name: 'Base Meshes (CC0)' }
+
+  const models: DemoModel[] = BASE_MESHES.map((entry, index) => ({
+    id: modelId(index),
+    name: displayName(entry.name),
+    description: `CC0 base mesh from thebasemesh.com (via M3-org/base-meshes).`,
+    tags: ['cc0', 'base mesh'],
+    files: [
+      {
+        id: fileId(index),
+        originalFileName: `${entry.name}.glb`,
+        storedFileName: `${entry.name}.glb`,
+        filePath: `${entry.name}.glb`,
+        mimeType: 'model/gltf-binary',
+        sizeBytes: entry.sizeBytes,
+        sha256Hash: `base-mesh-${entry.name}`,
+        fileType: 'glb',
+        isRenderable: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    createdAt: now,
+    updatedAt: now,
+    activeVersionId: versionId(index),
+    defaultTextureSetId: null,
+    categoryId: null,
+    conceptImages: [],
+    textureSets: [],
+    packs: [packRef],
+    projects: [],
+  }))
+
+  const versions: DemoModelVersion[] = BASE_MESHES.map((entry, index) => ({
+    id: versionId(index),
+    modelId: modelId(index),
+    versionNumber: 1,
+    description: 'Imported from Base Meshes (CC0)',
+    createdAt: now,
+    defaultTextureSetId: null,
+    thumbnailUrl: null,
+    pngThumbnailUrl: null,
+    files: [
+      {
+        id: fileId(index),
+        originalFileName: `${entry.name}.glb`,
+        mimeType: 'model/gltf-binary',
+        fileType: 'glb',
+        sizeBytes: entry.sizeBytes,
+        isRenderable: true,
+      },
+    ],
+    materialNames: [],
+    mainVariantName: '',
+    variantNames: [],
+    textureMappings: [],
+    textureSetIds: [],
+  }))
+
+  const pack: DemoPack = {
+    id: BASE_MESHES_PACK_ID,
+    name: packRef.name,
+    description:
+      'CC0 base meshes by The Base Mesh (thebasemesh.com), converted to glTF ' +
+      'by the M3-org/base-meshes project. Real-world scale with basic UVs — ' +
+      'free for any use, no attribution required.',
+    licenseType: 'CC0',
+    url: 'https://www.thebasemesh.com/',
+    createdAt: now,
+    updatedAt: now,
+    modelCount: models.length,
+    globalMaterialCount: 0,
+    multiModelTextureCount: 0,
+    spriteCount: 0,
+    soundCount: 0,
+    scriptCount: 0,
+    environmentMapCount: 0,
+    isEmpty: false,
+    customThumbnailFileId: null,
+    customThumbnailUrl: null,
+    models: models.map(m => ({ id: m.id, name: m.name })),
+    textureSets: [],
+    sprites: [],
+    sounds: [],
+    scripts: [],
+    environmentMaps: [],
+  }
+
+  return { models, versions, pack }
+}

--- a/src/frontend/src/mocks/db/demoDb.ts
+++ b/src/frontend/src/mocks/db/demoDb.ts
@@ -9,6 +9,8 @@
  */
 import { type DBSchema, type IDBPDatabase, openDB } from 'idb'
 
+import { buildBaseMeshSeed } from './baseMeshesSeed'
+
 // ─── Schema ─────────────────────────────────────────────────────────────
 
 export interface DemoFile {
@@ -635,6 +637,7 @@ export async function seedIfEmpty(): Promise<void> {
   if (modelCount > 0) return // already seeded
 
   const now = new Date().toISOString()
+  const baseMeshSeed = buildBaseMeshSeed(now)
 
   const seedModels: DemoModel[] = [
     {
@@ -1570,6 +1573,9 @@ public class Enemy : MonoBehaviour
   )
   for (const m of seedModels) await tx.objectStore('models').put(m)
   for (const v of seedVersions) await tx.objectStore('modelVersions').put(v)
+  for (const m of baseMeshSeed.models) await tx.objectStore('models').put(m)
+  for (const v of baseMeshSeed.versions)
+    await tx.objectStore('modelVersions').put(v)
   for (const ts of seedTextureSets) await tx.objectStore('textureSets').put(ts)
   for (const sp of seedSprites) await tx.objectStore('sprites').put(sp)
   for (const sn of seedSounds) await tx.objectStore('sounds').put(sn)
@@ -1577,6 +1583,7 @@ public class Enemy : MonoBehaviour
   for (const em of seedEnvironmentMaps)
     await tx.objectStore('environmentMaps').put(em)
   for (const pk of seedPacks) await tx.objectStore('packs').put(pk)
+  await tx.objectStore('packs').put(baseMeshSeed.pack)
   for (const pj of seedProjects) await tx.objectStore('projects').put(pj)
   for (const mc of seedModelCategories)
     await tx.objectStore('modelCategories').put(mc)

--- a/src/frontend/src/mocks/dynamic-demo/shared.ts
+++ b/src/frontend/src/mocks/dynamic-demo/shared.ts
@@ -3,6 +3,10 @@ import { HttpResponse } from 'msw'
 import { TextureSetKind } from '@/types'
 
 import {
+  baseMeshFileAssets,
+  baseMeshRemoteThumbnails,
+} from '../db/baseMeshesSeed'
+import {
   addRecycledItem,
   addUploadHistory,
   type DemoCategory,
@@ -94,8 +98,12 @@ const DEMO_BASE = import.meta.env.BASE_URL ?? '/Modelibr/demo/'
 export const assetUrl = (file: string) => `${DEMO_BASE}demo-assets/${file}`
 export const thumbnailUrl = (file: string) =>
   `${DEMO_BASE}demo-assets/thumbnails/${file}`
-export const seedAssetUrl = (file: string) =>
-  file.startsWith('hdri/') ? `${DEMO_BASE}${file}` : assetUrl(file)
+export const seedAssetUrl = (file: string) => {
+  // Remote seed assets (e.g. the Base Meshes pack served from GitHub raw)
+  // are stored as absolute URLs — pass them through untouched.
+  if (/^https?:\/\//i.test(file)) return file
+  return file.startsWith('hdri/') ? `${DEMO_BASE}${file}` : assetUrl(file)
+}
 
 /**
  * Infer a sensible MIME type for a File/Blob when `file.type` is missing.
@@ -141,8 +149,18 @@ export function inferMimeType(
   }
 }
 
-// Map seed file IDs to static asset paths (for pre-seeded data)
+/**
+ * entityKey ("model:{id}" / "version:{id}") → remote thumbnail URL for seed
+ * data that ships pre-rendered thumbnails (Base Meshes pack). Checked before
+ * falling back to in-browser thumbnail generation.
+ */
+export const seedRemoteThumbnails: Record<string, string> =
+  baseMeshRemoteThumbnails()
+
+// Map seed file IDs to static asset paths (for pre-seeded data).
+// Values may also be absolute URLs (remote seed assets) — see seedAssetUrl.
 export const seedFileAssets: Record<number, string> = {
+  ...baseMeshFileAssets(),
   101: 'test-cube.glb',
   102: 'test-cone.fbx',
   103: 'test-cylinder.fbx',

--- a/src/frontend/src/mocks/dynamicDemoHandlers.ts
+++ b/src/frontend/src/mocks/dynamicDemoHandlers.ts
@@ -47,6 +47,7 @@ import {
   removeThumbnail,
   seedAssetUrl,
   seedFileAssets,
+  seedRemoteThumbnails,
   serveFile,
   storeFileBlob,
   storeThumbnail,
@@ -805,6 +806,11 @@ export const dynamicDemoHandlers = [
         headers: { 'Content-Type': thumb.type || 'image/webp' },
       })
     }
+    // Seed data with pre-rendered remote thumbnails (Base Meshes pack)
+    const remoteThumb = seedRemoteThumbnails[`model:${id}`]
+    if (remoteThumb) {
+      return fetchStaticAsset(remoteThumb, 'image/webp')
+    }
     // Generate a real thumbnail for seed models on first request
     const model = await getById('models', id)
     if (model?.files[0]) {
@@ -1462,6 +1468,11 @@ export const dynamicDemoHandlers = [
       return new HttpResponse(thumb, {
         headers: { 'Content-Type': thumb.type || 'image/webp' },
       })
+    }
+    // Seed data with pre-rendered remote thumbnails (Base Meshes pack)
+    const remoteThumb = seedRemoteThumbnails[`version:${versionId}`]
+    if (remoteThumb) {
+      return fetchStaticAsset(remoteThumb, 'image/webp')
     }
     // Generate a real thumbnail for seed versions on first request
     const allVersions = await getAll('modelVersions')


### PR DESCRIPTION
## What

Adds a **Base Meshes (CC0)** pack to demo mode: 54 **deliberately curated** meshes (the fork holds ~900, all with pre-rendered thumbnails — the demo seeds a subset so the showcase content isn’t buried; the full set stays available for the future store) (fantasy weapons/props, street & workshop items, furniture, instruments, game icons) streamed from the [Papyszoo/base-meshes](https://github.com/Papyszoo/base-meshes) fork, pinned to commit `792e14d4` so upstream pushes can never break the demo. No binaries enter this repo.

Credits ship on the pack itself: description names [The Base Mesh](https://www.thebasemesh.com/) and the [M3-org/base-meshes](https://github.com/M3-org/base-meshes) glTF conversion, license type `CC0`, reference URL to thebasemesh.com.

## How

- **`baseMeshesSeed.ts`** — generates the models/versions/pack (ids 7000+, above the demo id sequences) with real GLB byte sizes, plus two lookup maps consumed by the handlers.
- **`seedAssetUrl`** passes absolute `http(s)` URLs through, so the existing `serveFile` seam streams GLBs from GitHub raw (which serves `Access-Control-Allow-Origin: *`).
- **`seedRemoteThumbnails`** — both thumbnail/file handlers serve the fork's pre-rendered **animated WebP turntables** (rendered with the asset-processor orbit pipeline at its default 256px/30-frame config, so they look identical to app-generated thumbnails). Checked after IndexedDB but before in-browser generation, so user-customized thumbnails still win.
- Contract test pins the cross-module id scheme — drift between the seed, the file map, and the thumbnail map wouldn't throw, it would silently 404 in the hosted demo.

## Checklist

- [x] Jest: 481 passed (62 suites), including the new seed contract test
- [x] `npm run lint` / `npm run format:check` clean
- [x] `npm run build` + `npm run build:demo` clean
- [x] Demo E2E suite: 13/13 passed
- [x] Manually drove the built demo (Playwright): grid shows the pack's thumbnails loading from GitHub raw (HTTP 200), Anvil opens in the 3D viewer streaming `anvil.glb`, pack page renders credits/license/URL
- [x] No count-based demo E2E assertions affected (pack tests select by name)
