### PR TITLE
release: v0.5.3

### DIFF
--- a/docs/videos/README.md
+++ b/docs/videos/README.md
@@ -2,27 +2,33 @@
 
 Playwright scripts that generate demo videos for the Docusaurus documentation site.
 
-> **Videos are generated automatically in CI.** The `generate-videos` job in the
-> GitHub Actions workflow spins up the E2E Docker environment, runs the full
-> screencast pipeline, and includes the finished demo videos in the Docusaurus build
-> for every workflow run (`push`, `pull_request`, and `workflow_dispatch`).
+> **Videos are rendered locally, not in CI.** GitHub runners have no GPU, so the
+> WebGL clips flake under software rendering - that lane blocked the docs deploy
+> for several releases before it was removed in 0.5.2. Rendering now happens on a
+> machine with a GPU and publishes straight to the site's `/videos/` path.
 >
-> Videos are **not** committed to the repository - they are generated fresh for each CI docs build.
+> Videos are **not** committed to the repository, and CI neither renders nor
+> fetches them. The docs bundle CI builds does not contain them; the pages
+> reference them by absolute `/videos/…` URL, which resolves against that
+> separate publish.
 
-## CI Pipeline
-
-The video generation is part of `ci-and-deploy.yml`:
+## Where this runs
 
 ```text
-e2e-tests ──► generate-videos ──► build-docs ──► deploy-docs
-                    │                   │
-                    │   ┌───────────────┘
-                    │   │ downloads final video artifact
-                    │   │ places in docs/static/videos/
-                    ▼   ▼
-       uploads analyzed .webm   builds Docusaurus
-          as artifact           with videos included
+local GPU machine                          CI
+─────────────────                          ──
+npm run videos:generate                    builds the docs-site artifact
+  clean → record → trim → analyze          (no videos in it)
+  → collect to docs/static/videos/
+npm run videos:verify -- --complete
+npm run videos:publish  ──────────────►  site /videos/   (published separately,
+                                          and protected from the docs sync's
+                                          --delete, so neither clobbers the other)
 ```
+
+The `docs-videos` suite in `npm run test:all` (slow tier) runs the same generate
+pipeline against current code, which is the only automated exercise the video
+specs get now that CI does not touch them.
 
 ## Local Development
 

--- a/docs/videos/video-manifest.js
+++ b/docs/videos/video-manifest.js
@@ -2,16 +2,22 @@
 // recordings are NEVER cut to the cap (only frozen tails are trimmed).
 // analyze-videos.js fails the pipeline when a recording exceeds its cap -
 // that means the spec choreography must be tightened, or the cap raised
-// here deliberately. Caps include headroom for slower CI rendering.
+// here deliberately.
+//
+// The durations below were measured on 2026-08-15 (v0.5.2) on the local GPU
+// lane, which since 0.5.2 is the only place these render - CI no longer does.
+// The caps still carry the headroom that was added for CI's slower software
+// rendering, so every clip now sits 43-79% under its ceiling. That makes them
+// weak gates: a clip could double in length and still pass. Tighten them
+// deliberately, from more than one measurement, when next touching a spec.
 export const videoManifest = [
     {
         slug: "model-management",
         outputName: "model-management.webm",
         title: "Model Management",
         description: "Compare versions, inspect changes, and keep model history moving.",
-        // ~40s on a local GPU; CI's software rendering paces the recorded
-        // waits to ~61s (observed 3× on the v0.4.2 main push). 45 left no
-        // CI headroom and failed the deploy.
+        // Records 25.3s locally. The old 40s/61s figures were CI-era; the
+        // 75s cap dates from when a software-rendered CI run had to fit.
         maxDurationSeconds: 75,
     },
     {
@@ -19,9 +25,10 @@ export const videoManifest = [
         outputName: "texture-sets.webm",
         title: "Texture Sets",
         description: "Inspect a reusable material built from global texture files.",
-        // Deliberate raise from 40: the choreography measures a stable ~44s
-        // locally (43.6s/44.6s over two runs, zero freeze/black frames), and
-        // main-push CI renders on software GL, which runs longer than local.
+        // Records 11.5s locally - far under the 44s this comment used to
+        // claim, and under half of any other clip. The clip is coherent and
+        // ends on its hero state, so this is choreography that got leaner,
+        // not a truncation; the shortest storyline in the set all the same.
         maxDurationSeconds: 55,
     },
     {
@@ -50,10 +57,8 @@ export const videoManifest = [
         outputName: "sounds.webm",
         title: "Sounds",
         description: "Browse, preview, and inspect sound assets.",
-        // Records ~26s locally. CI software rendering paces recorded waits
-        // ~1.5x local (measured on model-management at v0.4.2), which puts this
-        // at ~39s against the old 40s cap - inside the noise. Raised for CI
-        // headroom, not because the choreography grew.
+        // Records 25.2s locally. The 50s cap was raised for CI headroom that
+        // no longer applies.
         maxDurationSeconds: 50,
     },
     {
@@ -61,9 +66,8 @@ export const videoManifest = [
         outputName: "projects.webm",
         title: "Projects",
         description: "Browse, search, and inspect production-ready project boards.",
-        // Records ~28s locally, which the ~1.5x CI pacing puts at ~43s against
-        // the old 45s cap. Same reasoning as sounds above: too thin a margin to
-        // survive a slow runner, and an overrun blocks the docs deploy.
+        // Records 26.6s locally. The 55s cap was raised for CI headroom that
+        // no longer applies.
         maxDurationSeconds: 55,
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "modelibr",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "modelibr",
-            "version": "0.5.2",
+            "version": "0.5.3",
             "license": "MIT",
             "devDependencies": {
                 "playwright-bdd": "^8.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "modelibr",
     "private": true,
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "A modern 3D model file upload service built with .NET 9.0 and React",
     "type": "module",
     "scripts": {

--- a/src/asset-processor/package-lock.json
+++ b/src/asset-processor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-asset-processor",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BUSL-1.1",
       "dependencies": {
         "@microsoft/signalr": "^9.0.6",

--- a/src/asset-processor/package.json
+++ b/src/asset-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modelibr-asset-processor",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Node.js asset processor service for thumbnail rendering, waveform generation, and mesh analysis",
   "main": "index.js",
   "type": "module",

--- a/src/desktop-client/package.json
+++ b/src/desktop-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "modelibr-client",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Modelibr desktop client - an app window for a running Modelibr host",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/desktop/package-lock.json
+++ b/src/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "modelibr-desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "modelibr-desktop",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "modelibr-desktop",
   "productName": "Modelibr",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Native Modelibr launcher and installer packaging",
   "homepage": "https://github.com/Papyszoo/Modelibr",
   "author": {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Documentation correctness follow-up to 0.5.2.

`docs/videos/README.md` still described a `generate-videos` job and a Pages
deploy that 0.5.2 removed; the manifest carried per-clip timings measured under
CI's software rendering (`texture-sets` claimed ~44s, records 11.5s).

Also the second release the Linux self-update fix needs: `upgrade-test` runs the
FROM version's updater code, so 0.5.2's AppImage fix is only exercisable once a
release exists to update from it.