### PR TITLE
fix: texture preview demand rendering + docs-video de-flakes for 0.4.2

### DIFF
--- a/docs/videos/scripts/model-management.spec.ts
+++ b/docs/videos/scripts/model-management.spec.ts
@@ -90,6 +90,18 @@ test.describe("Model Management", () => {
             waitForThumbnailReady(thirdModelId),
         ]);
 
+        // Off-camera prewarm: open the comparison model once so its file is
+        // in the browser cache and the viewer machinery is warm. The recorded
+        // beat re-opens it and must not spend seconds on a cold FBX load
+        // (this wait timed out under CI load when the open was cold).
+        await navigateTo(
+            page,
+            `/?leftTabs=modelList&rightTabs=model-${comparisonModelId}&activeRight=model-${comparisonModelId}`,
+        );
+        await expect(
+            page.locator(".p-splitter-panel").nth(1).locator("canvas").first(),
+        ).toBeVisible({ timeout: ciVideoTimeout });
+
         // Start on a polished split view: library on the left, hero model on the right.
         await navigateTo(
             page,

--- a/docs/videos/scripts/packs.spec.ts
+++ b/docs/videos/scripts/packs.spec.ts
@@ -131,60 +131,61 @@ test.describe("Packs", () => {
         // Step 3: Add both models to the pack
         // ────────────────────────────────────────────────────────────
 
+        // Unconditional flow: the short isVisible guards this used to have
+        // silently skipped the whole add-models beat when a render took
+        // longer than the guard (loaded machine / no-GPU CI), and the video
+        // then failed downstream at "Models (2)" with 0. If a step here is
+        // genuinely broken the spec should fail AT that step.
         const addModelCard = page.locator(".model-card.model-card-add");
-        if (await addModelCard.isVisible({ timeout: 3000 }).catch(() => false)) {
-            const addBox = await addModelCard.boundingBox();
-            if (addBox) {
-                await page.mouse.move(
-                    addBox.x + addBox.width / 2,
-                    addBox.y + addBox.height / 2,
-                    { steps: 20 },
-                );
-                await viewerPause(page, 400);
-            }
-            await addModelCard.click();
-            await mediumPause(page);
-
-            const selectionDialog = page.locator(".p-dialog").filter({
-                has: page.getByText("Add Models to Pack"),
-            });
-            if (
-                await selectionDialog
-                    .isVisible({ timeout: 5000 })
-                    .catch(() => false)
-            ) {
-                const selectableItems = selectionDialog.locator(
-                    ".container-card[data-model-id]",
-                );
-                const itemCount = await selectableItems.count();
-                for (let i = 0; i < Math.min(itemCount, 2); i++) {
-                    const item = selectableItems.nth(i);
-                    const itemBox = await item.boundingBox();
-                    if (itemBox) {
-                        await page.mouse.move(
-                            itemBox.x + itemBox.width / 2,
-                            itemBox.y + itemBox.height / 2,
-                            { steps: 15 },
-                        );
-                        await viewerPause(page, 300);
-                    }
-                    await item.click();
-                    await shortPause(page);
-                }
-
-                const confirmBtn = selectionDialog
-                    .getByRole("button", { name: /Add Selected \([12]\)/ })
-                    .first();
-                if (
-                    await confirmBtn
-                        .isVisible({ timeout: 2000 })
-                        .catch(() => false)
-                ) {
-                    await confirmBtn.click();
-                    await mediumPause(page);
-                }
-            }
+        await addModelCard.waitFor({ state: "visible", timeout: ciVideoTimeout });
+        const addBox = await addModelCard.boundingBox();
+        if (addBox) {
+            await page.mouse.move(
+                addBox.x + addBox.width / 2,
+                addBox.y + addBox.height / 2,
+                { steps: 20 },
+            );
+            await viewerPause(page, 400);
         }
+        await addModelCard.click();
+        await mediumPause(page);
+
+        const selectionDialog = page.locator(".p-dialog").filter({
+            has: page.getByText("Add Models to Pack"),
+        });
+        await selectionDialog.waitFor({
+            state: "visible",
+            timeout: ciVideoTimeout,
+        });
+        const selectableItems = selectionDialog.locator(
+            ".container-card[data-model-id]",
+        );
+        await selectableItems
+            .first()
+            .waitFor({ state: "visible", timeout: ciVideoTimeout });
+        const itemCount = await selectableItems.count();
+        expect(itemCount).toBeGreaterThanOrEqual(2);
+        for (let i = 0; i < Math.min(itemCount, 2); i++) {
+            const item = selectableItems.nth(i);
+            const itemBox = await item.boundingBox();
+            if (itemBox) {
+                await page.mouse.move(
+                    itemBox.x + itemBox.width / 2,
+                    itemBox.y + itemBox.height / 2,
+                    { steps: 15 },
+                );
+                await viewerPause(page, 300);
+            }
+            await item.click();
+            await shortPause(page);
+        }
+
+        const confirmBtn = selectionDialog
+            .getByRole("button", { name: /Add Selected \(2\)/ })
+            .first();
+        await confirmBtn.waitFor({ state: "visible", timeout: ciVideoTimeout });
+        await confirmBtn.click();
+        await mediumPause(page);
 
         await expect(page.getByTestId("container-tab-models")).toHaveAttribute(
             "aria-label",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/frontend/src/features/texture-set/components/TexturePreviewPanel.tsx
+++ b/src/frontend/src/features/texture-set/components/TexturePreviewPanel.tsx
@@ -261,6 +261,11 @@ export function TexturePreviewPanel({
           shadows
           className="texture-preview-canvas"
           camera={{ position: [3, 2, 3], fov: 45 }}
+          // Static scene (no useFrame anywhere): render only when something
+          // changes. A continuous loop starves input for seconds per event
+          // under software GL; drei's OrbitControls and React state changes
+          // (texture loads, geometry switches) invalidate on their own.
+          frameloop="demand"
           gl={{
             antialias: true,
             alpha: true,


### PR DESCRIPTION
## Summary

Fixes the remaining `CI and Deploy Docs` failure on main (which keeps `Docker Publish` skipped — no 0.4.x Docker images have shipped yet). Root cause was a real app issue, not just a test problem.

## Changes

- **fix(texture-set)**: `TexturePreviewPanel`'s R3F Canvas ran `frameloop=always` for a fully static scene. Under software GL the continuous loop starves input for seconds per event — deterministically failing the texture-sets docs video on no-GPU CI, and lagging every interaction for users on weak GPUs. Now `frameloop="demand"` (OrbitControls and React state changes invalidate on their own).
- **fix(videos)**: two flakes that surfaced across today's runs:
  - *packs*: the add-models beat silently skipped when a 3s `isVisible` guard timed out under load, failing downstream at "Models (2)"; the flow is now unconditional.
  - *model-management*: the recorded comparison-model open cold-loaded an FBX on camera and timed out under CI load; prewarmed off-camera per the choreography rules.
- **chore(release)**: bump internal package versions to 0.4.2.

## Verification

- Frontend: 481 Jest tests, lint, format, build — green
- Storybook visual regression suite: pass (TexturePreviewPanel snapshot pixel-identical under demand mode)
- Docs videos: full `videos:generate`, **8/8 pass the analyze gate** (texture-sets confirmed twice; the orbit and geometry-switch beats render live, proving demand-mode invalidation)

Merging this into `version/0.4.2` → `main` → v0.4.2 release finally publishes the 0.4.x Docker images and the refreshed docs site.