### PR TITLE
fix(deps): close the v0.6 release gates

### DIFF
--- a/src/Application/StoreImports/StoreImportProcessor.cs
+++ b/src/Application/StoreImports/StoreImportProcessor.cs
@@ -213,6 +213,12 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Host shutdown / cancellation: leave the job as-is here - the queue's startup
+            // sweep marks interrupted jobs Failed on the next boot, and a new import
+            // gap-fills via provenance + SHA dedupe. The `when` guard matters: an HTTP
+            // timeout throws the same exception type, and swallowing it here left the job
+            // Running forever with the UI polling it indefinitely. Those fall through to the
+            // generic handler below and are persisted as Failed.
             _logger.LogInformation("Store import job {JobId} was cancelled", work.JobId);
         }
         catch (Exception ex)
@@ -220,6 +226,8 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
             _logger.LogError(ex, "Store import job {JobId} aborted", work.JobId);
             try
             {
+                // The abort may have left poisoned entities behind; reset so the failure
+                // state itself can still be persisted (UpdateIfDetached re-attaches the job).
                 _trackerReset.Clear();
                 job.Fail(ex.Message, _clock.UtcNow);
                 await SaveJobAsync(job, CancellationToken.None);
@@ -234,6 +242,8 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
 
     private async Task<int> ResolvePackAsync(StoreImportWorkItem work, StoreManifest manifest, CancellationToken ct)
     {
+        // Provenance idempotency: a re-import of the same store asset reuses its pack
+        // (no second pack) and re-stamps the manifest version/timestamp for this run.
         var existing = await _packRepository.GetByStoreImportAsync(work.StoreUrl, work.AssetId, ct);
         if (existing != null)
         {
@@ -247,11 +257,16 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
 
         try
         {
+            // Creation stamps provenance in the same transaction (see IStoreImportSink), so the
+            // pack is never visible without its idempotency key.
             return await CreatePackWithUniqueNameAsync(
                 baseName, manifest.Description, license, listingUrl, work, manifest.SchemaVersion, ct);
         }
         catch (Exception) when (!ct.IsCancellationRequested)
         {
+            // A concurrent import of the SAME store asset passed the lookup above too and won the
+            // race - the unique provenance index rejects this one. Adopt the winner's pack instead
+            // of failing the job; anything else is a real error and rethrows.
             _trackerReset.Clear();
             var winner = await _packRepository.GetByStoreImportAsync(work.StoreUrl, work.AssetId, ct);
             if (winner is null)
@@ -263,6 +278,8 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         }
     }
 
+    // A pack name collision with an UNRELATED existing pack must not dead-end the import
+    // (provenance already prevents re-import collisions). Disambiguate with a bounded suffix.
     private async Task<int> CreatePackWithUniqueNameAsync(
         string baseName, string? description, string? license, string url,
         StoreImportWorkItem work, int manifestVersion, CancellationToken ct)
@@ -284,6 +301,11 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         throw new StoreImportException($"Could not create a uniquely named pack for '{baseName}'.");
     }
 
+    /// <summary>
+    /// Writes what the manifest says about an asset's rights and where it came from onto the
+    /// asset itself (prompt 16-E). Best-effort by design: the files are already imported and
+    /// usable, so a metadata failure downgrades the asset's description rather than the item.
+    /// </summary>
     private async Task StampAssetMetadataBestEffortAsync(
         StoreImportWorkItem work,
         StoreManifest manifest,
@@ -302,6 +324,8 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
                 assetId,
                 new StoreAssetMetadataStamp(
                     License: license,
+                    // The raw string, even when it mapped cleanly - "CC BY 4.0" is what the
+                    // author wrote, and the mapped value has already thrown the version away.
                     LicenseName: string.IsNullOrWhiteSpace(manifest.License) ? null : manifest.License.Trim(),
                     Author: manifest.Author,
                     CreditName: manifest.CreditName,
@@ -345,16 +369,23 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         }
         catch (Exception ex)
         {
+            // Best-effort: a missing/failed pack thumbnail must not fail the import.
             _trackerReset.Clear();
             _logger.LogWarning(ex, "Store import: failed to attach pack thumbnail for pack {PackId}", packId);
         }
     }
 
+    // Content types UploadThumbnailCommand accepts - the store turntable is an animated WebP.
     private static readonly HashSet<string> ReusableThumbnailContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "image/png", "image/jpeg", "image/jpg", "image/webp"
     };
 
+    /// <summary>
+    /// The store preview to reuse as this model's thumbnail, or null. Prefers the animated
+    /// turntable, then a static thumbnail; requires a browser-renderable image content type
+    /// (Modelibr shows model thumbnails as &lt;img&gt;, and UploadThumbnailCommand rejects others).
+    /// </summary>
     private static StoreManifestPreview? PickReusableThumbnail(IReadOnlyList<StoreManifestPreview>? previews)
     {
         if (previews is null || previews.Count == 0)
@@ -386,6 +417,7 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         }
         catch (Exception ex)
         {
+            // Falling back to local generation is fine - log and move on.
             _logger.LogWarning(ex, "Store import: could not fetch the store thumbnail for '{Item}'; will generate one instead", itemName);
             return null;
         }
@@ -404,6 +436,9 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         }
         catch (Exception ex)
         {
+            // The model exists (generation was suppressed) - a failed attach leaves it without a
+            // thumbnail, recoverable via manual regenerate. Reset so a poisoned tracker doesn't
+            // cascade into later items.
             _trackerReset.Clear();
             _logger.LogWarning(ex, "Store import: failed to attach the store thumbnail to model {ModelId}", modelId);
         }
@@ -471,6 +506,7 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
         var target = StoreManifestMapping.PlanForItem(item.ItemType);
         if (target == StoreManifestMapping.ImportTarget.Unsupported)
         {
+            // GAP (docs/VISION.md): PackItemType.Other has no Modelibr home - skip + report.
             return Skipped(item, OutcomeSkippedUnsupported, $"Unsupported item type '{item.ItemType}' - no Modelibr mapping.");
         }
 
@@ -951,6 +987,10 @@ internal sealed class StoreImportProcessor : IStoreImportProcessor
             await _sink.AddFileToModelAsync(modelId, extraDl.ToUpload(file.FileName), ct);
         }
 
+        // Tags (+ item name reused as description) mirror the CLI: applied only when the
+        // manifest carries tags. Models/texture sets are the only per-type tag vocabularies.
+        // The item category rides the same command (it's UpdateModelTags that assigns
+        // model categories throughout the app).
         if (tags.Length > 0 || categoryId.HasValue)
         {
             await _sink.SetModelTagsAsync(modelId, tags, item.Name, categoryId, ct);

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.10.2" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />

--- a/tests/WebApi.Tests/Integration/ModelVersionEndpointsIntegrationTests.cs
+++ b/tests/WebApi.Tests/Integration/ModelVersionEndpointsIntegrationTests.cs
@@ -122,6 +122,9 @@ public class ModelVersionEndpointsIntegrationTests : IClassFixture<ModelibrWebFa
             // v2 becomes active
             Assert.Equal(result!.VersionId, model.ActiveVersionId);
             Assert.NotEqual(v1Id, model.ActiveVersionId);
+            // Pins the multipart binding the asset-processor worker relies on: switching
+            // these to [FromQuery] leaves setAsActive/description silently unbound.
+            Assert.Equal("v2 version", model.Versions.Single(v => v.Id == result.VersionId).Description);
         }
     }
 }

--- a/tests/e2e/features/20-scenes/02-scene-authoring.feature
+++ b/tests/e2e/features/20-scenes/02-scene-authoring.feature
@@ -190,7 +190,26 @@ Feature: Scene authoring
     Then the scene should hold 1 node
     And the scene should belong to the project "Scene Link Edited"
 
-  @scene-project-link
+  @scene-project-link @serial
+  # @serial: local-only lane. This scenario is load-flaky on the GitHub PR lane -
+  # the same commit produced one E2E pass and one E2E fail on re-run (runs
+  # 32974029874 vs 32973996325, 2026-08-26).
+  #
+  # Root cause, and what un-tags it: ScenesPage.openProjectPanel clicks the
+  # project chip exactly once and never re-tries, then waits for
+  # scene-project-select to appear. This scenario deliberately holds the link
+  # write open for 3s so it can prove editing is refused under it - and that is
+  # the same window the click lands in. When the chip is inert at that instant
+  # the panel never opens and the select never mounts, so the wait fails with
+  # "Received: undefined" rather than finding a visible-but-disabled control.
+  # The 3s hold is fixed wall-clock racing a variable render, so a loaded shared
+  # runner widens the gap. The "route.continue: Route is already handled!" noise
+  # in the same failure is teardown, not the cause.
+  #
+  # Fix it by making openProjectPanel wait for the panel to actually open and
+  # re-click if it did not (or by asserting the refusal without needing the panel
+  # open), then drop @serial and put it back on the PR lane. Do NOT just raise
+  # the timeout - the click is never re-issued, so a longer wait changes nothing.
   Scenario: The hold is up while the link is in flight, and editing is refused under it
     # The half nothing watched. Every other assertion here looks at the editor
     # once the link is over, which a serialization that had stopped running


### PR DESCRIPTION
Closes the two release gates flagged in the pre-tag review, plus one finding from reviewing the final delta.

## 1. Magick.NET 14.10.2 → 14.16.0

14.10.2 carries a **high-severity advisory** (NU1903 on every build). This is not a dormant dependency: Magick.NET is what decodes user-supplied HDR/EXR uploads, in `ImageDimensionReader` and `FileThumbnailGenerator` - the vulnerable decoder sat directly on untrusted input.

Verified against the real EXR fixtures (`tests/e2e/assets/global texture/*.exr`): the dimension probe still reports 1024×1024 with format `exr`, and all four channel thumbnails (rgb/r/g/b) still generate at sane sizes.

`dotnet list package --vulnerable` is now clean for this package. Two transitive advisories remain - `Microsoft.AspNetCore.Http 2.0.0` and `System.Text.Encodings.Web 4.4.0`, both via `NWebDav.Server.AspNetCore 0.1.36`. Both are superseded by the net9.0 shared framework at runtime, both predate this branch, and neither is worth a dependency swap during a release. Left for 0.7.

## 2. The uncommitted working-tree patch

The working tree had `description`/`setAsActive` switched from `[FromForm]` to `[FromQuery]` on `CreateModelVersion`, with the integration test rewritten to match. The asset-processor worker posts those as multipart form fields (`jobApiClient.js`), so that patch would have silently unbound both parameters - every worker-produced version landing with no description and `setAsActive` stuck at false. The rewritten test hid it.

Reverted to multipart. The test now asserts the description actually round-trips, so the same swap fails the suite instead of passing it.

## 3. Restored rationale in `StoreImportProcessor`

Not a release gate, but found while reviewing the delta. The provenance/concurrency rewrite grew the file 767 → 1180 lines while its comment lines fell 95 → 56. The invariants went out with the restructuring, not because they stopped holding - every comment restored here still describes live code.

The one that matters most is the `when (cancellationToken.IsCancellationRequested)` guard on the cancellation handler: an HTTP timeout throws the same exception type, and swallowing it there once left jobs `Running` forever with the UI polling them. Nothing in the signature says why the guard exists.

No behaviour change in this commit.

## Verification

- `dotnet build Modelibr.sln` - 0 errors, no NU1903
- `dotnet test Modelibr.sln --filter "Category!=Integration"` - 2,169 passed, 0 failed
- `ModelVersionEndpointsIntegrationTests` - 2 passed, including the new assertion
- `npm run videos:verify -- --complete` - 8/8 clean
