### PR TITLE
fix: CI-paced duration cap for model-management video (0.4.3)

### DIFF
--- a/docs/videos/video-manifest.js
+++ b/docs/videos/video-manifest.js
@@ -9,7 +9,10 @@ export const videoManifest = [
         outputName: "model-management.webm",
         title: "Model Management",
         description: "Compare versions, inspect changes, and keep model history moving.",
-        maxDurationSeconds: 45,
+        // ~40s on a local GPU; CI's software rendering paces the recorded
+        // waits to ~61s (observed 3× on the v0.4.2 main push). 45 left no
+        // CI headroom and failed the deploy.
+        maxDurationSeconds: 75,
     },
     {
         slug: "texture-sets",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

The v0.4.2 main push got further than 0.4.0/0.4.1 — **all 8 video specs now pass on CI** — but the analyze QA gate rejected `model-management.webm`: 60.5–60.8s against its 45s cap, consistently across all three attempts. The recording is ~40s on a local GPU; CI's software rendering paces the recorded waits ~1.5× slower, and 45s left no CI headroom (it was already at ~90% of cap before today, against the choreograph-for-60-70% guidance).

Per the manifest's own rules the cap is a QA ceiling, raised deliberately: **45 → 75** with a comment recording the observed CI pacing. All other videos have comfortable margins (worst: texture-sets 43.9s vs 55).

- **chore(release)**: bump internal package versions to 0.4.3.

## Note for later

This is the third docs-CI-blocks-Docker-Publish patch today. Two structural follow-ups worth queueing:
1. `docker-publish` shouldn't be held hostage by a docs *artifact* QA gate — consider gating it on the test jobs rather than the whole `CI and Deploy Docs` workflow.
2. The local `videos:generate` pre-release check can't reproduce CI pace — duration-cap regressions are only observable at main-push. Caps should be reviewed against CI durations, not local ones.