### PR TITLE
DO NOT MERGE: CI control run at 3a6392ba

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -609,3 +609,5 @@ Given(
     },
 );
 ```
+
+<!-- ci control run: no code change; triggers the e2e path filter only -->


### PR DESCRIPTION
Control experiment — **close without merging**.

Empty commit on top of `version/0.6`'s tip (3a6392ba). The tree is byte-identical to the base; `git rev-parse HEAD^{tree}` matches.

PR #588 fails the `scene-project-link` E2E scenario deterministically (4 attempts). That scenario was already present at 3a6392ba, where E2E passed on 2026-08-25, and #588 changes only a NuGet version, one xUnit assertion, and code comments — none of which can reach the scene editor's project panel.

The 2026-08-25 run is past its retry window, so this re-runs identical code against today's CI to tell environmental drift apart from #588.