### PR TITLE
fix: Blender enablement lost after install (unit-of-work fallout) + test-suite fixes for 0.4.1

### DIFF
--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -12,6 +12,10 @@ description: Modelibr git and release conventions — version-branch naming and 
 - Active development lands on a **version branch** named `version/<major>.<minor>`
   (e.g. `version/0.1`). Feature/fix branches PR **into the current version
   branch**, never directly into `main`.
+- **A version branch is done once its release ships.** Post-release fixes stage
+  on a new **patch branch** `version/<major>.<minor>.<patch>` (e.g.
+  `version/0.3.1`, `version/0.4.1`), created from the released tip — never
+  retarget more work at the already-released `version/X.Y` branch.
 - `main` only advances when cutting a release: merge the version branch → `main`,
   then publish a GitHub Release.
 
@@ -44,7 +48,7 @@ description: Modelibr git and release conventions — version-branch naming and 
   the testing rules in `CLAUDE.md` and the `test-triage` skill.
 
 ## Releases
-- Cutting a release = merge `version/X.Y` → `main`, then publish a GitHub
-  Release. electron-updater feeds (`latest*.yml` + `.blockmap`) are attached as
+- Cutting a release = merge the version branch (`version/X.Y` or patch branch
+  `version/X.Y.Z`) → `main`, then publish a GitHub Release. electron-updater feeds (`latest*.yml` + `.blockmap`) are attached as
   release assets; the desktop **client** publishes to its own `client` update
   channel so its feed never collides with the host's.

--- a/.claude/skills/test-triage/SKILL.md
+++ b/.claude/skills/test-triage/SKILL.md
@@ -16,7 +16,7 @@ Map what the user said to a suite id from `scripts/test-runner/suites.config.mjs
 | frontend / jest | `frontend` |
 | asset processor / thumbnails / vitest | `asset-processor` |
 | backup / restore | `backup-restore` |
-| desktop / tray | `desktop` (only on tray-host branches) |
+| desktop / tray | `desktop` |
 | performance / throughput | `e2e-performance` |
 
 If genuinely ambiguous, ask once; otherwise pick the obvious suite and proceed.

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -15,16 +15,16 @@ name: Upgrade Test
 #                 unsigned (Squirrel.Mac requires code signing; planned for 1.0).
 #
 # Installers come straight from GitHub Releases — no build step. Defaults to
-# "v0.1.0 → latest published release".
+# "v0.3.1 → latest published release".
 on:
   workflow_dispatch:
     inputs:
       from_tag:
-        # NOTE: move this to v0.2.1 after a few releases so the self-update job
-        # exercises the opt-in updater rather than v0.1.0's old forced one.
+        # v0.3.1 = first release containing the Windows silent quitAndInstall
+        # fix (#550), so the self-update job exercises the fixed updater path.
         description: "Release tag to upgrade FROM"
         required: false
-        default: "v0.1.0"
+        default: "v0.3.1"
         type: string
       to_tag:
         description: "Release tag to upgrade TO (blank = latest published release)"
@@ -76,7 +76,7 @@ jobs:
           INPUT_TO: ${{ inputs.to_tag }}
         run: |
           set -euo pipefail
-          from="${INPUT_FROM:-v0.1.0}"
+          from="${INPUT_FROM:-v0.3.1}"
           to="${INPUT_TO:-}"
           if [ -z "$to" ]; then
             to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
@@ -243,7 +243,7 @@ jobs:
           INPUT_TO: ${{ inputs.to_tag }}
         run: |
           set -euo pipefail
-          from="${INPUT_FROM:-v0.1.0}"
+          from="${INPUT_FROM:-v0.3.1}"
           to="${INPUT_TO:-}"
           if [ -z "$to" ]; then
             to=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ locally; core behavior must never depend on hosted services.
 - `src/frontend` — React + TypeScript + Vite; React Query + Zustand; Jest.
 - `src/asset-processor` — Node.js worker (thumbnails/renders via Puppeteer +
   Three.js + Blender CLI); Vitest.
-- `src/desktop` (branch `feat/tray-host`) — Electron tray host + installers.
+- `src/desktop` — Electron tray host + installers.
 - `tests/` — xUnit projects, `tests/e2e` (Playwright-BDD), `tests/backup-restore-e2e`.
 - Orchestration: Docker Compose (root `docker-compose.yml`; e2e has its own).
 

--- a/docs/videos/helpers/video-helpers.ts
+++ b/docs/videos/helpers/video-helpers.ts
@@ -412,6 +412,10 @@ export async function smoothMoveTo(
     options?: { offsetX?: number; offsetY?: number },
 ) {
     const element = page.locator(selector).first();
+    // Raw mouse events (unlike locator.click) don't auto-scroll; an
+    // off-screen target yields coordinates outside the viewport and the
+    // click/right-click silently misses.
+    await element.scrollIntoViewIfNeeded();
     const box = await element.boundingBox();
     if (!box) throw new Error(`Element not found: ${selector}`);
 

--- a/docs/videos/scripts/projects.spec.ts
+++ b/docs/videos/scripts/projects.spec.ts
@@ -163,6 +163,9 @@ async function removeRevealOverlay(page: Page) {
 async function moveToLocator(page: Page, locator: Locator, pause = 250) {
     const target = locator.first();
     await target.waitFor({ state: "visible", timeout: ciVideoTimeout });
+    // Raw mouse events don't auto-scroll like locator.click does; an
+    // off-screen target would make the cursor drift off-frame.
+    await target.scrollIntoViewIfNeeded();
     const box = await target.boundingBox();
     if (!box) {
         throw new Error("Unable to move to target locator.");
@@ -329,12 +332,14 @@ test.describe("Projects", () => {
             .filter({ has: page.getByRole("heading", { name: "Sky Harbor Launch" }) });
 
         await moveToLocator(page, featuredCard, 320);
-        const openFiltersButton = page.getByRole("button", { name: "Open Filters" });
-        if (await openFiltersButton.isVisible().catch(() => false)) {
-            await moveToLocator(page, openFiltersButton, 220);
-            await openFiltersButton.click();
-            await viewerPause(page, 350);
-        }
+        // The search input lives in a collapsed ListToolbarPanel; the shared
+        // toolbar's "Search" button expands it (the old "Open Filters" panel
+        // is gone from this page).
+        const searchToggle = page.getByRole("button", { name: "Search" });
+        await moveToLocator(page, searchToggle, 220);
+        await searchToggle.click();
+        await expect(searchInput).toBeVisible({ timeout: ciVideoTimeout });
+        await viewerPause(page, 350);
         await moveToLocator(page, searchInput, 220);
         await searchInput.click();
         await searchInput.pressSequentially("sky", { delay: 55 });

--- a/docs/videos/scripts/sprites.spec.ts
+++ b/docs/videos/scripts/sprites.spec.ts
@@ -21,6 +21,9 @@ const API_BASE_URL = process.env.API_BASE_URL || "http://127.0.0.1:8090";
 
 async function getLocatorCenter(locator: Locator) {
     await locator.waitFor({ state: "visible", timeout: ciVideoTimeout });
+    // Raw mouse events don't auto-scroll like locator.click does; an
+    // off-screen target would make the synthetic click miss silently.
+    await locator.scrollIntoViewIfNeeded();
     const box = await locator.boundingBox();
     if (!box) {
         throw new Error("Could not resolve visible bounding box for locator");
@@ -116,7 +119,10 @@ test.describe("Sprites", () => {
         await disableHighlights(page);
 
         const spriteCards = page.locator(".sprite-card");
-        await expect(spriteCards).toHaveCount(2, { timeout: ciVideoTimeout });
+        // The default category bucket is "All", so the categorized hero
+        // sprite (button-base, moved to UI Kit above) shows alongside the
+        // two unassigned ones.
+        await expect(spriteCards).toHaveCount(3, { timeout: ciVideoTimeout });
         await mediumPause(page);
         await startFeatureRecording(page, testInfo, { slug: "sprites" });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/scripts/test-runner/parsers.mjs
+++ b/scripts/test-runner/parsers.mjs
@@ -33,7 +33,10 @@ export function prepare(suite, workDir) {
             return { command, parse: () => parseJestLike(out) };
         }
         case "node-test": {
-            const command = `${suite.command} -- --test-reporter=tap`;
+            // `npm test -- --test-reporter=tap` puts the flag after the test-dir
+            // positional and node treats it as a test path; NODE_OPTIONS reaches
+            // the node --test process regardless of argument order.
+            const command = `NODE_OPTIONS="--test-reporter=tap" ${suite.command}`;
             return { command, parse: (result) => parseTap(result.output) };
         }
         case "playwright":

--- a/scripts/test-runner/suites.config.mjs
+++ b/scripts/test-runner/suites.config.mjs
@@ -74,8 +74,7 @@ export const suites = [
         command: "npm test",
         tier: "fast",
         requiresDocker: false,
-        // Only present on branches with the native installer work (feat/tray-host).
-        // Absent elsewhere -> reported as "not-present", runs automatically once merged.
+        // Absent on branches without src/desktop -> reported as "not-present".
         detectPath: "src/desktop/package.json",
     },
     {

--- a/src/Infrastructure/Services/BlenderInstallationService.cs
+++ b/src/Infrastructure/Services/BlenderInstallationService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using Application.Abstractions;
 using Application.Abstractions.Repositories;
 using Application.Abstractions.Services;
 using Application.Settings;
@@ -408,6 +409,11 @@ public sealed class BlenderInstallationService : IBlenderInstallationService
             {
                 await UpdateOrCreateSettingAsync(repo, SettingKeys.BlenderEnabled, "true", now);
             }
+
+            // Runs outside the command pipeline (background install task), so no
+            // decorator commits for us — repositories only stage changes.
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            await unitOfWork.SaveChangesAsync();
         }
         catch (Exception ex)
         {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/Infrastructure.Tests/Architecture/ServicesCommitStagedMutationsTests.cs
+++ b/tests/Infrastructure.Tests/Architecture/ServicesCommitStagedMutationsTests.cs
@@ -1,0 +1,76 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Infrastructure.Tests.Architecture;
+
+/// <summary>
+/// Companion gate to <see cref="RepositoriesDontSelfCommitTests"/>: repositories
+/// only stage mutations, and the CommandHandlerUnitOfWorkDecorator commits for
+/// command handlers — but services under src/Infrastructure/Services run
+/// outside the command pipeline (background tasks, own DI scopes), so nothing
+/// commits for them. A service that stages repository mutations without also
+/// calling IUnitOfWork silently drops its writes.
+///
+/// Real regression this catches: after the unit-of-work migration,
+/// BlenderInstallationService.PersistSettingsAsync staged the
+/// BlenderEnabled/BlenderPath settings via ISettingRepository but never
+/// committed, so a completed Blender install left the feature disabled
+/// (blend-upload E2E scenarios failed at "backend has Blender integration
+/// enabled").
+/// </summary>
+public class ServicesCommitStagedMutationsTests
+{
+    [Fact]
+    public void ServicesStagingRepositoryMutations_AlsoUseUnitOfWork()
+    {
+        var servicesDir = FindServicesDirectory();
+
+        var offenders = new List<string>();
+
+        foreach (var path in Directory.EnumerateFiles(servicesDir, "*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var content = File.ReadAllText(path);
+
+            var usesRepository = Regex.IsMatch(content, @"\bI[A-Za-z]+Repository\b");
+            var stagesMutations = Regex.IsMatch(content, @"\.(AddAsync|UpdateAsync|DeleteAsync|RemoveAsync)\s*\(");
+            var commits = content.Contains("IUnitOfWork");
+
+            if (usesRepository && stagesMutations && !commits)
+            {
+                offenders.Add(Path.GetFileName(path));
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "The following services stage repository mutations but never resolve " +
+            "IUnitOfWork, so their writes are staged and dropped (no command-handler " +
+            "decorator commits outside the command pipeline): " +
+            string.Join(", ", offenders) +
+            ". Resolve IUnitOfWork from the same scope as the repository and call " +
+            "SaveChangesAsync after staging. See the backend-patterns skill, " +
+            "\"Transactions — unit of work\" section.");
+    }
+
+    private static string FindServicesDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "Modelibr.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        if (dir == null)
+        {
+            throw new InvalidOperationException(
+                $"Could not locate Modelibr.sln by walking up from {AppContext.BaseDirectory}");
+        }
+
+        var servicesDir = Path.Combine(dir.FullName, "src", "Infrastructure", "Services");
+        if (!Directory.Exists(servicesDir))
+        {
+            throw new InvalidOperationException($"Expected directory not found: {servicesDir}");
+        }
+
+        return servicesDir;
+    }
+}

--- a/tests/e2e/steps/performance.steps.ts
+++ b/tests/e2e/steps/performance.steps.ts
@@ -12,7 +12,7 @@ const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8090";
 
 // ─── Shared state across steps within a scenario ───────────────────────────
 
-let bulkUploadedModelNames: string[] = [];
+let maxModelIdBeforeBulkUpload = 0;
 let apiUploadedModelIds: number[] = [];
 let networkRequestLog: { url: string; timestamp: number }[] = [];
 let tabSwitchRequestCount: number = 0;
@@ -25,7 +25,6 @@ let parallelProcessingStart: number = 0;
 When(
     "I bulk upload {int} models using unique files",
     async ({ page }, count: number) => {
-        bulkUploadedModelNames = [];
         const modelList = new ModelListPage(page);
 
         const filePaths: string[] = [];
@@ -35,13 +34,20 @@ When(
             const uniquePath =
                 await UniqueFileGenerator.generate("test-cube.glb");
             filePaths.push(uniquePath);
-
-            const basename = uniquePath.split("/").pop() || "";
-            const modelName = basename.replace(/\.[^/.]+$/, "");
-            bulkUploadedModelNames.push(modelName);
         }
 
-        console.log(`[Performance] Uploading ${count} models in batch`);
+        // Baseline for finding the models this step creates: names are
+        // unusable — every generated GLB keeps the base filename (only the
+        // content is made unique), so duplicate-name AutoRename turns them
+        // into "test-cube (N)". Newer id = created by this upload.
+        const baseline = await axios.get(
+            `${API_BASE_URL}/models?page=1&pageSize=1`,
+        );
+        maxModelIdBeforeBulkUpload = baseline.data?.items?.[0]?.id ?? 0;
+
+        console.log(
+            `[Performance] Uploading ${count} models in batch (baseline max model id: ${maxModelIdBeforeBulkUpload})`,
+        );
 
         await modelList.uploadMultipleModels(filePaths);
     },
@@ -228,24 +234,34 @@ When(
             }
         });
 
-        // Wait for all thumbnails to finish
+        // Wait for the uploaded models' thumbnails to finish. Check via API —
+        // the virtualized grid renders fewer DOM cards than `count` (the
+        // category sidebar narrows it to a single column), and the shared DB
+        // already holds thumbnails from earlier scenarios, so both DOM counts
+        // and unscoped totals are unusable. Models created by this scenario's
+        // bulk upload are the ones above the recorded id baseline. Polling
+        // axios from the test process doesn't show up in the page's request
+        // log.
         const timeoutMs = count * 60 * 1000;
         const startTime = Date.now();
 
         await expect(async () => {
-            if (Date.now() - startTime > 60000) {
-                await page.reload({ waitUntil: "domcontentloaded" });
-                await page.waitForSelector(
-                    ".model-card, .no-results, .empty-state",
-                    { state: "visible", timeout: 15000 },
-                );
-            }
-
-            const thumbnails = page.locator(
-                ".model-card .thumbnail-image, .model-card .thumbnail-image-container img",
+            const response = await axios.get(
+                `${API_BASE_URL}/models?page=1&pageSize=200`,
             );
-            const thumbnailCount = await thumbnails.count();
-            expect(thumbnailCount).toBeGreaterThanOrEqual(count);
+            const models = response.data?.items || [];
+            const uploadedWithThumbnails = models.filter(
+                (m: any) =>
+                    m.id > maxModelIdBeforeBulkUpload &&
+                    m.thumbnailUrl &&
+                    m.thumbnailUrl.length > 0,
+            );
+            console.log(
+                `[ST-2] Uploaded-model thumbnails (API): ${uploadedWithThumbnails.length}/${count} (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`,
+            );
+            expect(uploadedWithThumbnails.length).toBeGreaterThanOrEqual(
+                count,
+            );
         }).toPass({
             timeout: timeoutMs,
             intervals: [5000, 10000, 15000],
@@ -322,11 +338,20 @@ Then(
 Given(
     "there are at least {int} models visible",
     async ({ page }, minCount: number) => {
+        // The virtualized grid keeps DOM cards below minCount when the
+        // category sidebar narrows it to a single column, so require
+        // minCount models via the API and at least one rendered card.
         await expect(async () => {
-            const cards = page.locator(".model-card");
-            const count = await cards.count();
-            expect(count).toBeGreaterThanOrEqual(minCount);
+            const response = await axios.get(
+                `${API_BASE_URL}/models?page=1&pageSize=1`,
+            );
+            const totalCount = response.data?.totalCount ?? 0;
+            expect(totalCount).toBeGreaterThanOrEqual(minCount);
         }).toPass({ timeout: 30000, intervals: [2000, 3000] });
+
+        await expect(page.locator(".model-card").first()).toBeVisible({
+            timeout: 15000,
+        });
     },
 );
 


### PR DESCRIPTION
## Summary

Fixes for the three suites that failed in the full local test run on `version/0.4`, plus the 0.4.1 release prep. The Blender fix is user-facing: **v0.4.0 shipped with Blender enablement broken** — installing Blender from Settings completes but the `BlenderEnabled` setting is never persisted, so .blend processing stays off.

## Changes

- **fix(settings)**: `BlenderInstallationService` runs outside the command pipeline, so the `CommandHandlerUnitOfWorkDecorator` never commits for it; after the unit-of-work migration (#568) its staged settings writes were silently dropped. Now resolves `IUnitOfWork` from the service scope and saves after staging. Adds `ServicesCommitStagedMutationsTests` — an architecture gate (companion to the repos-don't-self-commit gate) failing any `Infrastructure/Services` file that stages repository mutations without referencing `IUnitOfWork`.
- **fix(e2e)**: performance steps ST-2/ST-4 counted cards in the virtualized models grid; the default-open category sidebar narrows it to one column (~3 DOM cards), so `>= 5` could never pass. Both now wait via the API; ST-2 tracks its bulk-uploaded models by a max-model-id baseline (names are unusable — generated GLBs keep the base filename and duplicate-name AutoRename yields "test-cube (N)").
- **fix(test-runner)**: the `desktop` suite failed because npm appends forwarded args after the script's own args, making node treat `--test-reporter=tap` as a test path; the reporter now goes through `NODE_OPTIONS`.
- **docs(agents)**: drop stale "src/desktop only on tray-host branches" claims (CLAUDE.md, test-triage skill, suite manifest comment).
- **chore(release)**: bump internal package versions to 0.4.1.

## Verification

- `dotnet build` + full unit suite: 704 passed (incl. the new gate)
- Live e2e stack: blend WebDAV scenario passed; `enableBlender` flips to true after install and persists
- ST-2 and ST-4 passed against the live stack (real assertions intact: 9 API calls < 50; ≤ 1 refetch on tab switch)
- `npm run test:all -- --only=desktop`: 46/46
- `npm run test:audit`: green

- **ci(upgrade-test)**: default `from_tag` bumped to `v0.3.1` — first release with the Windows silent `quitAndInstall` fix (#550), so the nightly self-update job exercises the fixed updater path.

- **fix(videos)**: repaired the three docs-video specs broken by version/0.4 UI changes (projects search moved into the ListToolbar Search panel; sprites default "All" bucket shows 3 cards; recycled-files right-click missed an off-screen card — raw mouse helpers now scroll into view). This is what failed `CI and Deploy Docs` on main after the 0.4.0 merge and thereby skipped `Docker Publish` — merging this and cutting 0.4.1 republishes docs and Docker images. Verified locally: full `videos:generate`, 8/8 pass the analyze gate.