### PR TITLE
Release 0.4.3

### DIFF
--- a/docs/videos/video-manifest.js
+++ b/docs/videos/video-manifest.js
@@ -9,7 +9,10 @@ export const videoManifest = [
         outputName: "model-management.webm",
         title: "Model Management",
         description: "Compare versions, inspect changes, and keep model history moving.",
-        maxDurationSeconds: 45,
+        // ~40s on a local GPU; CI's software rendering paces the recorded
+        // waits to ~61s (observed 3× on the v0.4.2 main push). 45 left no
+        // CI headroom and failed the deploy.
+        maxDurationSeconds: 75,
     },
     {
         slug: "texture-sets",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Modelibr desktop client — an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release: merge `version/0.4.3` → `main` for the v0.4.3 release.

## Contents (PR #576)

- **fix(videos)**: model-management duration cap 45 → 75 — all 8 video specs pass on CI since 0.4.2, but the analyze gate rejected the recording at 60.5–60.8s (CI's software rendering paces the ~40s local recording ~1.5× slower; the cap had no CI headroom).
- **chore(release)**: internal package versions bumped to 0.4.3.

This should be the push where `CI and Deploy Docs` finally goes green end-to-end, unblocking `Docker Publish` (first 0.4.x images) and the docs deploy.