### PR TITLE
fix(ci): unblock Docker publishing and repair the native-installer release lane

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -561,6 +561,21 @@ jobs:
                   FRONTEND_URL: http://localhost:3002
                   API_BASE_URL: http://localhost:8090
 
+            # Video specs run only on main-push/dispatch, so a failure here is
+            # the first time anyone sees it - and until now the job uploaded
+            # nothing on failure, leaving no way to tell WHY a clip broke
+            # without landing another commit on main. Playwright writes an ARIA
+            # page snapshot (error-context.md) next to each failure for free;
+            # keep it so the next breakage is diagnosable from the run alone.
+            - name: Upload video failure diagnostics
+              if: failure()
+              uses: actions/upload-artifact@v5
+              with:
+                  name: video-failure-diagnostics-${{ github.run_number }}
+                  path: docs/videos/test-results/
+                  retention-days: 14
+                  if-no-files-found: ignore
+
             - name: Upload feature videos
               uses: actions/upload-artifact@v5
               with:

--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -554,6 +554,15 @@ jobs:
                     fi
                     echo "::endgroup::"
                     echo "video generation attempt $attempt failed"
+                    # Preserve this attempt's Playwright output before the next
+                    # attempt overwrites it. A retry that eventually succeeds
+                    # still hides a real problem - the run that motivated this
+                    # failed attempt 1 and passed attempt 2, leaving no evidence
+                    # at all because the job as a whole was green.
+                    if [ -d test-results ]; then
+                      mkdir -p ../../video-failure-artifacts
+                      cp -r test-results "../../video-failure-artifacts/attempt-$attempt" || true
+                    fi
                   done
                   echo "video generation failed after 3 attempts"
                   exit 1
@@ -567,12 +576,16 @@ jobs:
             # without landing another commit on main. Playwright writes an ARIA
             # page snapshot (error-context.md) next to each failure for free;
             # keep it so the next breakage is diagnosable from the run alone.
+            # always(), not failure(): an attempt can fail and a later one
+            # succeed, leaving the job green with the evidence discarded.
             - name: Upload video failure diagnostics
-              if: failure()
+              if: always()
               uses: actions/upload-artifact@v5
               with:
                   name: video-failure-diagnostics-${{ github.run_number }}
-                  path: docs/videos/test-results/
+                  path: |
+                      video-failure-artifacts/
+                      docs/videos/test-results/
                   retention-days: 14
                   if-no-files-found: ignore
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,18 +9,59 @@ on:
 permissions:
     contents: read
     packages: write
+    # Needed to read the triggering run's job list in the gate below.
+    actions: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
+    # Publishing used to require the WHOLE "CI and Deploy Docs" run to succeed,
+    # which meant a documentation artifact could veto an image build: the
+    # GPU-dependent docs videos cannot render reliably on GitHub's GPU-less
+    # runners, and a red video lane fails build-docs -> skips deploy-docs ->
+    # skips this workflow. There is no manual trigger here, so the images simply
+    # never shipped - that is what cost 0.4.0, 0.4.1, 0.4.2 and 0.5.0 their
+    # Docker images.
+    #
+    # Gate on the "CI Status" job of the triggering run instead. That job already
+    # aggregates exactly the code-correctness lanes (backend, frontend,
+    # asset-processor, e2e) and deliberately excludes videos and docs, so the
+    # images are still gated on every test that says the code works - and on
+    # nothing that merely says a screencast rendered. Verified against the v0.5.0
+    # main push, where "CI Status" was success while the run overall was failure.
+    gate:
+        name: Check code-correctness lanes
+        runs-on: ubuntu-latest
+        if: >-
+            github.event.workflow_run.head_branch == 'main' &&
+            github.event.workflow_run.conclusion != 'cancelled'
+        outputs:
+            ok: ${{ steps.check.outputs.ok }}
+        steps:
+            - name: Resolve CI Status conclusion
+              id: check
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+              run: |
+                  conclusion=$(gh api --paginate \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
+                    --jq '[.jobs[] | select(.name == "CI Status") | .conclusion] | first // "missing"')
+                  echo "CI Status -> ${conclusion}"
+                  if [ "${conclusion}" = "success" ]; then
+                    echo "ok=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "ok=false" >> "$GITHUB_OUTPUT"
+                    echo "::warning::Skipping Docker publish - CI Status was '${conclusion}', not success."
+                  fi
+
     docker-publish:
         name: Build and Publish Docker Images
         runs-on: ubuntu-latest
-        if: >-
-            github.event.workflow_run.conclusion == 'success' &&
-            github.event.workflow_run.head_branch == 'main'
+        needs: [gate]
+        if: needs.gate.outputs.ok == 'true'
 
         steps:
             - name: Checkout code

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -441,6 +441,12 @@ jobs:
           # The demo phase tests a standalone demo build in Playwright's own
           # browser, not the installed app - skip it here (covered by Docker CI).
           SKIP_DEMO_PHASE: "1"
+          # The @asset-store scenario signs in to the store-fixture service that
+          # only exists in the Docker e2e stack, and the installed build points
+          # at the real store instead. Without the fixture the sign-in field
+          # never appears, so it fails on every retry (v0.5.0 release lane, all
+          # three OSes). Docker CI still gates this scenario on every PR.
+          SKIP_STORE_SCENARIOS: "1"
           # The hosted runners (Windows especially) are CPU-contended running the
           # native stack alongside parallel browsers, which thrashed and made UI
           # actions miss their timeouts (the Chromium phase took ~1.6h with flaky

--- a/docs/videos/helpers/video-helpers.ts
+++ b/docs/videos/helpers/video-helpers.ts
@@ -512,9 +512,29 @@ export async function dragElementTo(
 /**
  * Navigate to a page and wait for it to load fully.
  */
+const cpuThrottled = new WeakSet<Page>();
+
+/**
+ * CI runs the whole E2E Docker stack AND the capture browser on one small
+ * hosted runner, which is far more CPU-contended than a dev machine - the
+ * difference that makes a clip pass locally (even on SwiftShader) and fail in
+ * CI. VIDEO_CPU_THROTTLE=<rate> applies CDP CPU throttling so that contention
+ * is reproducible locally instead of only after a main push.
+ */
+async function applyCpuThrottle(page: Page) {
+    const rate = Number(process.env.VIDEO_CPU_THROTTLE || "0");
+    if (!rate || rate <= 1 || cpuThrottled.has(page)) {
+        return;
+    }
+    const client = await page.context().newCDPSession(page);
+    await client.send("Emulation.setCPUThrottlingRate", { rate });
+    cpuThrottled.add(page);
+}
+
 export async function navigateTo(page: Page, path: string) {
     // Use localhost (not 127.0.0.1) so browser origin matches CORS allowed origins
     const baseUrl = process.env.FRONTEND_URL || "http://localhost:3002";
+    await applyCpuThrottle(page);
     await ensureCursorOverlayInitScript(page);
     const usedLegacyNavigation = await applyLegacyNavigationState(
         page,

--- a/docs/videos/playwright.config.ts
+++ b/docs/videos/playwright.config.ts
@@ -32,6 +32,17 @@ export default defineConfig({
             args: [
                 "--disable-blink-features=AutomationControlled",
                 "--no-default-browser-check",
+                // CI runners have no GPU, so Chromium silently falls back to
+                // SwiftShader - which is where the video specs actually break.
+                // Set VIDEO_SOFTWARE_GL=1 to reproduce that path on a machine
+                // that does have a GPU, instead of waiting for a main push.
+                ...(process.env.VIDEO_SOFTWARE_GL === "1"
+                    ? [
+                          "--disable-gpu",
+                          "--use-gl=swiftshader",
+                          "--use-angle=swiftshader",
+                      ]
+                    : []),
             ],
         },
     },

--- a/docs/videos/scripts/model-management.spec.ts
+++ b/docs/videos/scripts/model-management.spec.ts
@@ -102,6 +102,27 @@ test.describe("Model Management", () => {
             page.locator(".p-splitter-panel").nth(1).locator("canvas").first(),
         ).toBeVisible({ timeout: ciVideoTimeout });
 
+        // Second off-camera prewarm: mount BOTH viewers at once. The prewarm
+        // above only warms the model file and a single viewer; the recorded
+        // beat instead brings up a second canvas while the hero viewer is
+        // already running, and on a GPU-less runner that first two-context
+        // setup is the expensive part. Paying it off-camera keeps it out of the
+        // recording. Without this the recorded clip ran 77.44s against its 75s
+        // cap (analyze gate failed the whole docs lane), and under heavier load
+        // the same wait blew its 30s timeout outright - which is what broke the
+        // v0.5.0 main push and cost that release its Docker image.
+        await navigateTo(
+            page,
+            `/?leftTabs=model-${comparisonModelId}&activeLeft=model-${comparisonModelId}` +
+                `&rightTabs=model-${primaryModelId}&activeRight=model-${primaryModelId}`,
+        );
+        await expect(
+            page.locator(".p-splitter-panel").first().locator("canvas").first(),
+        ).toBeVisible({ timeout: ciVideoTimeout });
+        await expect(
+            page.locator(".p-splitter-panel").nth(1).locator("canvas").first(),
+        ).toBeVisible({ timeout: ciVideoTimeout });
+
         // Start on a polished split view: library on the left, hero model on the right.
         await navigateTo(
             page,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Modelibr desktop client - an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/e2e/run-e2e-fast.js
+++ b/tests/e2e/run-e2e-fast.js
@@ -138,8 +138,21 @@ async function main() {
 
   const chromiumWorkers = process.env.PW_WORKERS || "3";
   console.log(`\n📋 Phase 2: Chromium tests (workers=${chromiumWorkers})\n`);
+  // The @asset-store scenarios sign in to the companion Asset Store, which in
+  // CI is the store-fixture service from docker-compose.e2e.yml. That fixture
+  // shares webapi-e2e's network namespace so the ONE store URL the frontend
+  // was BUILT with (VITE_STORE_URL=http://localhost:9280) resolves to it. An
+  // installed native build carries the real store URL and has no fixture on
+  // 9280, so the sign-in field never appears and the scenario burns its full
+  // timeout. This is an environment gap, not a flake: set
+  // SKIP_STORE_SCENARIOS=1 only where no fixture exists (the native-installer
+  // lane). Docker CI and the local runner leave it unset and keep the coverage.
+  const chromiumArgs =
+    process.env.SKIP_STORE_SCENARIOS === "1"
+      ? `${args} --grep-invert=@asset-store`
+      : args;
   const chromiumResult = run(
-    `npx playwright test --project=chromium --no-deps ${args}`,
+    `npx playwright test --project=chromium --no-deps ${chromiumArgs}`,
     { env: { ...testEnv, PW_WORKERS: chromiumWorkers } },
   );
   preserveBlobs("chromium");

--- a/tests/upgrade/drive-update.mjs
+++ b/tests/upgrade/drive-update.mjs
@@ -5,9 +5,15 @@
 // Instead we connect to the running app's status window and call the same update
 // IPC the tray buttons use:
 //
-//   1. poll window.modelibr.getUpdate() until status === 'downloaded'
-//      (electron-updater downloads from the live GitHub release feed),
-//   2. call window.modelibr.openUpdate() → install() → quitAndInstall(), which
+//   1. poll window.modelibr.getUpdate() until an update is 'available',
+//   2. call window.modelibr.downloadUpdate() - the same IPC the tray's Download
+//      button uses. Downloads are OPT-IN (updateManager sets
+//      autoUpdater.autoDownload = false, and a unit test asserts it stays off),
+//      so nothing downloads until this is called. This step used to be missing:
+//      the driver just waited for status 'downloaded' and timed out at
+//      percent 0 with error null, every night, on Linux and Windows,
+//   3. poll until status === 'downloaded',
+//   4. call window.modelibr.openUpdate() → install() → quitAndInstall(), which
 //      installs the new version and relaunches it.
 //
 // Launch the app with --remote-debugging-port=9222 first. Used by the
@@ -50,6 +56,7 @@ async function main() {
 
   const deadline = Date.now() + TIMEOUT_MS
   let state = null
+  let downloadRequested = false
   while (Date.now() < deadline) {
     state = await page.evaluate(() => window.modelibr.getUpdate()).catch(() => null)
     console.log(`[drive-update] update state: ${JSON.stringify(state)}`)
@@ -57,11 +64,29 @@ async function main() {
     if (state?.status === 'error') {
       throw new Error(`updater reported an error: ${state.error ?? 'unknown'}`)
     }
+    // Downloads are opt-in, so an 'available' update sits at percent 0 forever
+    // unless something presses the button for it. Do that once.
+    if (state?.status === 'available' && !downloadRequested) {
+      console.log('[drive-update] update available - requesting download')
+      const requested = await page
+        .evaluate(() => window.modelibr.downloadUpdate())
+        .then(() => true)
+        .catch(error => {
+          console.error(`[drive-update] downloadUpdate() threw: ${error?.message ?? error}`)
+          return false
+        })
+      downloadRequested = requested
+    }
     await sleep(POLL_MS)
   }
 
   if (state?.status !== 'downloaded') {
-    throw new Error(`update was not downloaded before timeout (last status: ${state?.status ?? 'none'})`)
+    const detail = downloadRequested
+      ? 'download was requested but never completed'
+      : 'download was never successfully requested'
+    throw new Error(
+      `update was not downloaded before timeout (last status: ${state?.status ?? 'none'}; ${detail})`,
+    )
   }
 
   console.log('[drive-update] downloaded - triggering install (quitAndInstall + relaunch)')


### PR DESCRIPTION
Patch release groundwork for **0.5.1**. v0.5.0 shipped correctly - all 22 release assets are attached - but it has **no Docker image**, for the fourth release running. This PR fixes the cause and two adjacent gaps found while diagnosing it.

## 1. Docker Publish no longer vetoed by the docs video lane

`docker-publish.yml` required the entire "CI and Deploy Docs" run to succeed. The docs videos drive GPU-dependent WebGL that does not render reliably on GitHub's GPU-less runners, and a red video lane fails `build-docs` -> skips `deploy-docs` -> skips Docker Publish. That workflow has no manual trigger, so the images simply never ship. This is what cost **0.4.0, 0.4.1, 0.4.2 and 0.5.0** their Docker images.

It now gates on the triggering run's **`CI Status`** job, which already aggregates exactly the code-correctness lanes (backend, frontend, asset-processor, e2e) and deliberately excludes videos and docs. Images stay gated on every test that says the code works, and on nothing that merely says a screencast rendered.

Validated against the real incident - run `31649270588`, the v0.5.0 main push:

| | value |
| --- | --- |
| Run conclusion (old gate) | `failure` -> image skipped |
| `CI Status` job (new gate) | `success` -> image publishes |

A missing or non-success `CI Status` resolves to `ok=false` and skips publishing with a warning annotation.

**Docs deployment is deliberately unchanged** - it still requires the videos, so a broken clip still blocks the docs site. Only the images are decoupled.

## 2. Native-installer lane: skip the store-fixture scenario

The v0.5.0 release lane failed on **all three OSes** with one scenario: `@asset-store` "Import a pack from the store library into the local instance" timed out at `locator.fill` on "When I sign in to the asset store", burning its full 180 s on every retry. Everything else passed - **107 of 108** - and every installer smoke check was green (install, launch, frontend served, native runtime API, proxied WebApi health, and the DB-backed endpoint that catches missing migrations, which matters with 11 new migrations in 0.5.0).

It is not flaky, it is unrunnable there. The scenario signs in to the companion store, which in CI is the `store-fixture` service from `docker-compose.e2e.yml`. That fixture shares `webapi-e2e`'s network namespace so the one store URL the frontend is **built** with (`VITE_STORE_URL=http://localhost:9280`) resolves to it from both browser and importer. The native lane installs the shipped production build, which carries the real store URL, and starts no fixture - nothing answers on 9280, so the sign-in field never renders.

Gated on `SKIP_STORE_SCENARIOS=1`, set only in `native-release.yml`, mirroring the existing `SKIP_DEMO_PHASE=1` opt-out for the same reason. **Docker CI and the local runner leave it unset, so the scenario still gates every PR** - no coverage is lost, and this is not a tag used to dodge a flake.

## 3. Video-lane failures are now diagnosable

The video job runs only on a main push or manual dispatch, and uploaded **nothing** on failure - so a red lane could not be diagnosed without landing another commit on `main`. Now:

- `docs/videos/test-results/` is uploaded on failure. Playwright already writes an `error-context.md` ARIA page snapshot next to each failure for free.
- `VIDEO_SOFTWARE_GL=1` forces Chromium onto SwiftShader so the GPU-less render path can be reproduced on a machine that has a GPU.

Both are diagnostic only - no spec or app behaviour is touched.

## Not included, deliberately

No attempt to make `model-management.spec.ts` pass on a GPU-less runner. It fails all 3 CI attempts yet **passes locally even under forced SwiftShader (36.5 s)**. GPU-render work belongs on the local GPU lane; videos are a documentation artifact, not a test, and `npm run videos:generate` before tagging stays the real gate.

## Verification

| Check | Result |
| --- | --- |
| `npm run test:audit` | Everything is tracked |
| `npm run docs:audit` | 11 passed, 0 warnings, 0 errors |
| Workflow YAML parse (all 3 files) | OK |
| New Docker gate vs. run 31649270588 | resolves `success` as intended |
| Prettier on changed files | `run-e2e-fast.js` clean; the 3 workflow/config files were already non-conforming on `main` and are outside root `format:check` scope, so untouched |

No application code is modified - the diff is CI configuration plus one E2E runner flag.

## Test checklist

- [ ] Merge to `version/0.5.1`, then to `main`, and confirm **Docker Publish actually runs** even though the video lane is red
- [ ] Confirm `ghcr.io/papyszoo/modelibr-{frontend,webapi,asset-processor}:dev` get new `dev-sha-*` tags
- [ ] Cut `v0.5.1` and confirm the native release lane goes green now that `@asset-store` is skipped there
- [ ] Confirm the asset-store scenario still runs (and passes) in Docker CI on this PR
- [ ] Optional: run `VIDEO_SOFTWARE_GL=1` locally to sanity-check the switch

---

## Added after this PR was opened

### 4. The video lane itself - root cause found and fixed

The v0.5.0 docs lane failed with `model-management` timing out on `leftCanvas.waitFor`. Root cause, measured rather than guessed:

| Environment | Recorded duration | Result |
| --- | --- | --- |
| Local, GPU | 24.8s | pass |
| Local, SwiftShader + `VIDEO_CPU_THROTTLE=20` | 24.8s | pass |
| CI, GPU-less runner (before fix) | **77.44s** | over the 75s cap -> lane red |
| CI, GPU-less runner (after fix) | **61.2s** | under cap -> lane green |

Scripted content is ~25s, so CI was spending roughly **50 seconds** waiting for a second viewer canvas to mount. One cause, two faces: under 30s it inflates the clip past its cap (`over-max-duration`), over 30s it fails `leftCanvas.waitFor` outright - which is why it looked deterministic on one run and passed on retry in another.

The existing off-camera prewarm only warmed the model file and a *single* viewer. The recorded beat brings up a **second** canvas while the hero viewer is already running, and that first two-context setup is the expensive part. This prewarms that exact state.

**The cap was deliberately not raised** - the recording was long because of a wait the finished clip's viewer never sees, and model-management already carries the longest cap in the manifest.

**Honest status:** improved, not cured. Attempts failing went from **3 of 3 to 1 of 3**, and the job is green. The residual flake is because `navigateTo` does a full page load between prewarm and recording, discarding GL state. With Docker Publish now decoupled (item 1), the worst case is a stale docs site rather than a missing image.

### 5. Upgrade test: actually press Download

The nightly upgrade test failed on Linux and Windows with `status: available, percent: 0, error: null` for 10 minutes. Updates are opt-in (`autoUpdater.autoDownload = false`, asserted by a unit test), but `drive-update.mjs` only polled for `downloaded` and never called the download IPC - its header comment claimed electron-updater downloaded on its own. `autoDownload` has been false since **v0.2.1**, so this lane has never actually exercised a self-update; it only started reporting once `resolve-tags` began picking a real predecessor instead of being stuck on v0.3.1.

This is a **test-harness** defect, not proof that user-facing auto-update is broken - the updater code is untouched and all `Reinstall` jobs passed. But the 0.4.3 -> 0.5.0 self-update path is currently *unverified* rather than verified-good, and gets its first genuine exercise on the nightly after 0.5.1 ships.

### 6. Diagnostics that survive a masking retry

The video step retries 3x and each attempt overwrites the last, so a run that fails attempt 1 and passes attempt 2 ends green with no evidence - which happened while chasing exactly this bug. Failed attempts are now preserved per-attempt and uploaded on `always()`.

## Updated test checklist

- [ ] Merge to `version/0.5.1` -> `main`, confirm **Docker Publish runs** (first image since 0.3.1)
- [ ] Confirm `ghcr.io/papyszoo/modelibr-{frontend,webapi,asset-processor}:dev` get fresh `dev-sha-*` tags
- [ ] Tag `v0.5.1`; confirm the native release lane is green now `@asset-store` is skipped there
- [ ] Confirm the docs site deploys with all 8 videos
- [ ] Next nightly: confirm the upgrade test genuinely self-updates 0.5.0 -> 0.5.1
- [ ] Watch whether `model-management` still burns an attempt; artifacts now survive if it does
